### PR TITLE
Modular Energy Guns

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -132,6 +132,7 @@
 		/obj/item/clothing/gloves/,
 		/obj/item/weapon/restraints/legcuffs/bola,
 		/obj/item/weapon/gun/projectile/automatic/pistol,
+		/obj/item/weapon/gun/energy/gun/mini,
 		/obj/item/ammo_box/magazine/m10mm,
 		/obj/item/weapon/gun/energy/gun/advtaser
 		)

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -104,10 +104,9 @@ Strip out?
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	r_pocket = /obj/item/device/assembly/flash/handheld
 	l_pocket = /obj/item/weapon/restraints/handcuffs
-	suit_store = /obj/item/weapon/gun/projectile/automatic/pistol		//stechkin
-	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,\
-		/obj/item/weapon/gun/energy/gun/advtaser=1,\
-		/obj/item/ammo_box/magazine/m10mm=2)				//2 spare mags
+	suit_store = /obj/item/weapon/gun/energy/gun/mini		//Mini E-Gun
+	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,
+		/obj/item/weapon/gun/energy/gun/advtaser=1,)
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec
@@ -216,10 +215,9 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/weapon/restraints/handcuffs
 	r_pocket = /obj/item/device/assembly/flash/handheld
-	suit_store = /obj/item/weapon/gun/projectile/automatic/pistol		//stechkin
-	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,\
-		/obj/item/weapon/gun/energy/gun/advtaser=1,\
-		/obj/item/ammo_box/magazine/m10mm=2)				//2 spare mags
+	suit_store = /obj/item/weapon/gun/energy/gun/mini		//Mini-Egun
+	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,
+		/obj/item/weapon/gun/energy/gun/advtaser=1,)
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -106,7 +106,7 @@ Strip out?
 	l_pocket = /obj/item/weapon/restraints/handcuffs
 	suit_store = /obj/item/weapon/gun/energy/gun/mini		//Mini E-Gun
 	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,
-		/obj/item/weapon/gun/energy/gun/advtaser=1,)
+		/obj/item/weapon/gun/energy/gun/advtaser=1)
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec
@@ -217,7 +217,7 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 	r_pocket = /obj/item/device/assembly/flash/handheld
 	suit_store = /obj/item/weapon/gun/energy/gun/mini		//Mini-Egun
 	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,
-		/obj/item/weapon/gun/energy/gun/advtaser=1,)
+		/obj/item/weapon/gun/energy/gun/advtaser=1)
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec


### PR DESCRIPTION
:cl: Pascal125
tweak: Modifies Security Belts to be capable of storing Miniature Energy Guns.
tweak: Replaces the starting Stetchkin with Miniature Energy Guns.
(Hopefully there should be no parsing errors.)
/:cl:



