### PR TITLE
changes the 'go home' thing to 2h 15'00" from 1h 30'00"

### DIFF
--- a/code/controllers/subsystem/starmap.dm
+++ b/code/controllers/subsystem/starmap.dm
@@ -178,7 +178,7 @@ var/datum/subsystem/starmap/SSstarmap
 		// Make a new objective
 		var/datum/objective/O
 
-		if(objective_types.len && world.time < 54000)
+		if(objective_types.len && world.time < 81000)
 			var/objectivetype = pickweight(objective_types)
 			objective_types[objectivetype]--
 			if(objective_types[objectivetype] <= 0)


### PR DESCRIPTION
:cl: EvilJackCarver
tweak: The 'ftl/gohome' objective now is called after 2h 15'00", up from 1h 30'00".
/:cl:

135 minute sessions minimum, instead of 90.