### PR TITLE
Small SpaceSHIP Map Changes

### DIFF
--- a/_maps/map_files/SpaceSHIP.dmm
+++ b/_maps/map_files/SpaceSHIP.dmm
@@ -1,0 +1,90081 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+"aed" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "AI Core Access";
+	req_access_txt = "44"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"afP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"ahK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/chiefs_office)
+"ajG" = (
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/cargo)
+"ajZ" = (
+/obj/machinery/mineral/stacking_unit_console{
+	dir = 2;
+	machinedir = 8;
+	pixel_y = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/storage/tech)
+"akx" = (
+/obj/machinery/porta_turret/ai{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"akJ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"alm" = (
+/obj/structure/table,
+/obj/item/device/radio/off{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"anE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/science)
+"anO" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "mechbay";
+	name = "Mech Bay Loading";
+	req_access = null;
+	req_access_txt = "18"
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/assembly/chargebay)
+"aoY" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"arA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"atv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/machinery/door/window/southleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"atG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"atQ" = (
+/turf/open/floor/plating,
+/turf/closed/wall/shuttle{
+	icon_state = "swall_f6";
+	dir = 2
+	},
+/area/shuttle/ftl/subshuttle/pod_3)
+"aul" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"axd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"ayz" = (
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"aBm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"aBF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
+"aBO" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/genetics)
+"aCj" = (
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
+"aFm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"aFn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/munitions)
+"aFw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "o2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/shuttle/ftl/atmos)
+"aHi" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"aHT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/munitions)
+"aIg" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"aJq" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"aMQ" = (
+/mob/living/simple_animal/bot/medbot,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"aNI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"aOb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/loading)
+"aOd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/medical/chemistry)
+"aOi" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start{
+	name = "Atmospheric Technician";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"aRz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"aRQ" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"aTI" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	color = "#444444"
+	},
+/obj/machinery/computer/pmanagement,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"aUj" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/shuttle/red,
+/area/shuttle/ftl/subshuttle/pod_3)
+"aVv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/telecomms/server)
+"aWf" = (
+/obj/machinery/ammo_rack/full/shield_piercing,
+/turf/open/floor/plasteel{
+	icon_state = "delivery"
+	},
+/area/shuttle/ftl/munitions/loading)
+"aXV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"bbc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
+"bcM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "n2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/n2,
+/area/shuttle/ftl/atmos)
+"beF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/toilet)
+"bgy" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/shuttle/ftl/munitions)
+"bgV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engineering)
+"biE" = (
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = 35;
+	pixel_y = 5
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
+"biH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "33"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/telecomms/server)
+"biK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"bkr" = (
+/obj/item/weapon/stamp{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/structure/table,
+/obj/item/clothing/head/soft,
+/obj/item/device/multitool,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	sortType = "0"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"bkD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"blk" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"bnD" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"bnJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"bqM" = (
+/obj/machinery/door/airlock/research{
+	name = "Mech Bay";
+	req_access_txt = "18";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
+"brI" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"bsL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"bsR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L7"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"buT" = (
+/obj/machinery/button/door{
+	id = "QMLoaddoor";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/conveyor_switch{
+	id = "QMLoad"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"bwq" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"bxl" = (
+/obj/structure/cable,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"bxt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"bxO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"byG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L9"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"byX" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/projectile/automatic/wt550{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/projectile/automatic/wt550,
+/obj/item/weapon/gun/projectile/automatic/wt550{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"bzd" = (
+/obj/machinery/power/shipweapon{
+	anchored = 1;
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/ftl/munitions/cannon)
+"bzU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/mining)
+"bAr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"bBN" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"bCV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"bFY" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"bGN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
+"bJu" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/flasher{
+	id = "brigentry";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"bJw" = (
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"bJU" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"bKy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Unisex Restrooms";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"bLL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_access_txt = "0";
+	req_one_access_txt = "12;35"
+	},
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/bridge)
+"bOu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"bRg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/secure_closet/miner,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
+/obj/item/device/spacepod_key{
+	id = 5.31801e+006
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"bUD" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "n2o_in";
+	name = "Nitrous Oxide Supply Control";
+	output_tag = "n2o_out";
+	sensors = list("n2o_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/escape{
+	dir = 1
+	},
+/area/shuttle/ftl/atmos)
+"bWC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"cbx" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=AP";
+	location = "FP"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"cfj" = (
+/obj/item/weapon/stock_parts/subspace/amplifier,
+/obj/item/weapon/stock_parts/subspace/amplifier,
+/obj/item/weapon/stock_parts/subspace/amplifier,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/ansible,
+/obj/item/weapon/stock_parts/subspace/ansible,
+/obj/item/weapon/stock_parts/subspace/ansible,
+/obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/transmitter,
+/obj/item/weapon/stock_parts/subspace/transmitter,
+/obj/item/weapon/stock_parts/subspace/transmitter,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/structure/table,
+/obj/item/weapon/storage/belt/utility/full,
+/obj/item/weapon/storage/belt/utility/full,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"cfA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"cfZ" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j2s";
+	sortType = 21
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"cgZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "41"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/detectives_office)
+"chy" = (
+/obj/structure/table,
+/obj/item/weapon/extinguisher{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/weapon/extinguisher{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/weapon/extinguisher{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/monkeycubes{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/weapon/storage/box/monkeycubes{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"cjy" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"con" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"cqd" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "air_sensor"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/shuttle/ftl/atmos)
+"ctI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"cuL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"cvt" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/darkwarning/corner,
+/area/shuttle/ftl/engine/engineering)
+"cvD" = (
+/obj/machinery/camera{
+	c_tag = "Conference Room";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"cwW" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/toilet)
+"cxe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/landmark/start{
+	name = "Shaft Miner"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"cxt" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"cze" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	name = "Captain RC";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"czw" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"czY" = (
+/obj/structure/table/glass,
+/obj/item/weapon/folder/white{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/weapon/stamp/cmo,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"cCb" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/shuttle/ftl/atmos)
+"cCd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"cCk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/item/weapon/banner,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"cDi" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"cEJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "captains_shutters";
+	name = "Captains Office"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/captain)
+"cFF" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics West";
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"cGP" = (
+/obj/structure/table,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/wrench,
+/obj/item/device/multitool,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"cJK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue/side,
+/area/shuttle/ftl/bridge)
+"cJS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"cKS" = (
+/obj/structure/table,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/pen,
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"cLJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
+"cMt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"cPk" = (
+/obj/structure/sign/securearea{
+	name = "SERVER ROOM";
+	desc = "A warning sign which reads 'SERVER ROOM'."
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/telecomms/computer)
+"cPn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Equipment";
+	req_access_txt = "15"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"cPx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"cPV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"cQD" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	tag = "icon-pump_map (WEST)";
+	icon_state = "pump_map";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"cQY" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "engine_in";
+	name = "Coolant Injector";
+	volume_rate = 700
+	},
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-black_warn_corner (NORTH)";
+	icon_state = "black_warn_corner";
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"cRZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "29"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"cTC" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"cUb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"cUS" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"cVj" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge)
+"cVK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"cVP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"cWf" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/bridge/meeting_room)
+"cXf" = (
+/obj/structure/closet/l3closet,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Virology Airlock";
+	dir = 8
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (SOUTHEAST)";
+	icon_state = "white_warn";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/virology)
+"cXn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"cYf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/science)
+"dbJ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"ddq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"dft" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access_txt = "22"
+	},
+/turf/open/floor/plasteel/green/side{
+	tag = "icon-green (WEST)";
+	icon_state = "green";
+	dir = 8
+	},
+/area/shuttle/ftl/hydroponics)
+"dfx" = (
+/obj/item/weapon/electronics/airlock{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/electronics/apc,
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/cable_coil,
+/obj/item/device/multitool{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"dhI" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/syringes,
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/shuttle/ftl/medical/virology)
+"dhU" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/bridge/meeting_room)
+"diP" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	tag = "icon-pump_map (WEST)";
+	icon_state = "pump_map";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"djI" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (WEST)";
+	icon_state = "white_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/research/lab)
+"djX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"dko" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 8;
+	filter_type = "plasma";
+	icon_state = "filter_off";
+	on = 1;
+	tag = "icon-filter_off (WEST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"dlC" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/machinery/computer/rdconsole/robotics,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 4
+	},
+/area/shuttle/ftl/assembly/robotics)
+"dmg" = (
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/structure/table/wood,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"dnx" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/engineering_chief{
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"dnQ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (NORTHWEST)";
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"dob" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"dqj" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"dqZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/detectives_office)
+"drc" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"dru" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"dsX" = (
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/book/manual/wiki/engineering_construction,
+/obj/item/weapon/book/manual/wiki/engineering_guide{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"due" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning/corner{
+	tag = "icon-plasteel_warn_corner (EAST)";
+	icon_state = "plasteel_warn_corner";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"dun" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"duK" = (
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"dvb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"dvl" = (
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/chemistry)
+"dvY" = (
+/obj/machinery/door/airlock/command{
+	name = "Conference Room";
+	req_access = null;
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"dwo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"dzf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"dBi" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Medical Storage";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"dBS" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"dFD" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"dFF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/sign/securearea{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"dFQ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"dJQ" = (
+/turf/open/floor/engine,
+/area/shuttle/ftl/cargo/mining)
+"dKg" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"dPP" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"dPX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j2s";
+	sortType = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"dSy" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	tag = "icon-pump_map (EAST)";
+	icon_state = "pump_map";
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engine North";
+	network = list("SS13","Supermatter")
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"dTh" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"dVH" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
+"eaq" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Core Access";
+	req_access_txt = "44"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"ecK" = (
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/ftl/assembly/chargebay)
+"edm" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"edL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "captains_shutters";
+	name = "Captains Office"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/captain)
+"efc" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"efi" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"egr" = (
+/obj/effect/landmark/start{
+	name = "Station Engineer";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"egL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"ehY" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"ejI" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "FTL Drive";
+	req_access_txt = "34";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
+"eli" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/glass,
+/obj/item/device/paicard{
+	pixel_y = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Research and Development";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"emP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/escape{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/central)
+"enn" = (
+/turf/open/floor/plasteel/darkblue/side,
+/area/shuttle/ftl/bridge)
+"enG" = (
+/obj/machinery/sleeper{
+	icon_state = "sleeper-open";
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 5
+	},
+/area/shuttle/ftl/security/main)
+"enU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/sortjunction{
+	icon_state = "pipe-j2s";
+	sortType = 5
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"eoB" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "co2_in";
+	name = "Carbon Dioxide Supply Control";
+	output_tag = "co2_out";
+	sensors = list("co2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/atmos)
+"eqy" = (
+/obj/structure/closet/emcloset,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/obj/item/weapon/tank/internals/emergency_oxygen/double,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"eqJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/open/floor/plasteel/warning,
+/area/shuttle/ftl/cargo/storage)
+"etd" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"ewm" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo Access";
+	dir = 8;
+	network = list("SS13")
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"ewT" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Office 2";
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/cargo/office)
+"exb" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen";
+	req_access_txt = "28"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"exf" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/warning,
+/area/shuttle/ftl/engine/engine_smes)
+"exk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters{
+	id = "captains_shutters";
+	name = "Captains Office"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/captain)
+"exC" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge)
+"eAs" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	dir = 2;
+	id = "rnd";
+	name = "Shutters Control Button";
+	pixel_x = 6;
+	pixel_y = 24;
+	req_access_txt = "47"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"eAF" = (
+/obj/structure/rack,
+/obj/item/weapon/wrench,
+/obj/item/weapon/crowbar,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"eBr" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	tag = "icon-intact (SOUTHEAST)";
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"eBt" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/disposal)
+"eBD" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"eDI" = (
+/obj/machinery/smartfridge/chemistry/virology,
+/obj/machinery/camera{
+	c_tag = "Virology";
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"eDM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"eFz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"eHa" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=AS";
+	location = "AP"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"eHp" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "18"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/assembly/chargebay)
+"eJe" = (
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"eJj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"eJk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"eKt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics";
+	name = "Robotics Desk"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/assembly/robotics)
+"eKM" = (
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/mop,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"eLg" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"eLy" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engine_smes)
+"eOq" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 5
+	},
+/area/shuttle/ftl/bridge)
+"eOL" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"eQc" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/ftl/subshuttle/pod_3)
+"eQe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"eQf" = (
+/obj/machinery/computer/rdconsole/core,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"eSu" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/shuttle/ftl/security/armory)
+"eUm" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/structure/closet/l3closet,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (NORTHEAST)";
+	icon_state = "white_warn";
+	dir = 5
+	},
+/area/shuttle/ftl/medical/virology)
+"eVt" = (
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/reagent_containers/syringe{
+	name = "steel point"
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/charcoal,
+/obj/item/weapon/reagent_containers/glass/bottle/epinephrine,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 10
+	},
+/area/shuttle/ftl/security/main)
+"eVP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"eXo" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"eXM" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Chemist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/chemistry)
+"eYt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/wood,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"eZf" = (
+/obj/effect/landmark/start{
+	name = "Bartender";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"faT" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/landmark/start{
+	name = "Scientist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Research Division";
+	network = list("SS13","RD")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"fcA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay North";
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"feg" = (
+/turf/open/floor/plasteel/arrival,
+/area/shuttle/ftl/hallway/primary/port)
+"feJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"ffa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"ffm" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Cryo";
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 0;
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_x = 30;
+	pixel_y = 0;
+	pixel_z = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/medbay)
+"ffQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"fgI" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/warning{
+	dir = 10
+	},
+/area/shuttle/ftl/munitions)
+"fkN" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"flO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/telecomms/server)
+"fqg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
+"fqS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"frO" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Supermatter Chamber";
+	dir = 4;
+	network = list("SS13","Supermatter")
+	},
+/turf/open/floor/plasteel/darkwarning{
+	tag = "icon-black_warn (NORTH)";
+	icon_state = "black_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"fsj" = (
+/obj/machinery/door/airlock/external{
+	id_tag = null;
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"ftf" = (
+/obj/machinery/airalarm{
+	pixel_y = 28
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mailSort";
+	tag = "munitions west"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"ftL" = (
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/whitered/side,
+/area/shuttle/ftl/security/main)
+"ftT" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"ftW" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"fuv" = (
+/obj/structure/table/reinforced,
+/obj/item/device/multitool,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"fxe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"fya" = (
+/obj/structure/sign/bluecross_2,
+/turf/closed/wall,
+/area/shuttle/ftl/medical/medbay_lobby)
+"fyw" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (EAST)";
+	icon_state = "white_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/research/lab)
+"fzw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"fCa" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/weapon/book/manual/ftl_wiki/supermatter,
+/obj/item/device/lightreplacer,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"fCe" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"fDr" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "mailSort";
+	pixel_x = -10;
+	pixel_y = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"fOZ" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/green/side{
+	tag = "icon-green (SOUTHEAST)";
+	icon_state = "green";
+	dir = 6
+	},
+/area/shuttle/ftl/hydroponics)
+"fPz" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"fRs" = (
+/obj/machinery/sleeper{
+	dir = 4;
+	icon_state = "sleeper-open"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	locked = 0;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"fRv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_x = 0;
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
+"fUN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"fVp" = (
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 1";
+	name = "Cell 1";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"fVJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/cargo/storage)
+"fWa" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"fYG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"fYX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 9
+	},
+/area/shuttle/ftl/munitions)
+"fZa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"fZp" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning,
+/area/shuttle/ftl/engine/engine_smes)
+"fZt" = (
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/wrench,
+/obj/item/weapon/weldingtool,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"fZv" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen";
+	req_access_txt = "28"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/machinery/atmospherics,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"fZN" = (
+/obj/machinery/door/airlock/glass_virology{
+	name = "Isolation A";
+	req_access_txt = "23"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"gaa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"gaq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"gcj" = (
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/stack/cable_coil,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"gdp" = (
+/obj/machinery/door/airlock/security{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"gdu" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"gdI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"geG" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"geS" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	tag = "icon-pump_map (NORTH)";
+	icon_state = "pump_map";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"ggd" = (
+/obj/effect/landmark/start{
+	name = "Station Engineer";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"ggk" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel/blue/side{
+	dir = 10
+	},
+/area/shuttle/ftl/atmos)
+"ggB" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"ggE" = (
+/obj/machinery/vending/engivend{
+	req_access_txt = "34"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/break_room)
+"ghv" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"gkC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
+"gkL" = (
+/obj/machinery/processor{
+	desc = "A machine used to process slimes and retrieve their extract.";
+	name = "Slime Processor"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"glH" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning{
+	dir = 9
+	},
+/area/shuttle/ftl/atmos)
+"gpm" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"gsZ" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
+"gti" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start{
+	name = "Roboticist";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"guC" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"gvy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos)
+"gwz" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/weapon/shovel/spade,
+/obj/item/weapon/wrench,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/green/side,
+/area/shuttle/ftl/hydroponics)
+"gAw" = (
+/turf/closed/wall,
+/area/shuttle/ftl/hydroponics)
+"gBs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
+"gDa" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"gFg" = (
+/obj/structure/cryofeed/right,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 1
+	},
+/area/shuttle/ftl/crew_quarters/sleep)
+"gFN" = (
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"gHC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
+"gJb" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"gKe" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"gKx" = (
+/obj/structure/shuttle/engine/propulsion/burst/right,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/space,
+/area/shuttle/ftl/subshuttle/pod_3)
+"gLv" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/maintenance/bar)
+"gMx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"gMA" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"gMC" = (
+/obj/machinery/dna_scannernew{
+	tag = ""
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHEAST)";
+	icon_state = "whiteblue";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/genetics)
+"gPR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHWEST)";
+	icon_state = "whiteblue";
+	dir = 9
+	},
+/area/shuttle/ftl/medical/medbay)
+"gQa" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Hallway North"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engineering)
+"gQp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L13";
+	name = "floor"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"gQB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"gTV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"gUo" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"gXM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_x = -4;
+	pixel_y = -32
+	},
+/obj/machinery/light_switch{
+	pixel_x = 10;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/cargo/office)
+"gYy" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/storage/tech)
+"haP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"haZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"hdr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"hgj" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"hju" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/poddoor{
+	id = "Supermatter doors"
+	},
+/turf/open/floor/noslip,
+/area/shuttle/ftl/engine/engine_smes)
+"hjC" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/bo/helms,
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 4
+	},
+/area/shuttle/ftl/bridge)
+"hjW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"hkS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"hlx" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"hmz" = (
+/obj/item/weapon/grenade/barrier{
+	pixel_x = 4
+	},
+/obj/item/weapon/grenade/barrier,
+/obj/item/weapon/grenade/barrier{
+	pixel_x = -4
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/box/teargas{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/flashbangs{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/security/armory)
+"hqi" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"hqH" = (
+/obj/structure/closet/l3closet,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"hrt" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/engine/engineering)
+"hsa" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/escape{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/central)
+"hsW" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"htp" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-black_warn_corner (WEST)";
+	icon_state = "black_warn_corner";
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"htG" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"hup" = (
+/obj/effect/landmark/latejoin,
+/obj/structure/chair,
+/turf/open/floor/plasteel/arrival{
+	tag = "icon-arrival (NORTH)";
+	icon_state = "arrival";
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"hxQ" = (
+/obj/machinery/conveyor_switch{
+	id = "munitions"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"hyH" = (
+/obj/machinery/door/airlock/glass{
+	name = "Emergency Storage"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"hyN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	external_pressure_bound = 100;
+	frequency = 1441;
+	icon_state = "vent_map";
+	id_tag = "engine_out";
+	pump_direction = 0
+	},
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-black_warn_corner (EAST)";
+	icon_state = "black_warn_corner";
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"hzx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6;
+	initialize_directions = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"hAP" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	tag = "icon-pump_map (NORTH)";
+	icon_state = "pump_map";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"hAZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"hBe" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"hBS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/sortjunction{
+	icon_state = "pipe-j2s";
+	sortType = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"hEf" = (
+/obj/machinery/conveyor_switch{
+	id = "munitions_loading"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/munitions)
+"hEp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"hFV" = (
+/obj/machinery/conveyor{
+	id = "munitions";
+	tag = "munitions south"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/munitions)
+"hGk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"hGW" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"hIe" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/door/poddoor{
+	id = "Supermatter doors"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engine_smes)
+"hIC" = (
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"hJI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/weapon/folder,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	name = "Cargo Desk";
+	req_access_txt = "20"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"hLw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/detectives_office)
+"hLy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/shuttle/ftl/bridge)
+"hLG" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel/blue/side{
+	dir = 6
+	},
+/area/shuttle/ftl/atmos)
+"hLI" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j2s";
+	sortType = 19
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"hNA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L8"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"hOS" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
+/area/shuttle/ftl/hydroponics)
+"hSl" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"hSI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"hTc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"hTh" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Medical Doctor";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/button/door{
+	id = "MedbayFoyer";
+	name = "Medbay Doors";
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHEAST)";
+	icon_state = "whiteblue";
+	dir = 5
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"hTs" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engineering)
+"hUH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/science)
+"hUN" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"hVN" = (
+/obj/machinery/camera{
+	c_tag = "R&D Server Room";
+	name = "security camera";
+	network = list("SS13","RD")
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 2;
+	on = 1;
+	target_temperature = 80
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
+"hWG" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/atmos_alert{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/stationalert,
+/obj/item/weapon/circuitboard/computer/powermonitor{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/machine/thermomachine/freezer{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"hXo" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"hYD" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 4;
+	icon_state = "mixer_off";
+	node1_concentration = 0.8;
+	node2_concentration = 0.2;
+	on = 1;
+	tag = "icon-mixer_off (EAST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"hZc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"iax" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp/green,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"iaF" = (
+/obj/effect/landmark/ship_fire,
+/turf/open/space,
+/area/shuttle/ftl/space)
+"icc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"icW" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/item/weapon/storage/belt/utility,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"idm" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/shuttle/ftl/medical/genetics)
+"idy" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"iiy" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"iiB" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"iiT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"iiW" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"ikz" = (
+/obj/machinery/clonepod{
+	connected = null;
+	tag = ""
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/genetics)
+"imC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"ina" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"ioZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"iqA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"irG" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"irM" = (
+/obj/machinery/computer/pmanagement,
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"isr" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"isP" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"ith" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"ivg" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/vault,
+/area/shuttle/ftl/security/nuke_storage)
+"iwP" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"iyC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/genetics)
+"iAW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"iCk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 1";
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L2"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"iER" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	tag = "icon-intact (WEST)";
+	icon_state = "intact";
+	dir = 8;
+	color = "#444444"
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"iFd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/heads)
+"iFk" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"iFp" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"iFP" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/camera{
+	c_tag = "Engineering Access"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"iHz" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/fancy/cigarettes,
+/obj/item/clothing/glasses/sunglasses,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"iIc" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel/darkwarning{
+	tag = "icon-black_warn (WEST)";
+	icon_state = "black_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"iIe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=AFT";
+	location = "FS"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"iKj" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"iLj" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
+"iLu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/item/weapon/storage/fancy/donut_box,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"iMj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/bridge)
+"iMI" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/office)
+"iQr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"iQL" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"iRw" = (
+/obj/machinery/door/window/westleft{
+	name = "Brig Infirmary";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 9
+	},
+/area/shuttle/ftl/security/main)
+"iSc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/armory)
+"iSF" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/clothing/head/soft{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/soft{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"iTk" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"iTS" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6;
+	initialize_directions = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"iUf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"iUt" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/weapon/electronics/airlock,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"iUQ" = (
+/turf/closed/wall/shuttle{
+	icon_state = "swall3";
+	dir = 2
+	},
+/area/shuttle/ftl/subshuttle/pod_3)
+"iVe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"iWl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/virology)
+"iWu" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"iYs" = (
+/obj/machinery/ftl_drive,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"iYx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"iZg" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/obj/item/weapon/watertank,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/shuttle/ftl/hydroponics)
+"iZx" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/camera{
+	c_tag = "EVA Access";
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"iZz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"iZO" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"jfv" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/atmos)
+"jfw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"jgv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"jkY" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/button/door{
+	id = "munitions";
+	name = "Munitions Lockdown";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "43"
+	},
+/obj/effect/landmark/start{
+	name = "Munitions Officer";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -38
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 36
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"jnb" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window{
+	name = "Power Storage";
+	req_access_txt = "36"
+	},
+/obj/effect/landmark/start{
+	name = "Station Engineer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 10
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"jpc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mining Podbay";
+	req_access_txt = "27"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"jqx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"jqA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/camera{
+	c_tag = "Vault";
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"jqE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/bar)
+"jqV" = (
+/obj/structure/closet/secure_closet/hop,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	departmentType = 5;
+	name = "Head of Personnel RC";
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"jrk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"jsi" = (
+/obj/machinery/computer/cloning{
+	pod1 = null;
+	scanner = null
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/genetics)
+"jub" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"jvU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"jwd" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"jyg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"jyi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"jzH" = (
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (NORTHWEST)";
+	icon_state = "white_warn";
+	dir = 9
+	},
+/area/shuttle/ftl/research/lab)
+"jBN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"jCu" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"jDd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"jGm" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L13";
+	name = "floor"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"jIc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"jIe" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/button/door{
+	name = "Shutters Control";
+	pixel_x = -25;
+	pixel_y = 6;
+	req_access_txt = "36";
+	id = "Supermatter doors"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"jIj" = (
+/obj/machinery/computer/munitions_console,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"jIS" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"jLE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"jNj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"jQA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"jRU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/office)
+"jSB" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/munitions/loading)
+"jSH" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"jUC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	name = "Conference Room";
+	req_access = null;
+	req_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"jVe" = (
+/obj/structure/table/wood,
+/obj/effect/holodeck_effect/cards,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/bridge/meeting_room)
+"jVM" = (
+/obj/structure/plasticflaps/mining,
+/turf/open/floor/plating/warnplate/side{
+	tag = "icon-plating_warn_side (EAST)";
+	icon_state = "plating_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"kat" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Dormitories";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/weapon/storage/book/bible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"kaR" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"keN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"kgt" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"kgR" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/lights/mixed{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/box/mousetraps{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/item/device/lightreplacer,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"khZ" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"kiD" = (
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"kjj" = (
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"kmh" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"koy" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "CargoMunitions";
+	tag = "CargoMunitions"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"koK" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 5
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"kpe" = (
+/obj/machinery/camera{
+	c_tag = "Tool Storage";
+	dir = 1
+	},
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"ksv" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/device/multitool{
+	pixel_x = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/weapon/melee/classic_baton/telescopic{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"kuk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"kvp" = (
+/obj/machinery/conveyor{
+	id = "QMLoad";
+	tag = "munitions south"
+	},
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor";
+	name = "supply dock loading door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"kxH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L13";
+	name = "floor"
+	},
+/area/shuttle/ftl/bridge)
+"kyQ" = (
+/obj/machinery/door/poddoor{
+	id = "EvaGarage";
+	name = "garage door"
+	},
+/turf/open/floor/plating/warnplate/side,
+/area/shuttle/ftl/bridge/eva)
+"kyW" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"kAF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"kBM" = (
+/mob/living/simple_animal/pet/dog/corgi/Ian{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"kCF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	icon_state = "right";
+	name = "Hydroponics Desk";
+	req_access_txt = "22";
+	tag = "icon-right (WEST)"
+	},
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
+"kDa" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/science)
+"kDx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Armory Maintenance Area";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"kFR" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"kII" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"kJm" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/brig)
+"kJy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"kJK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"kJT" = (
+/obj/machinery/chem_master,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHEAST)";
+	icon_state = "whiteblue";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/chemistry)
+"kKl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	icon_state = "left";
+	name = "Reception Window";
+	req_access_txt = "0"
+	},
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	dir = 4;
+	icon_state = "rightsecure";
+	name = "Head of Personnel's Desk";
+	req_access = null;
+	req_access_txt = "30"
+	},
+/obj/machinery/flasher{
+	id = "hopflash";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	layer = 2.9;
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"kLU" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"kNj" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	tag = "icon-intact (WEST)";
+	icon_state = "intact";
+	dir = 8;
+	color = "#444444"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"kNl" = (
+/obj/structure/shuttle/engine/propulsion/burst,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/space,
+/area/shuttle/ftl/subshuttle/pod_3)
+"kOG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"kOO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
+"kPO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/mecha_part_fabricator,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"kQi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge)
+"kQU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L14"
+	},
+/area/shuttle/ftl/bridge)
+"kRm" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"kRY" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/item/device/pipe_painter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"kTI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/telecomms/computer)
+"kUw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"kUO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/safe,
+/obj/item/clothing/head/bearpelt,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/weapon/gun/projectile/revolver/russian,
+/obj/item/ammo_box/a357,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/badminka,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"kXJ" = (
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber North";
+	network = list("SS13","MiniSat");
+	pixel_x = 0
+	},
+/obj/structure/rack,
+/obj/item/weapon/aiModule/core/freeformcore,
+/obj/item/weapon/aiModule/core/full/asimov{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"lcy" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/machine/telecomms/broadcaster{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/telecomms/bus,
+/obj/item/weapon/circuitboard/machine/telecomms/server{
+	pixel_x = 3;
+	pixel_y = -3;
+	pixel_z = 0
+	},
+/obj/item/weapon/circuitboard/machine/telecomms/receiver{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/telecomms/processor,
+/obj/item/weapon/circuitboard/computer/message_monitor{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"lcz" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_y = 0
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"leo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"lfy" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"lha" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"liU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"ljX" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/medbay)
+"lkk" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start{
+	name = "Virologist";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"lms" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engineering)
+"loo" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"lor" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"lrB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=FS";
+	location = "AS"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"lrM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
+"lrV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"lvM" = (
+/obj/structure/fireaxecabinet{
+	pixel_x = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"lyr" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"lyO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 1;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	icon_state = "vent_map";
+	id_tag = "air_out";
+	internal_pressure_bound = 2000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/shuttle/ftl/atmos)
+"lzf" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Equipment"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"lzW" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"lBJ" = (
+/obj/structure/table,
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	freerange = 0;
+	frequency = 1485;
+	listening = 1;
+	name = "Station Intercom (Medbay)";
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay)
+"lCa" = (
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTHWEST)";
+	icon_state = "plasteel_warn";
+	dir = 9
+	},
+/area/shuttle/ftl/munitions)
+"lCx" = (
+/obj/machinery/ammo_rack/full/smart_homing,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "delivery"
+	},
+/area/shuttle/ftl/munitions/loading)
+"lEr" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"lEE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"lIT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"lJq" = (
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"lJV" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/atmos)
+"lKe" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/genetics)
+"lKj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 2";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"lMV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"lNI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"lNX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"lTL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/hos)
+"lWt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"lXg" = (
+/obj/machinery/door/airlock/command{
+	emergency = 0;
+	name = "Munitions Access";
+	req_access_txt = "35"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"lZN" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"lZT" = (
+/obj/machinery/telecomms/hub/preset,
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"mac" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/security)
+"mbB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"meg" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/server)
+"mfa" = (
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/bridge/eva)
+"mfh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"mfm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/corner{
+	tag = "icon-whitebluecorner (WEST)";
+	icon_state = "whitebluecorner";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"mgL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue/side,
+/area/shuttle/ftl/bridge)
+"mii" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"miw" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/sleep)
+"mkJ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2;
+	frequency = 1441;
+	id = "n2o_in";
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/n2o,
+/area/shuttle/ftl/atmos)
+"mle" = (
+/obj/item/device/mmi/posibrain{
+	pixel_y = 5
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"mng" = (
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"mnN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"mnO" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"mpz" = (
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/ftl/engine/engine_smes)
+"mrp" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = -24;
+	pixel_z = 0
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/mob/living/simple_animal/pet/cat/Runtime,
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"mvH" = (
+/obj/machinery/door/airlock/external{
+	id_tag = null;
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"mvR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"mwx" = (
+/turf/closed/wall,
+/area/shuttle/ftl/medical/medbay_lobby)
+"mwU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L9"
+	},
+/area/shuttle/ftl/bridge)
+"mxX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/nuke_storage)
+"myF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/tool_storage)
+"myV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"mzu" = (
+/obj/machinery/hologram/holopad,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"mzJ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"mAh" = (
+/obj/machinery/computer/upload/borg,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"mBh" = (
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"mDx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"mGb" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"mHa" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"mHZ" = (
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"mIK" = (
+/obj/machinery/r_n_d/protolathe,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"mKX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/warning{
+	dir = 6
+	},
+/area/shuttle/ftl/munitions)
+"mMn" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay_lobby)
+"mOV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"mPV" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"mQB" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"mTi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "munitions_loading";
+	tag = "munitions west"
+	},
+/obj/structure/plasticflaps,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"mTz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/sortjunction{
+	icon_state = "pipe-j2s";
+	sortType = 12
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"mUf" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"mVM" = (
+/obj/structure/sign/securearea,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"mYh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay West";
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"mYO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"naG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/warning/corner,
+/area/shuttle/ftl/cargo/storage)
+"nbC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"nck" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = "plasma";
+	on = 1
+	},
+/obj/machinery/button/massdriver{
+	id = "supermatter_eject";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"ndF" = (
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/cargo/office)
+"ndH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"nfJ" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"nfO" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "munitions_loading";
+	tag = "munitions west"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"niY" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"njk" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"njp" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Hydroponics";
+	dir = 1
+	},
+/turf/open/floor/plasteel/green/side,
+/area/shuttle/ftl/hydroponics)
+"nkI" = (
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"nmO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 7
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"nol" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"nqN" = (
+/obj/structure/cryofeed/right,
+/turf/open/floor/plasteel/warnwhite,
+/area/shuttle/ftl/crew_quarters/sleep)
+"nrI" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warning/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"nuF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"nuI" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"nvH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"nxr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start{
+	name = "Quartermaster"
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"nxt" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/morphine,
+/obj/item/weapon/reagent_containers/syringe,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"nyD" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/ftl/assembly/chargebay)
+"nzl" = (
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/office)
+"nBj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"nBp" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"nEX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"nFe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"nGM" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	layer = 2.9;
+	name = "Privacy Shutters"
+	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/heads)
+"nGW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Librarian"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"nHm" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"nHx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "36"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"nKk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"nKE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/office)
+"nLu" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "tox_sensor"
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/engine/plasma,
+/area/shuttle/ftl/atmos)
+"nLQ" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/assembly/chargebay)
+"nMq" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/device/flashlight{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/device/flashlight,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"nNd" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/table,
+/obj/item/weapon/crowbar,
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"nNl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"nNV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 38
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"nOZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (NORTHWEST)";
+	icon_state = "intact";
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"nPG" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/cloning{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/circuitboard/computer/med_data{
+	pixel_x = 3;
+	pixel_y = -3;
+	pixel_z = 0
+	},
+/obj/item/weapon/circuitboard/machine/clonescanner{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/clonepod,
+/obj/item/weapon/circuitboard/computer/scan_consolenew{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"nPK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access_txt = "39"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"nQJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"nRp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"nVA" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/structure/closet/jcloset,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"nVF" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/bar)
+"nWz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"nXw" = (
+/obj/machinery/camera{
+	c_tag = "External Cargo Access";
+	dir = 1
+	},
+/turf/open/space,
+/area/shuttle/ftl/space)
+"nZj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"ode" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"odj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/green/corner{
+	tag = "icon-greencorner (EAST)";
+	icon_state = "greencorner";
+	dir = 4
+	},
+/area/shuttle/ftl/hydroponics)
+"odV" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/shuttle/ftl/hydroponics)
+"oej" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/weapon/extinguisher{
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"ofm" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/manual/barman_recipes,
+/obj/item/weapon/reagent_containers/glass/rag,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/item/weapon/gun/projectile/revolver/doublebarrel,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"ofQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engineering)
+"ogE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/office)
+"ojz" = (
+/obj/machinery/message_server,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"olM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"omz" = (
+/obj/machinery/telecomms/relay/portable/preset,
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/cargo/mining)
+"omN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"ooa" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"ooG" = (
+/obj/machinery/vending/cigarette{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"oqd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"oqf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/warning/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/mining)
+"oqn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Brig Cell 2";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"oqL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"oqN" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"osA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"osO" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"osT" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 4
+	},
+/area/shuttle/ftl/assembly/robotics)
+"oti" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"oul" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"oxh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/computer/cargo/request,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/office)
+"oxp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Munitions Access";
+	req_access_txt = "35"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"oxB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"ozU" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"oAv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/landmark/start{
+	name = "Chaplain"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"oCg" = (
+/obj/structure/displaycase/labcage,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"oCQ" = (
+/obj/machinery/telecomms/processor/preset_one/birdstation,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"oDm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	sortType = 9
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"oFb" = (
+/obj/machinery/door/airlock/command{
+	emergency = 0;
+	name = "Munitions Access";
+	req_access_txt = "35"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"oFI" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "n2_in"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/n2,
+/area/shuttle/ftl/atmos)
+"oHE" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"oHQ" = (
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"oJn" = (
+/obj/machinery/blackbox_recorder,
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 8
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"oLy" = (
+/obj/machinery/announcement_system,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"oMU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access_txt = "21"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/chemistry)
+"oNT" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"oQd" = (
+/obj/structure/closet/secure_closet/freezer/money,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"oQP" = (
+/obj/effect/landmark{
+	name = "Observer-Start"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"oRz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/landmark/start{
+	name = "Mime"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"oTq" = (
+/obj/structure/table/wood,
+/obj/item/device/paicard,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/bridge/meeting_room)
+"oUK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Shaft Miner"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"oUM" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/box/rubbershot,
+/obj/item/weapon/storage/box/rubbershot,
+/obj/item/weapon/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/security/armory)
+"oXs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"oXv" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/primary/port)
+"paa" = (
+/obj/machinery/computer/emergency_shuttle,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"pab" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"pas" = (
+/obj/machinery/door/poddoor{
+	id = "weapon_k_1";
+	name = "munitions launcher bay door"
+	},
+/turf/open/floor/plating/warnplate/side{
+	tag = "icon-plating_warn_side (EAST)";
+	icon_state = "plating_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"pdi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Robotics East";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/assembly/robotics)
+"pdD" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Geneticist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Genetics";
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/genetics)
+"pdL" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2;
+	frequency = 1441;
+	id = "tox_in";
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/plasma,
+/area/shuttle/ftl/atmos)
+"peW" = (
+/obj/machinery/conveyor{
+	dir = 5;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"phh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"piz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"piJ" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"plV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"pmw" = (
+/obj/effect/landmark/start{
+	name = "Captain"
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "captains_shutters";
+	name = "Shutters Control";
+	pixel_x = -24;
+	pixel_y = 32
+	},
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = 34
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"pmE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"pmQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor{
+	id = "Supermatter doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engine_smes)
+"poc" = (
+/obj/machinery/flasher/portable,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/item/weapon/wrench,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"poG" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 1
+	},
+/area/shuttle/ftl/security/main)
+"prz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engine_smes)
+"puf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"pui" = (
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 2";
+	name = "Cell 2";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"puE" = (
+/obj/structure/window/reinforced,
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "o2_in";
+	name = "Oxygen Supply Control";
+	output_tag = "o2_out";
+	sensors = list("o2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/blue/side,
+/area/shuttle/ftl/atmos)
+"pwm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"pxb" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	color = "#444444";
+	dir = 10;
+	initialize_directions = 10;
+	pixel_x = 0
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"pxi" = (
+/obj/effect/landmark/start{
+	name = "Scientist";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"pxE" = (
+/obj/machinery/suit_storage_unit/cmo,
+/obj/item/device/radio/intercom{
+	pixel_x = 32;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/barber,
+/area/shuttle/ftl/medical/cmo)
+"pyf" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"pyN" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/cannon)
+"pyY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/science{
+	name = "Research Division Access";
+	req_access_txt = "26"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/research/lab)
+"pzc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/cannon)
+"pzf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"pAw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Atmospheric Technician";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"pAF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"pBR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
+"pBY" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"pCL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32;
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/medical,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"pHm" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"pIG" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/engine,
+/area/shuttle/ftl/turret_protected/ai)
+"pII" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"pLz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"pNY" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"pOb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"pPc" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"pQB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/weapon/aiModule/core/full/corp,
+/obj/item/weapon/aiModule/reset{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"pRq" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"pSN" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	id = "supermatter_eject"
+	},
+/obj/machinery/power/supermatter_shard,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"pTP" = (
+/turf/open/floor/plasteel/green/corner{
+	tag = "icon-greencorner (NORTH)";
+	icon_state = "greencorner";
+	dir = 1
+	},
+/area/shuttle/ftl/hydroponics)
+"pUz" = (
+/turf/open/floor/plasteel/warning,
+/area/shuttle/ftl/bridge/eva)
+"pVB" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/shuttle/ftl/hydroponics)
+"pWc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"pXc" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/primary/starboard)
+"pYP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"pYR" = (
+/obj/structure/table/wood,
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"pZO" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"qbf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"qbo" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"qbq" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	tag = "icon-intact (NORTHWEST)";
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"qbH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"qco" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"qes" = (
+/obj/structure/table{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/weapon/book/manual/robotics_cyborgs{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"qfz" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/cmo)
+"qga" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"qgD" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 8;
+	pixel_y = -28;
+	req_access_txt = "23"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (SOUTHWEST)";
+	icon_state = "white_warn";
+	dir = 10
+	},
+/area/shuttle/ftl/medical/virology)
+"qgT" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/sleep)
+"qhq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L6"
+	},
+/area/shuttle/ftl/bridge)
+"qia" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"qjc" = (
+/obj/machinery/camera{
+	c_tag = "Waste Disposals"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"qjX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"qkp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Central Hallway 2";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"qlh" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"qlk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"qlq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"qmL" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	tag = "icon-intact (NORTHWEST)";
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"qnU" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"qqG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hydroponics)
+"qtS" = (
+/obj/machinery/computer/mech_bay_power_console,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
+"quh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/cmo)
+"qvI" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/westleft{
+	name = "Monkey Pen";
+	req_access_txt = "6"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/genetics)
+"qvU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"qwF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"qxC" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "engine_sensor"
+	},
+/turf/open/floor/plasteel/darkwarning{
+	tag = "icon-black_warn (WEST)";
+	icon_state = "black_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"qyy" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engineering)
+"qyN" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"qCD" = (
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	name = "Virology Access Console";
+	pixel_x = 8;
+	pixel_y = 22;
+	req_access_txt = "23";
+	idSelf = "virology_airlock_control";
+	idInterior = "virology_airlock_interior";
+	idExterior = "virology_airlock_exterior"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"qFN" = (
+/obj/structure/table,
+/obj/item/weapon/tank/internals/emergency_oxygen{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/weapon/tank/internals/emergency_oxygen{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"qFX" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
+"qGw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L12"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"qGz" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/captain,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
+"qHK" = (
+/obj/structure/window/reinforced,
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "n2_in";
+	name = "Nitrogen Supply Control";
+	output_tag = "n2_out";
+	sensors = list("n2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/red/side,
+/area/shuttle/ftl/atmos)
+"qKP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"qMK" = (
+/obj/structure/closet/secure_closet/CMO,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"qPc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"qSx" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"qVk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/hos)
+"qVm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"rai" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/snacks/mint,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"rbh" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio/intercom,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"reK" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"rfQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"rfV" = (
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions/cannon)
+"rge" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"rgR" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 0;
+	pixel_y = -28;
+	req_access_txt = "20"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/weapon/hand_labeler,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"rhx" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/weapon/pen/red,
+/obj/item/weapon/hand_labeler,
+/obj/structure/reagent_dispensers/virusfood{
+	density = 0;
+	pixel_x = -1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"rhJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"rhM" = (
+/obj/machinery/r_n_d/server/core,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/floor/bluegrid{
+	name = "Server Base";
+	initial_gas_mix = "n2=500;TEMP=80"
+	},
+/area/shuttle/ftl/research/server)
+"rhO" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Roboticist";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"rir" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"rkr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"rkt" = (
+/obj/structure/rack,
+/obj/item/pod_parts/armor/mining,
+/obj/item/device/spacepod_equipment/misc/tracker/ftl,
+/obj/item/device/spacepod_equipment/lock/keyed{
+	id = 5.31801e+006
+	},
+/obj/item/device/spacepod_equipment/sec_cargo/chair,
+/obj/item/device/spacepod_equipment/cargo/ore,
+/obj/item/weapon/stock_parts/cell,
+/obj/item/weapon/stock_parts/cell,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"rlt" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/atmos)
+"rmc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/requests_console{
+	department = "Robotics";
+	departmentType = 2;
+	name = "Robotics RC";
+	pixel_y = 30
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"rnu" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Shield Generator";
+	req_access_txt = "34";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
+"rnz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"rpU" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"rqu" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"rrm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"rry" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/cargo/office)
+"rsq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"rvi" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Coolant valve"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"rvX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"rwN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/loading)
+"ryL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"rzr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"rzA" = (
+/obj/structure/chair,
+/obj/effect/landmark/start/bo/weapons,
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 6
+	},
+/area/shuttle/ftl/bridge)
+"rBU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L10"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"rCL" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/clothing/glasses/welding,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"rDG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch{
+	id = "CargoMunitions"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 6
+	},
+/area/shuttle/ftl/cargo/office)
+"rER" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"rFr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"rFw" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"rHc" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/bar)
+"rHO" = (
+/obj/structure/displaycase/captain,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"rIA" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "co2_sensor"
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/engine/co2,
+/area/shuttle/ftl/atmos)
+"rIG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"rJN" = (
+/turf/closed/wall,
+/area/shuttle/ftl/bridge/eva)
+"rJS" = (
+/obj/machinery/door/window/southright{
+	name = "Bar Door";
+	req_access_txt = "16";
+	req_one_access_txt = "0"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"rKs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"rKL" = (
+/turf/open/floor/plasteel/warnwhite{
+	dir = 4
+	},
+/area/shuttle/ftl/assembly/robotics)
+"rLu" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "n2o_sensor"
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/engine/n2o,
+/area/shuttle/ftl/atmos)
+"rLI" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"rNr" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Chief Medical Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"rPO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"rQv" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/escape{
+	dir = 5
+	},
+/area/shuttle/ftl/atmos)
+"rQN" = (
+/obj/structure/table,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"rSZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/storage)
+"rTK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Central Hallway 3";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"rTL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/arrival{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/central)
+"rUa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"rUB" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/door/airlock/command{
+	emergency = 0;
+	name = "Munitions Access";
+	req_access_txt = "35"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"rVb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "munitions_loading";
+	tag = "munitions west"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"rVq" = (
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"rVA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"rVI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"rXT" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/box/evidence,
+/obj/item/weapon/hand_labeler{
+	pixel_x = 5
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"rYI" = (
+/obj/structure/sign/securearea{
+	name = "SERVER ROOM";
+	desc = "A warning sign which reads 'SERVER ROOM'."
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/telecomms/server)
+"sbX" = (
+/turf/closed/wall,
+/area/shuttle/ftl/assembly/chargebay)
+"scX" = (
+/obj/machinery/conveyor{
+	id = "munitions";
+	tag = "munitions south"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/munitions)
+"scZ" = (
+/obj/effect/landmark/event_spawn,
+/mob/living/simple_animal/slime,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"sde" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
+"sdg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"sfA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"sfK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/hallway/primary/central)
+"sgy" = (
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/break_room)
+"sif" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/light,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
+"sjq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"skU" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/virology)
+"smE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (WEST)";
+	icon_state = "plasteel_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/office)
+"smL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"snw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-black_warn_corner (EAST)";
+	icon_state = "black_warn_corner";
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engineering)
+"sny" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "34"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"soj" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"soP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"spW" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/security/wooden_tv,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"sqe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/cargo/office)
+"sqF" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/weapon/razor,
+/obj/item/weapon/surgical_drapes,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"sqU" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	tag = "icon-intact (WEST)";
+	icon_state = "intact";
+	dir = 8;
+	color = "#444444"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"srO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (WEST)";
+	icon_state = "intact";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"suM" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"svS" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"svT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"svX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"sxq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"szy" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L8"
+	},
+/area/shuttle/ftl/bridge)
+"sAY" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/machinery/camera/motion{
+	c_tag = "Holding Pen"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"sBl" = (
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/wrench/medical,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/medbay)
+"sBs" = (
+/obj/machinery/light,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"sBC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"sBF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"sCa" = (
+/obj/machinery/door/poddoor{
+	id = "Supermatter port"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating/airless,
+/area/shuttle/ftl/engine/engine_smes)
+"sDI" = (
+/obj/structure/table/glass,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHWEST)";
+	icon_state = "whiteblue";
+	dir = 9
+	},
+/area/shuttle/ftl/medical/chemistry)
+"sGG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"sHh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/window/westleft{
+	name = "Mech Bay";
+	req_access_txt = "18"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
+"sHB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"sHH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"sHX" = (
+/obj/structure/table/glass,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"sIZ" = (
+/obj/structure/spacepoddoor{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/multi_tile/four_tile_hor{
+	id = "miningpodbay";
+	layer = 3.1;
+	opacity = 1
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/cargo/mining)
+"sJG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "captains_shutters";
+	name = "Captains Office"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/captain)
+"sLN" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "0"
+	},
+/obj/docking_port/mobile/ftl{
+	dir = 2
+	},
+/obj/docking_port/stationary{
+	dheight = 8;
+	dir = 2;
+	dwidth = 49;
+	height = 73;
+	id = "ftl_start";
+	name = "Starting Area";
+	width = 97
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"sMX" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"sNJ" = (
+/obj/item/key/janitor,
+/obj/structure/table,
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"sPo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"sQz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"sSh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Conference Room Access";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"sTh" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"sTG" = (
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/bridge/eva)
+"sTR" = (
+/turf/open/floor/plasteel/escape/corner{
+	tag = "icon-escapecorner (NORTH)";
+	icon_state = "escapecorner";
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"sUr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"sWF" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/main)
+"sWQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"sXZ" = (
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"sYA" = (
+/obj/structure/table/wood,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/stamp/hos,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"sYF" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"taq" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "atmos blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/atmos)
+"tbf" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/ftl/munitions/loading)
+"tbZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"tcr" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"tcX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"tgR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Janitor";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"tgZ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/weapon/storage/belt/utility,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"tin" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"tix" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen";
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
+"tjj" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	tag = "icon-intact (NORTH)";
+	icon_state = "intact";
+	dir = 1
+	},
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"tkX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"tlF" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"toK" = (
+/turf/open/space,
+/area/shuttle/ftl/space)
+"tpQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"trE" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/chemistry)
+"tsM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"tsU" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
+/obj/item/device/spacepod_key{
+	id = 5.31801e+006
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"tuI" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/munitions)
+"tuM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L6"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"tuY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining{
+	name = "Mining Equipment";
+	req_access_txt = "27"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"tvQ" = (
+/obj/item/weapon/folder/white{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/structure/table,
+/obj/item/weapon/disk/tech_disk{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/disk/tech_disk{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"twP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"twV" = (
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"tyB" = (
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"tyG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "Server Room";
+	req_access_txt = "19"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
+"tzT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"tBw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"tBB" = (
+/turf/closed/wall,
+/area/shuttle/ftl/medical/medbay)
+"tBU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/medical/surgery)
+"tCv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/chemistry)
+"tEx" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"tHR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"tLn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "L6"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"tLv" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"tLE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/loading)
+"tMN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge RC";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"tNP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"tOF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"tOP" = (
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 4";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"tPQ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Security Office East";
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = -24
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"tPZ" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
+"tTr" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "15"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"tTX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"tUg" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/machine/mac_barrel{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/mac_breech,
+/obj/item/weapon/circuitboard/machine/phase_cannon{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"tUk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "delivery"
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"tUq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"tVP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 6
+	},
+/area/shuttle/ftl/cargo/office)
+"tVX" = (
+/obj/machinery/computer/security,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"tWa" = (
+/obj/machinery/door/window/southright{
+	name = "Shuttle Brig";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/shuttle/red,
+/area/shuttle/ftl/subshuttle/pod_3)
+"tWy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L14"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"tXa" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/bar)
+"tXR" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"tXV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
+"uac" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"uaf" = (
+/turf/closed/wall,
+/area/shuttle/ftl/storage/tech)
+"uam" = (
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/whitered/side,
+/area/shuttle/ftl/security/main)
+"uaU" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/regular,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"uby" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/detectives_office)
+"ubP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/detectives_office)
+"ueD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"uhj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"ujx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"umG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"upk" = (
+/obj/structure/chair,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge";
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/darkblue/side,
+/area/shuttle/ftl/bridge)
+"urw" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	tag = "icon-intact (WEST)";
+	icon_state = "intact";
+	dir = 8;
+	color = "#444444"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"uvL" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"uxq" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
+/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
+/obj/item/ammo_box/magazine/sniper_rounds/soporific,
+/obj/structure/window/reinforced,
+/obj/item/ammo_box/magazine/sniper_rounds/soporific,
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle,
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/security/armory)
+"uzo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"uAi" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "munitions_loading";
+	tag = "munitions west"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"uAP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Bar"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"uCb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "L5"
+	},
+/area/shuttle/ftl/bridge)
+"uCT" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/escape{
+	dir = 9
+	},
+/area/shuttle/ftl/atmos)
+"uDV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "warehouse shutters"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/storage)
+"uEc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"uEo" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"uIK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"uIQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"uJn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"uKn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"uLm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/assembly/robotics)
+"uMc" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"uNe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access_txt = "23"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_exterior";
+	locked = 1;
+	name = "Virology Exterior Airlock";
+	req_access_txt = "23"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"uNy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"uOp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"uOS" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"uPj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/ftl/munitions/loading)
+"uPL" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/item/weapon/book/manual/ftl_wiki/supermatter,
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"uPS" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"uQy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
+"uRl" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "5"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/medbay_lobby)
+"uRY" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	sortType = 15
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"uUb" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
+"uXV" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
+"uZf" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/closet/emcloset,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/obj/item/weapon/tank/internals/emergency_oxygen/double,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"uZs" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/open/space,
+/area/shuttle/ftl/space)
+"vaT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"vfa" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"vgB" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor{
+	id = "Supermatter doors"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"vjV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L3"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"vkd" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 38
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"vlC" = (
+/turf/closed/wall,
+/area/shuttle/ftl/bridge/meeting_room)
+"vot" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/syringes,
+/obj/item/device/radio/intercom{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHEAST)";
+	icon_state = "whiteblue";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/medbay)
+"vpm" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 38
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/storage)
+"vpt" = (
+/obj/machinery/mac_breech{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
+"vsF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"vtM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"vuM" = (
+/obj/structure/dresser,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
+"vxg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"vyh" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"vyq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"vzu" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"vzM" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/cargo/office)
+"vAY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"vEV" = (
+/obj/structure/piano{
+	tag = "icon-piano";
+	icon_state = "piano"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"vFk" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (SOUTHEAST)";
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"vFM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"vFZ" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/storage/fancy/cigarettes,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"vGh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"vHa" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge)
+"vId" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"vJk" = (
+/obj/structure/table/glass,
+/obj/item/weapon/book/manual/medical_cloning{
+	pixel_y = 6
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/item/weapon/disk/data,
+/obj/item/weapon/disk/data,
+/obj/item/weapon/disk/data,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/genetics)
+"vJQ" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/item/weapon/melee/chainofcommand,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"vKw" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp/green,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"vLg" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"vLy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/medbay)
+"vOR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"vSj" = (
+/obj/machinery/camera{
+	c_tag = "Shield Generator"
+	},
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/engine/engineering)
+"vTh" = (
+/obj/structure/mirror{
+	pixel_y = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/toilet)
+"vWP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"vYf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge Access";
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L4"
+	},
+/area/shuttle/ftl/bridge)
+"vYr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/science)
+"vZs" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Central Hallway 1";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"wax" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/detectives_office)
+"wbV" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/toilet)
+"wcK" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"wdp" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"wev" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel/whitered/side{
+	dir = 4
+	},
+/area/shuttle/ftl/security/main)
+"wgr" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF WEAPONS AREA'.";
+	layer = 2.9;
+	name = "KEEP CLEAR OF WEAPONS AREA";
+	pixel_y = 0
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/space)
+"wgC" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Detective";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"wgR" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/medbay)
+"whm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plasteel/warning,
+/area/shuttle/ftl/engine/engine_smes)
+"wjB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"wlA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"wmS" = (
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/mining)
+"wno" = (
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 5";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"woa" = (
+/obj/machinery/ftl_shieldgen{
+	plasma_charge_max = 25;
+	power_charge_max = 50
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"woq" = (
+/turf/open/floor/plasteel/arrival/corner,
+/area/shuttle/ftl/hallway/primary/port)
+"wpB" = (
+/obj/machinery/meter{
+	name = "Mixed Air Tank In"
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel/arrival{
+	dir = 10
+	},
+/area/shuttle/ftl/atmos)
+"wrr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/xenobiology)
+"wrD" = (
+/obj/machinery/button/door{
+	id = "EvaGarage";
+	name = "Garage Doors";
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/machinery/camera{
+	c_tag = "EVA Garage";
+	dir = 8
+	},
+/turf/open/floor/plasteel/warning,
+/area/shuttle/ftl/bridge/eva)
+"wui" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"wvm" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/cargo/storage)
+"wvC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/glass_large{
+	name = "Cargo Bay Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"wvI" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"wvO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"wwl" = (
+/obj/machinery/dna_scannernew,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/genetics)
+"wwq" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"wwT" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"wyH" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/bar)
+"wzt" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 8;
+	filter_type = "n2o";
+	icon_state = "filter_off";
+	on = 1;
+	tag = "icon-filter_off (WEST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"wzC" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2;
+	frequency = 1441;
+	id = "co2_in";
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/co2,
+/area/shuttle/ftl/atmos)
+"wzG" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "5"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/medbay)
+"wAk" = (
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"wDl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L3"
+	},
+/area/shuttle/ftl/bridge)
+"wDT" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"wED" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"wGe" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"wGi" = (
+/obj/machinery/conveyor{
+	id = "munitions";
+	tag = "munitions south"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"wJO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"wKN" = (
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"wLI" = (
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"wLM" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/cargo/office)
+"wNp" = (
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/mining)
+"wNV" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/dropper,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHEAST)";
+	icon_state = "whiteblue";
+	dir = 5
+	},
+/area/shuttle/ftl/medical/chemistry)
+"wPt" = (
+/obj/structure/table,
+/obj/item/weapon/scalpel{
+	pixel_y = 12
+	},
+/obj/item/weapon/circular_saw,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"wRm" = (
+/obj/machinery/computer/telecomms/monitor{
+	network = "tcommsat"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"wRt" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"wRW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"wTY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
+"wUj" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"wUD" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"wWs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L1"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"wXy" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/chemistry)
+"xac" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/storage)
+"xag" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"xbe" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"xcD" = (
+/obj/spacepod{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/cargo/mining)
+"xcS" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"xhc" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "tox_in";
+	name = "Plasma Supply Control";
+	output_tag = "tox_out";
+	sensors = list("tox_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/atmos)
+"xhl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"xhK" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"xif" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"xin" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"xjC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"xkC" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/bridge/meeting_room)
+"xkS" = (
+/obj/machinery/door/airlock/security{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"xmw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L9"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"xmU" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/turf/open/floor/plasteel/green/side{
+	dir = 9
+	},
+/area/shuttle/ftl/hydroponics)
+"xnf" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
+/area/shuttle/ftl/hydroponics)
+"xnE" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/hor)
+"xqg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"xts" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
+"xwa" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8;
+	initialize_directions = 11
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"xwz" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/vehicle/janicart,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"xwF" = (
+/obj/structure/filingcabinet/security,
+/obj/item/weapon/folder/documents,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"xzn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/structure/closet/secure_closet/RD,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"xzv" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"xzH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"xzQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"xBJ" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"xCr" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"xEg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"xEA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"xEE" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
+"xFh" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"xHB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"xJQ" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"xJT" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	tag = "icon-dvalve_map (EAST)";
+	icon_state = "dvalve_map";
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"xLN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"xNR" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/telecomms/server)
+"xPe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"xRn" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"xRZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"xSv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"xSE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/detectives_office)
+"xSH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"xTF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
+"xUH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"xUQ" = (
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room";
+	dir = 1
+	},
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"xVT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"xVZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"xXc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"xXx" = (
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/security)
+"xZs" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"yaN" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_one_access_txt = "7;19"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"yaY" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/nuke_storage)
+"ybq" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"ybB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_interior";
+	locked = 1;
+	name = "Virology Interior Airlock";
+	req_access_txt = "23"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"ycQ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"yda" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"yfu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/science)
+"yfx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"yfA" = (
+/obj/effect/landmark/latejoin,
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/arrival{
+	tag = "icon-arrival (NORTH)";
+	icon_state = "arrival";
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"ygk" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/break_room)
+"yhI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"yhQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"yiw" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"yiI" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/borgupload{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/aiupload,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"yiR" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"ylA" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"ylK" = (
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"ynA" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/button/door{
+	name = "Emitter Port";
+	pixel_x = -25;
+	pixel_y = 27;
+	req_access_txt = "36";
+	id = "Supermatter port"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 10
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"ynW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"ypb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"yqN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"yti" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/aifixer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/teleporter,
+/obj/item/weapon/circuitboard/computer/rdconsole{
+	pixel_x = 3;
+	pixel_y = -3;
+	pixel_z = 0
+	},
+/obj/item/weapon/circuitboard/computer/pandemic{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/circuit_imprinter,
+/obj/item/weapon/circuitboard/machine/destructive_analyzer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/machine/mechfab{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/protolathe,
+/obj/item/weapon/circuitboard/machine/rdserver{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"yuL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
+"yuU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"yvg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"yxE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"yxX" = (
+/obj/structure/table,
+/obj/item/device/taperecorder{
+	pixel_x = -3
+	},
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/folder/white{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/weapon/stamp/rd{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/device/taperecorder{
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"yyc" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/hor)
+"yyV" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHWEST)";
+	icon_state = "whiteblue";
+	dir = 10
+	},
+/area/shuttle/ftl/medical/genetics)
+"yAe" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/shuttle/red,
+/area/shuttle/ftl/subshuttle/pod_3)
+"yBF" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Head of Personnel Office";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"yDE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"yDR" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"yEf" = (
+/obj/effect/landmark/start{
+	name = "Cook";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"yFi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"yFs" = (
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
+	},
+/area/shuttle/ftl/engine/break_room)
+"yGe" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"yGq" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"yHj" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access_txt = "22"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "green";
+	dir = 4
+	},
+/area/shuttle/ftl/hydroponics)
+"yHo" = (
+/obj/machinery/telecomms/bus/preset_one/birdstation,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"yHO" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkwarning{
+	tag = "icon-black_warn (WEST)";
+	icon_state = "black_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"yJb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"yLk" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/lab)
+"yMC" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"yQb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"yQm" = (
+/obj/machinery/vending/tool{
+	req_access_txt = "34"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
+/area/shuttle/ftl/engine/break_room)
+"ySj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"yTv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"yUi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Engineering Hallway South";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"yUX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"yUY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/arrival{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/central)
+"yWi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"yWs" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/item/device/pipe_painter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"yWt" = (
+/obj/machinery/gravity_generator/main/station,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"yYq" = (
+/obj/machinery/camera{
+	c_tag = "FTL Drive"
+	},
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/engine/engineering)
+"yYS" = (
+/obj/machinery/telecomms/receiver/preset_left/birdstation,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"yZe" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6;
+	initialize_directions = 6
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"yZl" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"yZZ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF WEAPONS AREA'.";
+	layer = 2.9;
+	name = "KEEP CLEAR OF WEAPONS AREA";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"zaH" = (
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"zaI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/turret_protected/ai)
+"zaO" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"zbI" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engineering)
+"zbL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"zbY" = (
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (NORTH)";
+	icon_state = "white_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
+"zcq" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"zfq" = (
+/obj/machinery/atmospherics/components/binary/circulator{
+	dir = 2;
+	icon_state = "circ2-off";
+	tag = "icon-circ2-off"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"zhw" = (
+/obj/machinery/computer/communications,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge)
+"zis" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/window/southleft{
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/security/armory)
+"ziR" = (
+/obj/structure/table/glass,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"ziY" = (
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"zjf" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "0"
+	},
+/obj/effect/landmark/pod_port_spawner{
+	dir = 1;
+	dwidth = 2;
+	height = 11;
+	pod_id = "pod3";
+	pod_name = "Escape Shuttle A";
+	width = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/ftl/subshuttle/pod_3)
+"zjh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=FP";
+	location = "AFT"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"zkZ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "outerbrig";
+	name = "Brig Exterior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -26;
+	pixel_y = -5;
+	req_access_txt = "1"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "innerbrig";
+	name = "Brig Interior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -26;
+	pixel_y = 5;
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"zmt" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"zoj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	tag = "icon-intact (NORTH)";
+	icon_state = "intact";
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkwarning{
+	tag = "icon-black_warn (WEST)";
+	icon_state = "black_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"zsz" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/lighter,
+/obj/item/weapon/stamp/ce,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/book/manual/ftl_wiki/supermatter,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/paper/monitorkey,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"zsE" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"zuO" = (
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	icon_state = "direction_evac";
+	pixel_x = 32;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"zxw" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	tag = "icon-intact (SOUTHEAST)";
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"zxR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"zCl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"zCY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"zDE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHEAST)";
+	icon_state = "whiteblue";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/medbay)
+"zFd" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"zHn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 5
+	},
+/area/shuttle/ftl/munitions)
+"zIu" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
+/area/shuttle/ftl/atmos)
+"zIv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"zIE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"zKg" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-black_warn_corner (EAST)";
+	icon_state = "black_warn_corner";
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engineering)
+"zKB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"zLv" = (
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"zRv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"zRI" = (
+/turf/open/floor/plasteel/escape/corner{
+	tag = "icon-escapecorner (EAST)";
+	icon_state = "escapecorner";
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"zRQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"zSr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"zSE" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "27"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/mining)
+"zTs" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"zUw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"zXj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "Control Room";
+	req_access_txt = "12;33"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"zXy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Abo" = (
+/obj/machinery/cryopod/right,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 5
+	},
+/area/shuttle/ftl/crew_quarters/sleep)
+"AbS" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"Aec" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	tag = "icon-pump_map (NORTH)";
+	icon_state = "pump_map";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"AeT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
+"Ahq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"Ail" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"Ais" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Aiu" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/shuttle/ftl/bridge)
+"Ajb" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	tag = "icon-pump_map (WEST)";
+	icon_state = "pump_map";
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"Akp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"Aks" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTHWEST)";
+	icon_state = "plasteel_warn";
+	dir = 9
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"Alx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 8;
+	output_dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"AlA" = (
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 3";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"AlR" = (
+/obj/machinery/computer/station_alert,
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"AnB" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"AnY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"AoV" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"ApK" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
+"Aqw" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Reception";
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay_lobby)
+"AsB" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo Office 1";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"Avj" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	icon_state = "dvalve_map";
+	name = "Coolant valve";
+	tag = "icon-dvalve_map (EAST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"Awn" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/mining)
+"Axg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"AyP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L12"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"AyR" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"AzE" = (
+/obj/item/device/analyzer,
+/obj/item/device/healthanalyzer,
+/obj/item/device/plant_analyzer{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/structure/table,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"AAR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/office)
+"ACU" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"AEh" = (
+/obj/machinery/telecomms/broadcaster/preset_left/birdstation,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"AEx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L5"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"AEM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"AHc" = (
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"AHk" = (
+/obj/machinery/computer/message_monitor,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"AJh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "15"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"AJB" = (
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel";
+	req_access = null;
+	req_access_txt = "30"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"AKi" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
+/obj/item/device/spacepod_key{
+	id = 5.31801e+006
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"ALq" = (
+/obj/machinery/door/window/southleft{
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"ANA" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/mecha_control{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/robotics,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"APj" = (
+/obj/structure/closet/crate/internals,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"AQw" = (
+/turf/closed/wall,
+/area/shuttle/ftl/medical/chemistry)
+"AQM" = (
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"ASK" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"AVW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "1"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"AXu" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "munitions_loading";
+	tag = "munitions west"
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"AYP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Detectives Office";
+	req_access_txt = "41"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"BaM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L1"
+	},
+/area/shuttle/ftl/bridge)
+"BbM" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"BcZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"Bdg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	name = "Conference Room";
+	req_access = null;
+	req_access_txt = "12"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"Bdj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Bdw" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"Bgk" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Server Walkway";
+	initial_gas_mix = "n2=500;TEMP=80"
+	},
+/area/shuttle/ftl/research/server)
+"BmX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"BnO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"BnR" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"Boj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"Bpe" = (
+/obj/effect/landmark/latejoin,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/arrival,
+/area/shuttle/ftl/hallway/primary/port)
+"Bpu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"Bqf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHWEST)";
+	icon_state = "whiteblue";
+	dir = 10
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"Bsg" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"BsK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "co2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/co2,
+/area/shuttle/ftl/atmos)
+"BtK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Buo" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/engineering)
+"BuO" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/engine/engine_smes)
+"BvF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"BvL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
+"Bwo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/drone,
+/obj/item/weapon/storage/toolbox/drone,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"BxU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"Byz" = (
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Bzo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/hor)
+"BzW" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_x = 30;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"BBw" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/space)
+"BCG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"BDq" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "munitions_loading";
+	tag = "munitions west"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"BDY" = (
+/obj/machinery/telecomms/server/presets/common/birdstation,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"BGl" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/briefcase,
+/obj/item/device/taperecorder,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"BGz" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"BHM" = (
+/turf/closed/wall,
+/area/shuttle/ftl/medical/genetics)
+"BIw" = (
+/turf/closed/wall,
+/area/shuttle/ftl/bridge)
+"BLc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/computer/aifixer,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"BOB" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "Chief Engineer";
+	req_access_txt = "29"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"BOH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"BQx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"BQC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"BSd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/device/radio/intercom{
+	pixel_x = -32;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"BSz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"BTe" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"BTL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"BTZ" = (
+/turf/closed/wall,
+/area/shuttle/ftl/janitor)
+"BXi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "miningpodbay";
+	layer = 4;
+	name = "Mining Podbay Doors";
+	pixel_x = 8;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"BYI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	name = "RnD Desk";
+	req_access_txt = "26"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"Ccb" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"Cec" = (
+/obj/effect/landmark{
+	name = "Observer-Start"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Cgl" = (
+/obj/structure/table,
+/obj/item/weapon/cautery{
+	pixel_x = 4
+	},
+/obj/item/weapon/hemostat,
+/obj/machinery/camera{
+	c_tag = "Medbay Surgery";
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"Cht" = (
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/munitions)
+"ChJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L1"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"Cjj" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/engine/engineering)
+"Cjn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
+"ClH" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/ftl/subshuttle/pod_3)
+"CmJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"Cof" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "18"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/assembly/robotics)
+"Col" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "29"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"Cqh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
+"CqX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Crw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay)
+"CrN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"CsA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 2
+	},
+/area/shuttle/ftl/cargo/office)
+"CtY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/lab)
+"CwT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"Cyk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"Cyq" = (
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"CBc" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"CBE" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"CBG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/assembly/robotics)
+"CCX" = (
+/obj/machinery/conveyor{
+	dir = 6;
+	id = "garbage";
+	verted = -1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"CDf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"CDP" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/cannon)
+"CGR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"CIc" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"CJG" = (
+/obj/machinery/door/airlock/research{
+	name = "Robotics";
+	req_access_txt = "18";
+	req_one_access_txt = "0"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"CJX" = (
+/obj/machinery/conveyor_switch/oneway{
+	convdir = -1;
+	id = "garbage";
+	name = "disposal coveyor"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"CKU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"CON" = (
+/obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 3
+	},
+/obj/item/weapon/lighter,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"CPz" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "trash"
+	},
+/turf/open/floor/plating/warnplate{
+	dir = 8
+	},
+/area/shuttle/ftl/maintenance/disposal)
+"CQz" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/telecomms/server)
+"CRa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"CRO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/retractor,
+/obj/item/weapon/hemostat,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"CSr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/assembly/chargebay)
+"CUo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/office)
+"CVE" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 10
+	},
+/area/shuttle/ftl/cargo/office)
+"CWX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"CWZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/captain)
+"CXj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"CYg" = (
+/obj/machinery/pipedispenser,
+/obj/machinery/camera{
+	c_tag = "Atmospherics Storage"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"CZq" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/heads)
+"DaF" = (
+/obj/structure/toilet{
+	pixel_y = 8
+	},
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"DbX" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"Dcv" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"DcH" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"Deu" = (
+/obj/machinery/button/door{
+	id = "kitchen";
+	name = "Kitchen Shutters Control";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access_txt = "17"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"Dgi" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/energy/ionrifle,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/security/armory)
+"Dhe" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"Djz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
+"DjH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"DjW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/glass_large{
+	name = "EVA airlock";
+	req_access_txt = "42"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"Dkp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"DkK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"DnD" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkwarning{
+	tag = "icon-black_warn (WEST)";
+	icon_state = "black_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"Dox" = (
+/obj/structure/table,
+/obj/item/weapon/weldingtool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
+"DpH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"DqA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"DsB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"DtJ" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/weapon/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/weapon/storage/lockbox/loyalty,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"DvP" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
+/area/shuttle/ftl/engine/break_room)
+"DBA" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/table/reinforced,
+/obj/item/device/instrument/guitar,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"DDF" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"DDS" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	freerange = 1;
+	listening = 1;
+	name = "Common Channel";
+	pixel_x = -27;
+	pixel_y = -9
+	},
+/obj/item/device/radio/intercom{
+	anyai = 1;
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = 0;
+	pixel_y = -31
+	},
+/obj/item/device/radio/intercom{
+	anyai = 1;
+	broadcasting = 0;
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = 27;
+	pixel_y = -9
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -28;
+	pixel_y = -28
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	pixel_x = 28;
+	pixel_y = -28
+	},
+/obj/effect/landmark/start{
+	name = "AI";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/bluegrid,
+/area/shuttle/ftl/turret_protected/ai)
+"DGf" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/hos)
+"DGq" = (
+/obj/machinery/computer/card,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"DHC" = (
+/obj/structure/table,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"DJt" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"DJC" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"DJK" = (
+/obj/structure/table,
+/obj/item/weapon/crowbar,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"DKa" = (
+/obj/structure/cryofeed/right,
+/turf/open/floor/plasteel/white,
+/area/shuttle/ftl/crew_quarters/sleep)
+"DNb" = (
+/obj/machinery/camera{
+	c_tag = "Munitions Access";
+	dir = 8
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
+"DNy" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/green/side{
+	tag = "icon-green (SOUTHWEST)";
+	icon_state = "green";
+	dir = 10
+	},
+/area/shuttle/ftl/hydroponics)
+"DPP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warnwhite{
+	dir = 1
+	},
+/area/shuttle/ftl/medical/virology)
+"DPZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/glass_large{
+	name = "Medical Bay Airlock"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"DRe" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"DUl" = (
+/obj/effect/landmark/start{
+	name = "Station Engineer";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"DUG" = (
+/obj/structure/closet/wardrobe/science_white,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
+"DXq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/telecomms/server)
+"DZT" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/weapon/storage/fancy/cigarettes,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"Edc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"EdF" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"EdS" = (
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
+	},
+/area/shuttle/ftl/engine/break_room)
+"Eii" = (
+/obj/machinery/recharger,
+/obj/structure/table,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"Ejl" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"EjI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/munitions/loading)
+"EkD" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"ElI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"Epv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/office)
+"Eus" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"Ewc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"Ewk" = (
+/obj/structure/shuttle/engine/propulsion/burst/left,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/space,
+/area/shuttle/ftl/subshuttle/pod_3)
+"EwJ" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
+"ExG" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"ExZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"Eyb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"Eyi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"EyZ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (WEST)";
+	icon_state = "intact";
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"EAt" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/cargo)
+"EAP" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/obj/machinery/recycler,
+/obj/structure/sign/securearea{
+	name = "\improper STAY CLEAR HEAVY MACHINERY";
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"ECy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "L7"
+	},
+/area/shuttle/ftl/bridge)
+"EEd" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"EEJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/lab)
+"EEM" = (
+/obj/structure/closet/radiation,
+/obj/item/clothing/mask/gas,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"EEQ" = (
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/dropper,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"EEU" = (
+/obj/machinery/door/airlock/external{
+	id_tag = null;
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"EFk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"EFO" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"EFU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"EFV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"EIr" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"EKj" = (
+/obj/machinery/meter,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	tag = "icon-manifold (EAST)";
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"EKN" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 8
+	},
+/area/shuttle/ftl/security/main)
+"ELn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "n2o_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/n2o,
+/area/shuttle/ftl/atmos)
+"ELO" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"EMC" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/cargo)
+"ENt" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access = null;
+	req_access_txt = "13"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/captain)
+"EOy" = (
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"EOG" = (
+/obj/machinery/computer/telecomms/server{
+	network = "tcommsat"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecoms Admin";
+	departmentType = 5;
+	name = "Telecoms RC";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"EPS" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"EQk" = (
+/obj/machinery/door/airlock/command{
+	name = "Munitions Officer";
+	req_access_txt = "43"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"ESv" = (
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/ftl/subshuttle/pod_3)
+"ETj" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start{
+	name = "Chief Engineer"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"ETM" = (
+/obj/machinery/vending/snack,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"EUO" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"EXf" = (
+/turf/open/floor/bluegrid,
+/area/shuttle/ftl/assembly/chargebay)
+"EYH" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/space)
+"EZv" = (
+/turf/closed/wall,
+/area/shuttle/ftl/medical/cmo)
+"FbA" = (
+/obj/machinery/computer/monitor,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"FbC" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"Fdx" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "AI Core Door";
+	req_access_txt = "44"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"FdA" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"FeB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/toilet)
+"FeJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"FeZ" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/white{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"Ffg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Central Hallway 4";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"FfR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"FgG" = (
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/device/healthanalyzer,
+/obj/item/device/healthanalyzer,
+/obj/item/device/healthanalyzer,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"FgV" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"Fhn" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Fjm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"FjM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-black_warn_corner (WEST)";
+	icon_state = "black_warn_corner";
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"Fph" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Fpk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L2"
+	},
+/area/shuttle/ftl/bridge)
+"Fqz" = (
+/obj/structure/table,
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/weapon/crowbar,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"FqO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"Frh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"FrL" = (
+/obj/structure/table/glass,
+/obj/item/weapon/folder/white{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/weapon/storage/box/monkeycubes{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/weapon/storage/pill_bottle/mannitol{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/genetics)
+"FuH" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"FvO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/warnwhite{
+	dir = 4
+	},
+/area/shuttle/ftl/assembly/robotics)
+"FvT" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"FwT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"Fyi" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Photon Cannon";
+	dir = 4
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"Fzf" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/door/window/westleft{
+	req_access_txt = "13"
+	},
+/obj/machinery/button/door{
+	id = "bridge blast";
+	name = "Bridge Blast Door Control";
+	pixel_x = 0;
+	pixel_y = 28;
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge)
+"Fzw" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j2s";
+	sortType = 20
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"FAw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Captain's Office"
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"FBz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/nuke_storage)
+"FBB" = (
+/obj/effect/landmark/start{
+	name = "Cook";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"FCX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"FDu" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"FDK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engine_smes)
+"FHA" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"FOa" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"FOm" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/box/matches,
+/obj/item/clothing/mask/cigarette/cigar,
+/obj/item/weapon/reagent_containers/food/drinks/flask/gold,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"FPi" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/bridge/meeting_room)
+"FQK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"FRh" = (
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/engine/engineering)
+"FRO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/science{
+	name = "Research Division Access";
+	req_access_txt = "26"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"FUk" = (
+/turf/open/floor/plasteel/shuttle/red,
+/area/shuttle/ftl/subshuttle/pod_3)
+"FWG" = (
+/obj/machinery/telecomms/relay/preset/station,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"Gae" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"GaQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/green/side{
+	dir = 1
+	},
+/area/shuttle/ftl/hydroponics)
+"Gbs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"GbN" = (
+/obj/structure/closet/secure_closet/hos,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"GcL" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"Gdn" = (
+/obj/structure/table,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/wrench,
+/obj/item/device/multitool,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
+"Gdo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"GdN" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/engine/engineering)
+"Geq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"GeI" = (
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/bar)
+"GhC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHWEST)";
+	icon_state = "whiteblue";
+	dir = 10
+	},
+/area/shuttle/ftl/medical/medbay)
+"GiP" = (
+/obj/structure/table/reinforced,
+/obj/item/device/aicard,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"GiS" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"GjT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"Gkx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/science{
+	name = "Research Division Access";
+	req_access_txt = "26"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"GkJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/weapon/dice/d20,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"Glg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"GmA" = (
+/turf/open/floor/plasteel/loadingarea{
+	dir = 4
+	},
+/area/shuttle/ftl/bridge/eva)
+"GnE" = (
+/obj/machinery/pipedispenser/disposal,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Gpi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"GpF" = (
+/obj/machinery/door/airlock/glass_external{
+	name = "Escape Shuttle"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Gqc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/detectives_office)
+"GrD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Detective's Office"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"GrT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"Gsm" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/atmos)
+"Gso" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gsr" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/munitions/cannon)
+"Gte" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (EAST)";
+	icon_state = "white_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/research/lab)
+"GwN" = (
+/obj/machinery/door/poddoor{
+	id = "trash";
+	name = "disposal bay door"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"GAi" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/blue/side{
+	dir = 9
+	},
+/area/shuttle/ftl/crew_quarters/heads)
+"GCi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/obj/structure/sign/securearea{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/bridge)
+"GCq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"GEw" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/toilet)
+"GHq" = (
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 4"
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"GHD" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"GIV" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = -11;
+	pixel_y = -24
+	},
+/obj/machinery/camera/motion{
+	c_tag = "MiniSat AI Chamber North";
+	dir = 1;
+	network = list("MiniSat")
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"GRL" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	sortType = 1
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"GTm" = (
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"GTE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_access_txt = "42"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"GVw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/warning{
+	dir = 10
+	},
+/area/shuttle/ftl/cargo/office)
+"GWG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Brig Cell 3";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"GWJ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"GYj" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/security)
+"GYU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "L5"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"HaK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Hbp" = (
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay)
+"Hbq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"Hdj" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Hfl" = (
+/obj/machinery/power/port_gen/pacman{
+	pixel_y = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"Hfw" = (
+/obj/machinery/computer/atmos_control/tank{
+	force_blueprints = 0;
+	frequency = 1441;
+	input_tag = "engine_in";
+	name = "Engine Cooling Control";
+	output_tag = "engine_out";
+	sensors = list("engine_sensor" = "Engine Core")
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 6
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"HfQ" = (
+/turf/open/floor/plasteel/warning{
+	dir = 5
+	},
+/area/shuttle/ftl/cargo/mining)
+"HhE" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"Hif" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"Hit" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"HlQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"Hmf" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"HoD" = (
+/obj/effect/landmark/start{
+	name = "Shaft Miner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"Hpg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Hqi" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"HqT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"HqV" = (
+/turf/open/floor/plasteel/warnwhite/corner,
+/area/shuttle/ftl/assembly/robotics)
+"HsN" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/weapon/storage/belt/utility,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"HwP" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/energy/gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/energy/gun,
+/obj/item/weapon/gun/energy/gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	on = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"HzF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/hardsuit_jetpack,
+/obj/item/hardsuit_jetpack,
+/obj/item/hardsuit_jetpack,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
+"HAh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"HAq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"HAt" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/device/multitool{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/multitool,
+/obj/item/clothing/glasses/meson{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/meson,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"HAv" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF WEAPONS AREA'.";
+	layer = 2.9;
+	name = "KEEP CLEAR OF WEAPONS AREA";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/space)
+"HAM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/hos)
+"HEF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
+"HFX" = (
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engineering)
+"HIo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"HJm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"HMG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/armory)
+"HOh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/brig)
+"HOI" = (
+/obj/machinery/computer/atmos_alert,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"HPm" = (
+/obj/machinery/camera{
+	c_tag = "Secure Tech Storage";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"HQu" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF WEAPONS AREA'.";
+	layer = 2.9;
+	name = "KEEP CLEAR OF WEAPONS AREA";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/space)
+"HRt" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"HRy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"HRC" = (
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engineering)
+"HSB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"HSF" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"HSM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/chair/wood,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"HTO" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"HUt" = (
+/obj/machinery/ammo_rack/full,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/munitions/loading)
+"HWr" = (
+/obj/machinery/door/airlock/command{
+	name = "Conference Room";
+	req_access = null;
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"HXN" = (
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/reinforced,
+/obj/machinery/camera{
+	c_tag = "Bar";
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"HYj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 23
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
+"HYx" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/sign/securearea{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (NORTHWEST)";
+	icon_state = "white_warn";
+	dir = 9
+	},
+/area/shuttle/ftl/medical/virology)
+"IaT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"Idm" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/division)
+"Ifn" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"Igh" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	tag = "icon-manifold (NORTH)";
+	icon_state = "manifold";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"IgU" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTHEAST)";
+	icon_state = "plasteel_warn";
+	dir = 5
+	},
+/area/shuttle/ftl/cargo/office)
+"IiY" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/genetics)
+"Ijj" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	tag = "icon-intact (NORTH)";
+	icon_state = "intact";
+	dir = 1
+	},
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"IlU" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/chemistry)
+"Inb" = (
+/obj/structure/closet/l3closet/janitor,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"Ing" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"Inm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/machinery/door/window/eastright{
+	name = "Brig Desk";
+	req_access_txt = "2"
+	},
+/obj/item/weapon/restraints/handcuffs,
+/obj/item/device/radio/off,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
+"Ins" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
+/area/shuttle/ftl/hydroponics)
+"InZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Iqe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 3"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Isw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/shuttle/ftl/bridge)
+"IsU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"Ivq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"Ixf" = (
+/obj/machinery/power/smes/engineering{
+	color = ""
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 5
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"IyK" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/meter{
+	name = "Mixed Air Tank Out"
+	},
+/turf/open/floor/plasteel/arrival{
+	dir = 6
+	},
+/area/shuttle/ftl/atmos)
+"IyN" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/captain)
+"IDC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"IDF" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"IDX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"IFL" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/disposal)
+"IIk" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"ILx" = (
+/turf/closed/wall/shuttle{
+	icon_state = "swall12";
+	dir = 2
+	},
+/area/shuttle/ftl/subshuttle/pod_3)
+"INT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos)
+"IRA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"ISa" = (
+/turf/open/floor/plating,
+/turf/closed/wall/shuttle{
+	dir = 2;
+	icon_state = "swall_f10";
+	layer = 2
+	},
+/area/shuttle/ftl/subshuttle/pod_3)
+"ISU" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "delivery"
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"ITf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"ITq" = (
+/obj/structure/closet/secure_closet/medical3,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"ITK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "GeneticsDoor";
+	name = "Genetics";
+	req_access_txt = "6"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
+"IVV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"IWp" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/break_room)
+"JaY" = (
+/obj/machinery/computer/card/minor/hos,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/requests_console{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"JbD" = (
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	stack_amt = 10
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"Jds" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	icon_state = "direction_evac";
+	pixel_x = 32;
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"JdP" = (
+/obj/structure/closet/bombcloset,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"JfN" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"JkO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	sortType = 13
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"JlJ" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"Jmd" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "34"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
+"JqC" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_one_access_txt = "19;29"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"JrE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"Jtg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"Jva" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/bar)
+"JwC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"JwF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"Jxr" = (
+/obj/machinery/computer/monitor{
+	name = "primary power monitoring console"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"JyU" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plating/warnplate{
+	dir = 4
+	},
+/area/shuttle/ftl/maintenance/disposal)
+"JAF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"JAL" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	tag = "icon-pump_map (EAST)";
+	icon_state = "pump_map";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"JBF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	sortType = 11
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"JGZ" = (
+/obj/machinery/telecomms/relay/portable/preset,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/bridge/eva)
+"JIw" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/syringes,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"JIU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"JJh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/chiefs_office)
+"JOv" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/weapon/book/manual/ftl_wiki/supermatter,
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"JOB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/status_display,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"JOJ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"JPd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm5";
+	name = "Dormitory"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"JPm" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
+"JPN" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"JRp" = (
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/stamp/hop,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"JRS" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 8;
+	filter_type = "co2";
+	icon_state = "filter_off";
+	on = 1;
+	tag = "icon-filter_off (WEST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"JRT" = (
+/obj/machinery/mac_barrel{
+	dir = 4;
+	id = "weapon_k_1"
+	},
+/turf/open/floor/plating/warnplate/side{
+	tag = "icon-plating_warn_side (EAST)";
+	icon_state = "plating_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"JUj" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"JUH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"JVY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"JWB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"JXB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"JYK" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/kitchen/rollingpin,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"KcV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L4"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"Kdk" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"Kdw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "MedbayFoyer";
+	name = "Medbay Doors";
+	normaldoorcontrol = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"Kfi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/warnwhite,
+/area/shuttle/ftl/assembly/robotics)
+"KgE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/bar)
+"KgN" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/medbay)
+"Kib" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"KjZ" = (
+/obj/machinery/door/window/southleft{
+	name = "Research and Development";
+	req_access_txt = "26"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"Kky" = (
+/turf/open/space,
+/area/space)
+"KmK" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/door/airlock/command{
+	emergency = 0;
+	name = "Munitions Access";
+	req_access_txt = "35"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"KmZ" = (
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"Knk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/turret_protected/ai)
+"Kos" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/weapon/storage/belt/utility,
+/obj/item/device/t_scanner{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/t_scanner{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/t_scanner{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Ksg" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"KsF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engineering)
+"KuF" = (
+/turf/closed/wall,
+/area/space)
+"KvI" = (
+/obj/effect/landmark/start{
+	name = "Scientist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"Kyy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm5";
+	name = "Dormitory"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"KyF" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"KAj" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access = null;
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"KAu" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/bar)
+"KAG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/hor)
+"KCY" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"KDH" = (
+/obj/machinery/door/airlock/command{
+	name = "Munitions Access";
+	req_access_txt = "35"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"KEw" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"KFz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"KGt" = (
+/obj/machinery/button/door{
+	id = "briggate";
+	name = "Desk Shutters";
+	pixel_x = -26;
+	pixel_y = 6;
+	req_access_txt = "1"
+	},
+/obj/machinery/button/flasher{
+	id = "brigentry";
+	pixel_x = -38;
+	pixel_y = -6;
+	req_access_txt = "1"
+	},
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_x = -26;
+	pixel_y = -6;
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"KJj" = (
+/obj/structure/sign/biohazard,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
+"KJo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"KJT" = (
+/obj/structure/table,
+/obj/item/device/multitool{
+	pixel_x = 7
+	},
+/obj/item/device/radio/off{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Control Room"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"KMG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"KNz" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"KNI" = (
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Captains Chair Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"KOB" = (
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 5";
+	dir = 2
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/escape/corner{
+	tag = "icon-escapecorner (EAST)";
+	icon_state = "escapecorner";
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"KTq" = (
+/obj/item/weapon/card/id/captains_spare,
+/obj/structure/table/wood,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/stamp/captain,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"KUx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L11"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"KWe" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"KWI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"KYC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/chemistry)
+"Lbz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTHWEST)";
+	icon_state = "plasteel_warn";
+	dir = 9
+	},
+/area/shuttle/ftl/munitions)
+"Len" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"Lfx" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mailSort";
+	tag = "munitions west"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"LgD" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"Lhu" = (
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"LiV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Ljv" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"LjX" = (
+/obj/structure/spacepoddoor{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/cargo/mining)
+"Lke" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"Lmw" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access = null;
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/captain)
+"Lnv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/sortjunction{
+	sortType = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"LnI" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/virology)
+"LoK" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"Lpy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"Lpz" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"LpT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"LqC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"LqQ" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/virology)
+"LrP" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"Lun" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	dir = 2;
+	id = "mechbay";
+	name = "Shutters Control Button";
+	pixel_x = 6;
+	pixel_y = 24;
+	req_access_txt = "18"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
+"Lwd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"LwW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"Lxc" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"Lzs" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/arrival{
+	tag = "icon-arrival (NORTH)";
+	icon_state = "arrival";
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"LzT" = (
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"LAt" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
+"LBA" = (
+/obj/machinery/button/door{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	pixel_x = 25;
+	pixel_y = 4;
+	req_access_txt = "40"
+	},
+/obj/machinery/button/massdriver{
+	id = "trash";
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"LBD" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHWEST)";
+	icon_state = "whiteblue";
+	dir = 9
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"LBJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"LCi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"LCv" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"LDp" = (
+/obj/structure/table/glass,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"LDq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/lab)
+"LDH" = (
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"LHf" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_y = -32
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	layer = 2.9;
+	name = "Privacy Shutters"
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/heads)
+"LHD" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "CargoMunitions";
+	tag = "CargoMunitions"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/door/window/northright,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"LID" = (
+/obj/machinery/door/airlock/glass{
+	moving_diagonally = 0;
+	name = "Tool Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"LIS" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "garbage";
+	verted = -1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"LJU" = (
+/obj/structure/sign/securearea{
+	pixel_x = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/server)
+"LLY" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"LNf" = (
+/obj/machinery/button/door{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 0;
+	pixel_y = 28;
+	req_access_txt = "20"
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"LNI" = (
+/obj/machinery/computer/prisoner,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"LOW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"LQl" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/engine/engineering)
+"LUK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/office)
+"LVg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/wood,
+/obj/item/weapon/dice/d6,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"LVl" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start{
+	name = "Virologist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"LWb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/mob/living/simple_animal/bot/secbot/beepsky{
+	name = "Officer Beepsky"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"LWv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L7"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"LWW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"LYf" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"Mbv" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"Mdv" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"Mfg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/warning/corner{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/storage)
+"MhX" = (
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engine_smes)
+"Mii" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"MiH" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Head of Security's Office";
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"Mjw" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"Mko" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"Mky" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 9
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"Mlz" = (
+/obj/structure/table/glass,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/stock_parts/scanning_module,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"MlW" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"MoM" = (
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"Msa" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Msv" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"MsS" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/britcup{
+	desc = "Kingston's personal cup."
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"Mta" = (
+/obj/machinery/cryopod/right,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 4
+	},
+/area/shuttle/ftl/crew_quarters/sleep)
+"Mxo" = (
+/obj/machinery/smartfridge/extract,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"MyF" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"MzZ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Gravity Generator";
+	req_access_txt = "34";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
+"MCS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"MDH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/janitor)
+"MHx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"MJv" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHWEST)";
+	icon_state = "whiteblue";
+	dir = 9
+	},
+/area/shuttle/ftl/medical/medbay)
+"MJP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay_lobby)
+"MKf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"MKx" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"MKz" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start{
+	name = "Research Director";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/computer/card/minor/rd,
+/obj/machinery/computer/card/minor/rd,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"MKU" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"MNx" = (
+/turf/open/floor/plasteel/stairs,
+/area/shuttle/ftl/cargo/mining)
+"MNB" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"MQH" = (
+/obj/machinery/computer/card/minor/ce,
+/obj/machinery/camera{
+	c_tag = "Chief Engineer's Office";
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"MRa" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/surgery)
+"MRO" = (
+/turf/open/floor/plating/warnplate/side{
+	tag = "icon-plating_warn_side (EAST)";
+	icon_state = "plating_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"MTL" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/armory)
+"MWZ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	name = "Robotics Desk";
+	req_access_txt = "18"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/weapon/pen,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics";
+	name = "Robotics Desk"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"MYh" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"MYw" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"Naw" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/bar)
+"Nby" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/munitions)
+"NdA" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"NhK" = (
+/obj/machinery/door/window/southleft{
+	name = "Medical Reception";
+	req_access_txt = "5"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"NhU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/loadingarea{
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/central)
+"NiN" = (
+/obj/machinery/monkey_recycler,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"Njc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"NjF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTHWEST)";
+	icon_state = "plasteel_warn";
+	dir = 9
+	},
+/area/shuttle/ftl/cargo/office)
+"NjO" = (
+/obj/structure/closet/wardrobe/robotics_black,
+/obj/machinery/camera{
+	c_tag = "Robotics West";
+	dir = 2;
+	network = list("SS13","RD")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"NlQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"NmY" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northright{
+	name = "Server Room";
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Server Walkway";
+	initial_gas_mix = "n2=500;TEMP=80"
+	},
+/area/shuttle/ftl/research/server)
+"NoR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"NpH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"Nqs" = (
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"NqJ" = (
+/obj/machinery/button/flasher{
+	id = "hopflash";
+	pixel_x = 6;
+	pixel_y = 36;
+	req_access_txt = "30"
+	},
+/obj/machinery/button/door{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "30"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -4;
+	pixel_y = 36
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Head of Personnel";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"NsG" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/chemistry)
+"NuR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L2"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"Nwc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge)
+"Nwt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"Nyh" = (
+/obj/machinery/camera{
+	c_tag = "Research Access";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (NORTHEAST)";
+	icon_state = "white_warn";
+	dir = 5
+	},
+/area/shuttle/ftl/research/lab)
+"Nzv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/hos)
+"NDY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate,
+/obj/item/weapon/coin/silver{
+	pixel_x = -4;
+	pixel_y = -4;
+	pixel_z = 0
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = 4
+	},
+/obj/item/weapon/coin/silver,
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/belt/champion,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"NFA" = (
+/obj/machinery/porta_turret/ai{
+	dir = 8
+	},
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber South";
+	dir = 8;
+	network = list("SS13","MiniSat");
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"NGa" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/masks{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"NGr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"NJi" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics East";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/suit_storage_unit/atmos,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"NKg" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/obj/item/stack/cable_coil,
+/obj/item/weapon/electronics/airlock,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"NKC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "0";
+	req_one_access_txt = "7;15"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"NKS" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/xenobiology)
+"NLx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"NMO" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
+"NNb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"NOj" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"NOS" = (
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
+"NPj" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start{
+	name = "Head of Security"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"NPv" = (
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-black_warn_corner (NORTH)";
+	icon_state = "black_warn_corner";
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engineering)
+"NPU" = (
+/turf/open/floor/plasteel/white,
+/area/shuttle/ftl/security/main)
+"NQF" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10;
+	initialize_directions = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"NRo" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/landmark/event_spawn,
+/mob/living/simple_animal/slime,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"NRU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Cargo Bay";
+	req_access_txt = "0";
+	req_one_access_txt = "20;27"
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/cargo/office)
+"NVg" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"NWj" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"NYn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"NZG" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/book/bible,
+/obj/machinery/flasher{
+	id = "Holding_Pen";
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"NZO" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "air_in"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/shuttle/ftl/atmos)
+"OcT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"Ods" = (
+/obj/machinery/door/airlock/external{
+	name = "EVA airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge/eva)
+"Oes" = (
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/machinery/computer/camera_advanced/xenobio,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
+"Ogq" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"OgC" = (
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/storage)
+"Ohe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whiteblue/corner,
+/area/shuttle/ftl/medical/medbay)
+"OhQ" = (
+/obj/structure/table,
+/obj/item/weapon/book/manual/hydroponics_pod_people,
+/turf/open/floor/plasteel/green/side{
+	tag = "icon-green (NORTHEAST)";
+	icon_state = "green";
+	dir = 5
+	},
+/area/shuttle/ftl/hydroponics)
+"OhR" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
+"OkH" = (
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Storage";
+	dir = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHEAST)";
+	icon_state = "whiteblue";
+	dir = 5
+	},
+/area/shuttle/ftl/medical/medbay)
+"OkM" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/camera{
+	c_tag = "Kitchen";
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"OlV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warnwhite,
+/area/shuttle/ftl/research/lab)
+"Ome" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Omk" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
+"OmM" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Onw" = (
+/obj/machinery/door/window/southleft{
+	name = "Cockpit";
+	req_access_txt = "42"
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"OnF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/office)
+"OnM" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"OoQ" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms";
+	req_access_txt = "0"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"OoS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Opn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"Oqn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions)
+"Oqr" = (
+/obj/machinery/conveyor{
+	dir = 6;
+	id = "munitions";
+	tag = "munitions sw"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"OtE" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"Ovg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor{
+	id = "Supermatter doors"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engine_smes)
+"OvE" = (
+/turf/open/floor/plasteel/warning/corner,
+/area/shuttle/ftl/bridge/eva)
+"OxN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Janitor's Closet";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"ODE" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/captain)
+"OEe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay)
+"OER" = (
+/obj/machinery/gibber,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"OHS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault,
+/area/shuttle/ftl/security/nuke_storage)
+"OIp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L8"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"OKd" = (
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"OKo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"OKM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
+"OLp" = (
+/obj/machinery/vending/security,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"OLV" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"OMM" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/blood/AMinus,
+/obj/item/weapon/reagent_containers/blood/BMinus{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/blood/BPlus{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OPlus{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"OOl" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"OOV" = (
+/turf/open/floor/plasteel/arrival/corner{
+	tag = "icon-arrivalcorner (EAST)";
+	icon_state = "arrivalcorner";
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"OUZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"OVK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"OXp" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "7;9"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/cannon)
+"OYV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/cargo)
+"Pal" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"Par" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"PaT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"PbR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"Pcf" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/break_room)
+"Pdm" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/green/side,
+/area/shuttle/ftl/hydroponics)
+"Pge" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Bay"
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
+"Plh" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/ftl/subshuttle/pod_3)
+"Ppu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"Prr" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Bar"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"PsY" = (
+/obj/machinery/conveyor{
+	id = "QMLoad";
+	tag = "munitions south"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"Ptu" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"PtL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"PtQ" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/drone,
+/obj/item/weapon/storage/toolbox/drone,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"PuJ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
+/area/shuttle/ftl/hydroponics)
+"PuZ" = (
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 3";
+	name = "Cell 3";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Pvg" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/armory)
+"PvD" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engine_smes)
+"Pwx" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"Pxk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"Pxz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"PyT" = (
+/mob/living/carbon/monkey/punpun,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"PyY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"Pzj" = (
+/obj/machinery/conveyor_switch{
+	id = "munitions"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/munitions)
+"PAU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warnwhite,
+/area/shuttle/ftl/medical/virology)
+"PCC" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (SOUTHWEST)";
+	icon_state = "white_warn";
+	dir = 10
+	},
+/area/shuttle/ftl/research/lab)
+"PDg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/cannon)
+"PDA" = (
+/obj/machinery/door/airlock/glass_command{
+	name = "Head of Security";
+	req_access_txt = "31"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/hos)
+"PDK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"PEd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/chemistry)
+"PEg" = (
+/obj/machinery/camera{
+	c_tag = "Gravity Generator";
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engineering)
+"PGY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"PHS" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/fancy/donut_box,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/bridge/meeting_room)
+"PIX" = (
+/obj/effect/landmark/start{
+	name = "Station Engineer";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"PJZ" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/cmo)
+"PKf" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "7;9"
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/cannon)
+"PKW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"PNa" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"PNM" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"PNU" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"POg" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/security,
+/obj/item/weapon/circuitboard/computer/secure_data{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/computer/arcade/battle{
+	permeability_coefficient = 1;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/mining,
+/obj/item/weapon/circuitboard/machine/autolathe{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"PQN" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id = "Holding_Pen";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"PSp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"PSO" = (
+/turf/open/floor/plasteel/darkwarning{
+	tag = "icon-black_warn (NORTH)";
+	icon_state = "black_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"PTO" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 4
+	},
+/area/shuttle/ftl/bridge)
+"PUC" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "o2_in"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/shuttle/ftl/atmos)
+"PVq" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"PWG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
+"PYD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
+"PZL" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"PZZ" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/brig)
+"Qah" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"QaT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"Qdg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "tox_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/plasma,
+/area/shuttle/ftl/atmos)
+"Qfc" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Geneticist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/genetics)
+"Qgr" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	icon_state = "rightsecure";
+	id = "Holding_pen";
+	name = "Holding Pen";
+	req_access_txt = "2";
+	tag = "icon-rightsecure (NORTH)"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Qis" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"QjT" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"Qoi" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/loading)
+"Qop" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/obj/machinery/r_n_d/circuit_imprinter,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"QoV" = (
+/obj/structure/closet/jcloset,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"QpJ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"QpL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "15"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Qre" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/hor)
+"QrW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Qsq" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"QsI" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	tag = "icon-manifold (EAST)";
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"QtG" = (
+/obj/machinery/camera{
+	c_tag = "Mining Equipment";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
+"QuA" = (
+/obj/machinery/atmospherics/components/trinary/filter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"Qwd" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"QxK" = (
+/obj/machinery/atmospherics/components/binary/circulator{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"Qyh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"QCq" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/turf/open/floor/plating/warnplate{
+	dir = 4
+	},
+/area/shuttle/ftl/maintenance/disposal)
+"QCu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/shuttle/ftl/bridge)
+"QEp" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"QHw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Security Office West";
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"QHF" = (
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = -30
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"QKR" = (
+/obj/machinery/r_n_d/server/robotics,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/floor/bluegrid{
+	name = "Server Base";
+	initial_gas_mix = "n2=500;TEMP=80"
+	},
+/area/shuttle/ftl/research/server)
+"QKY" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/shuttle/ftl/space)
+"QNE" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/medbay)
+"QPF" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"QRs" = (
+/obj/effect/landmark/latejoin,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/arrival,
+/area/shuttle/ftl/hallway/primary/port)
+"QRu" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"QSR" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"QVV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"QXd" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge/eva)
+"QYB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/mecha_part_fabricator,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"RaB" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
+"Rcd" = (
+/obj/machinery/plantgenes,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/shuttle/ftl/hydroponics)
+"Rct" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	filter_type = "n2";
+	on = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"RdD" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "27"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"Rez" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8;
+	initialize_directions = 11
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"ReI" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel/shuttle/red,
+/area/shuttle/ftl/subshuttle/pod_3)
+"Rge" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Rgr" = (
+/turf/open/floor/plasteel/green/side,
+/area/shuttle/ftl/hydroponics)
+"RgP" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
+"RhE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"RiJ" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -28;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"Rkv" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"RmO" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"Rom" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning/corner{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"RoS" = (
+/turf/open/floor/plasteel/warning{
+	dir = 9
+	},
+/area/shuttle/ftl/cargo/mining)
+"Rpc" = (
+/obj/machinery/computer/scan_consolenew,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHWEST)";
+	icon_state = "whiteblue";
+	dir = 9
+	},
+/area/shuttle/ftl/medical/genetics)
+"Rqm" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"Rqt" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion";
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/ftl/engine/engine_smes)
+"Rrx" = (
+/obj/structure/closet/crate/medical,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/cargo/office)
+"RrB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/captain)
+"Rtd" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
+"RtE" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engine South";
+	dir = 1;
+	network = list("SS13","Supermatter")
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"RtQ" = (
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	network = list("SS13","RD")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"Rui" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = 0;
+	name = "Medbay";
+	req_access_txt = "21"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/chemistry)
+"RuS" = (
+/obj/machinery/computer/security,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"RvY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/shuttle/ftl/engine/engine_smes)
+"RwE" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"RxZ" = (
+/obj/machinery/computer/ftl_weapons{
+	req_access_txt = "45"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"RyM" = (
+/obj/machinery/power/generator{
+	cold_dir = 4;
+	hot_dir = 8
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"Rzi" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"RBX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 22
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"RCk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_access_txt = "0";
+	req_one_access_txt = "12;35"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"REb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L11"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"REL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/nuke_storage)
+"REW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"RFL" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/warning,
+/area/shuttle/ftl/cargo/storage)
+"RGl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"RLN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"RMv" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/assembly/robotics)
+"RPA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge/eva)
+"RTo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_access_txt = "42"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"RWM" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHWEST)";
+	icon_state = "whiteblue";
+	dir = 10
+	},
+/area/shuttle/ftl/medical/chemistry)
+"RXj" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"RXn" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"RZg" = (
+/obj/item/device/aicard,
+/obj/item/weapon/aiModule/reset{
+	pixel_y = 2
+	},
+/obj/structure/table,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/machinery/cell_charger,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/device/assembly/flash{
+	pixel_x = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"SaO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"Sbm" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
+"ScX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "hydrofloor"
+	},
+/area/shuttle/ftl/hydroponics)
+"Sdw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
+"SdM" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/chiefs_office)
+"Sel" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Disposal Exit";
+	layer = 3;
+	name = "disposal exit vent"
+	},
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "garbage";
+	tag = "munitions ne";
+	verted = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"SgU" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge/meeting_room)
+"Shu" = (
+/obj/structure/closet/emcloset,
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"Sln" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"Slq" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/lighter,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"SmE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"SmV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10;
+	initialize_directions = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"SmX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/ftl/turret_protected/ai)
+"Sod" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/munitions/office)
+"Sok" = (
+/obj/structure/table,
+/obj/item/weapon/folder/red{
+	pixel_x = 3
+	},
+/obj/item/device/taperecorder{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/device/assembly/flash/handheld,
+/obj/item/weapon/reagent_containers/spray/pepper,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"SoC" = (
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"SqJ" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"Sru" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"SsW" = (
+/turf/open/floor/plasteel/darkwarning{
+	tag = "icon-black_warn (WEST)";
+	icon_state = "black_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/engine/engineering)
+"Stf" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
+"SuQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "Chief Medical Officer";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/cmo)
+"SxW" = (
+/obj/machinery/conveyor{
+	id = "CargoMunitions";
+	tag = "CargoMunitions"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/office)
+"Syi" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"SAW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/assembly/robotics)
+"SEL" = (
+/obj/structure/closet/firecloset/full,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"SHq" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"SHr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"SHL" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"SJb" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/ftl/subshuttle/pod_3)
+"SJH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"SNf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "22"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"SNg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Captain's Bedroom"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
+"SNh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_x = 32;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"SOj" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/obj/structure/sign/securearea{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/bridge)
+"SOs" = (
+/obj/machinery/light,
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"SRq" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/bridge/eva)
+"SRF" = (
+/obj/structure/plasticflaps,
+/obj/structure/window/reinforced,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mailSort";
+	tag = "munitions west"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"SSW" = (
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/shuttle/ftl/security/armory)
+"STo" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"SUD" = (
+/obj/structure/sign/biohazard,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/cmo)
+"SVG" = (
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/device/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/machinery/requests_console{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/shuttle/ftl/medical/virology)
+"SWb" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF WEAPONS AREA'.";
+	layer = 2.9;
+	name = "KEEP CLEAR OF WEAPONS AREA";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions)
+"SZi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Tam" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"TaU" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
+	},
+/area/shuttle/ftl/atmos)
+"Tbn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/nuclearbomb/selfdestruct,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"TbI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"Teh" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"TeY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/medical/medbay)
+"Tfc" = (
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"Tgc" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "o2";
+	icon_state = "filter_off";
+	on = 1;
+	tag = "icon-filter_off (EAST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"TgU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/ore_box,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
+"TgV" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"ThN" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "0"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"Tiz" = (
+/obj/machinery/hologram/holopad,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge)
+"TnY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"ToC" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"Tpi" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/eastright,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/ftl/bridge/eva)
+"Tpn" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/bar)
+"Tqb" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/weapon/storage/belt/medical{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/weapon/gun/syringe,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHWEST)";
+	icon_state = "whiteblue";
+	dir = 10
+	},
+/area/shuttle/ftl/medical/medbay)
+"TqV" = (
+/obj/structure/closet/firecloset/full,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"TsQ" = (
+/obj/machinery/sleeper{
+	icon_state = "sleeper-open";
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"TuO" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHEAST)";
+	icon_state = "whiteblue";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"Txn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/vault{
+	icon_state = "closed";
+	locked = 1;
+	req_access_txt = "13"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"TAv" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	id = "munitions";
+	tag = "munitions south"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"TBW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/science{
+	name = "Research Division Access";
+	req_access_txt = "26"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"TCP" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"TDy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"TFG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/lab)
+"THW" = (
+/turf/closed/wall,
+/area/shuttle/ftl/munitions/office)
+"TJD" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"TPp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Surgery";
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"TQd" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"TQH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hydroponics)
+"TRO" = (
+/obj/structure/closet{
+	name = "Joyride Closet"
+	},
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"TTc" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"TTh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"TUT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"TUZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"TVq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/conveyor_switch{
+	id = "munitions";
+	pixel_x = -10
+	},
+/obj/machinery/conveyor_switch{
+	id = "munitions_loading";
+	pixel_x = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"TWo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"TXg" = (
+/turf/closed/wall,
+/area/shuttle/ftl/munitions)
+"TYu" = (
+/obj/machinery/computer/med_data,
+/obj/machinery/camera{
+	c_tag = "Chief Medical Officer's Office";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"TYS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"Ucg" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"Ueb" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"Uej" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge/meeting_room)
+"Uev" = (
+/obj/machinery/light,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"Ugc" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/shuttle/red,
+/area/shuttle/ftl/subshuttle/pod_3)
+"Ugd" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10;
+	initialize_directions = 10
+	},
+/turf/open/floor/plasteel/warning/corner{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"Uhi" = (
+/obj/machinery/computer/ftl_navigation{
+	req_access_txt = "46"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"UiW" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"UiY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"UkH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/storage)
+"Umb" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/science)
+"Unn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L12"
+	},
+/area/shuttle/ftl/bridge)
+"UpV" = (
+/obj/structure/grille,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"Ury" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"UrM" = (
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
+"Usl" = (
+/obj/vehicle/atv{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/bridge/eva)
+"Utw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Uua" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"Uux" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"UyK" = (
+/obj/structure/window/reinforced,
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "air_in";
+	name = "Mixed Air Supply Control";
+	output_tag = "air_out";
+	sensors = list("air_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/arrival,
+/area/shuttle/ftl/atmos)
+"UzV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"UAi" = (
+/obj/structure/table,
+/obj/item/weapon/retractor,
+/obj/item/weapon/surgicaldrill,
+/turf/open/floor/plasteel{
+	icon_state = "whitehall";
+	dir = 2
+	},
+/area/shuttle/ftl/medical/surgery)
+"UCZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
+"UES" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access_txt = "17"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"UEZ" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"UFa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"UHz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"UIs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"UIt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"UIM" = (
+/obj/machinery/cryopod/right,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 6
+	},
+/area/shuttle/ftl/crew_quarters/sleep)
+"UJr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"UJS" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/turretid{
+	name = "AI Chamber turret control";
+	pixel_x = 5;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"ULZ" = (
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"UME" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge/eva)
+"UOd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"UPm" = (
+/obj/machinery/computer/med_data,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"URL" = (
+/obj/machinery/computer/security,
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"URZ" = (
+/turf/open/floor/plasteel/darkwarning/corner,
+/area/shuttle/ftl/engine/engineering)
+"UTo" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/science{
+	name = "Research Division Access";
+	req_access_txt = "26"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"UUh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/genetics)
+"UUP" = (
+/obj/machinery/door/airlock/glass_large{
+	name = "EVA airlock";
+	req_access_txt = "42"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"UWx" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/packageWrap,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"UXb" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"UXj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"UXO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"UYl" = (
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/security/armory)
+"UZs" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "o2_sensor"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine/o2,
+/area/shuttle/ftl/atmos)
+"UZA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"VaN" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/manual/chef_recipes,
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"VaT" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
+"VbE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"Vde" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Munitions East";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"Vdy" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/brig)
+"VfE" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"VfF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"VfU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Vkq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Vml" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"Vmm" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"Vmo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/janitor)
+"VnM" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"Vto" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/armory)
+"Vtr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"Vuy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"Vve" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "Research Director";
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"VvI" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/communications{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/card,
+/obj/item/weapon/circuitboard/computer/crew{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"Vwg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/sign/securearea{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"VwL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/light_switch{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/telecomms/computer)
+"VwM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
+"Vxj" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
+"VxJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch{
+	id = "munitions_loading"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"VyX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"VzP" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"VBr" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"VBF" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/armory)
+"VCb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"VCy" = (
+/obj/machinery/door/window/southright{
+	name = "Research and Development";
+	req_access_txt = "26"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"VCA" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/manual/ftl_wiki/bo_guide,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"VDq" = (
+/obj/structure/closet/secure_closet/captains,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
+"VDA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/machinery/door/window/southleft{
+	
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"VEP" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/manual/barman_recipes,
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"VLJ" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "CargoMunitions";
+	tag = "CargoMunitions"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"VLK" = (
+/obj/machinery/pdapainter,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/machinery/requests_console{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"VNx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"VOi" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"VOt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"VTB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"VUo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"VUS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/mining)
+"VVU" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"VXS" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"VYp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
+"VZe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/hallway/primary/central)
+"VZR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/science{
+	name = "Research Division Access";
+	req_access_txt = "26"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"WcX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"WdZ" = (
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"Wel" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/surgery)
+"WfU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"Whr" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "munitions";
+	tag = "munitions west"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"Wip" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay)
+"WmR" = (
+/obj/machinery/cell_charger,
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/warning/corner{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/mining)
+"Woe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Woh" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/item/device/camera/detective,
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"Wol" = (
+/obj/structure/toilet{
+	pixel_y = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
+"Wpv" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/heads)
+"WpP" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/hos)
+"WqN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/chemistry)
+"WqO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
+"Wsk" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"Wsm" = (
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"WsH" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (WEST)";
+	icon_state = "plasteel_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/munitions)
+"Wuw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"Wuy" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	tag = "icon-pump_map (NORTH)";
+	icon_state = "pump_map";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"WuX" = (
+/obj/structure/table,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/device/multitool,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"WyF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/captain,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
+"WyW" = (
+/obj/structure/table,
+/obj/item/device/mmi,
+/obj/item/device/mmi,
+/obj/item/device/mmi,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"Wzi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"WBk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "delivery"
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"WBx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"WEf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"WFz" = (
+/obj/machinery/sleeper{
+	dir = 4;
+	icon_state = "sleeper-open"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHWEST)";
+	icon_state = "whiteblue";
+	dir = 10
+	},
+/area/shuttle/ftl/medical/medbay)
+"WIE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"WIL" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"WJq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10;
+	initialize_directions = 10
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"WOH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"WPu" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"WPz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"WQx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"WRx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	tag = "icon-outlet (NORTH)";
+	icon_state = "outlet";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"WTe" = (
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"WTD" = (
+/turf/open/floor/plasteel/warning/corner{
+	tag = "icon-plasteel_warn_corner (EAST)";
+	icon_state = "plasteel_warn_corner";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"WTG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"WUc" = (
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/crowbar,
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"WZg" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"WZC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"WZD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/loading)
+"Xco" = (
+/obj/machinery/computer/pandemic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"XgF" = (
+/obj/structure/table,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"Xhm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"XiN" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0;
+	layer = 2.9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (WEST)";
+	icon_state = "white_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/research/lab)
+"Xjg" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
+"XkS" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/scalpel{
+	pixel_y = 10
+	},
+/obj/item/weapon/circular_saw,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"Xmh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 9
+	},
+/area/shuttle/ftl/munitions)
+"Xmo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L3"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"Xpb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"Xqz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L4"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"Xrl" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/medbay)
+"Xsm" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "munitions";
+	tag = "munitions east"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"XsW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"Xtb" = (
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"XtS" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
+"XtV" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
+"Xub" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "atmos blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/atmos)
+"Xwg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Brig Cell 1";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"XwR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/bar)
+"Xye" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel{
+	icon_state = "L10"
+	},
+/area/shuttle/ftl/bridge)
+"XBo" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/munitions/cannon)
+"XDo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"XDv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/storage/tech)
+"XEW" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"XHb" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/ftl/subshuttle/pod_3)
+"XHC" = (
+/obj/item/clothing/gloves/color/latex,
+/obj/structure/table,
+/obj/item/weapon/surgical_drapes,
+/obj/item/weapon/razor,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"XJo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"XLd" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"XLe" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/turret_protected/ai)
+"XMe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/medbay)
+"XNB" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/telecomms/computer)
+"XOi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"XOB" = (
+/obj/machinery/light{
+	dir = 2;
+	icon_state = "tube1"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j2s";
+	sortType = 14
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"XOX" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/projectile/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/projectile/shotgun/riot,
+/obj/item/weapon/gun/projectile/shotgun/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"XQs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
+"XSp" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"XWL" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning{
+	dir = 5
+	},
+/area/shuttle/ftl/atmos)
+"YaA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge)
+"YaV" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"YbP" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"YiH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warnwhite,
+/area/shuttle/ftl/assembly/robotics)
+"YjW" = (
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"Ylj" = (
+/obj/structure/window/reinforced,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/medical/genetics)
+"Ylu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"YmT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"Ynq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"Yoc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"YoA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = -10
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"YpK" = (
+/obj/machinery/suit_storage_unit/hos,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"Ysw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/hallway/primary/central)
+"Yty" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 10;
+	pixel_y = 34
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"Yuf" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"YwP" = (
+/obj/machinery/camera{
+	c_tag = "External EVA Access";
+	dir = 4
+	},
+/turf/open/space,
+/area/shuttle/ftl/space)
+"YyT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"Yza" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/mining)
+"Yzp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"YAp" = (
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"YAM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L14"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"YBU" = (
+/obj/structure/table/glass,
+/obj/item/weapon/book/manual/wiki/infections{
+	pixel_y = 7
+	},
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/storage/box/monkeycubes{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/shuttle/ftl/medical/virology)
+"YDs" = (
+/obj/structure/sign/securearea,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
+"YEC" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"YFi" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"YIn" = (
+/turf/open/floor/plasteel/warnwhite,
+/area/shuttle/ftl/assembly/robotics)
+"YIx" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/button/door{
+	dir = 2;
+	id = "robotics";
+	name = "Shutters Control Button";
+	pixel_x = -24;
+	pixel_y = 6;
+	req_access_txt = "18"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
+"YIH" = (
+/obj/effect/landmark/start{
+	name = "Botanist";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"YJq" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"YJx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"YJU" = (
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"YNf" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	name = "Research Director RC";
+	pixel_x = -2;
+	pixel_y = 30
+	},
+/obj/machinery/suit_storage_unit/rd,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"YNO" = (
+/obj/structure/table,
+/obj/item/weapon/book/manual/ftl_wiki/munitions_manual,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
+"YNY" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"YOV" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay)
+"YPi" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/mob/living/simple_animal/hostile/lizard{
+	desc = "That's Faster-Than-Lizard (13). The Shuttle's lovable Mascot. Eats those pesky cockroaches, too. Bonus!";
+	name = "Faster-Than-Lizard"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"YRv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L10"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"YRP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
+"YRZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L11"
+	},
+/area/shuttle/ftl/bridge)
+"YSj" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"YSZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"YUs" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap,
+/obj/item/ammo_box/magazine/wt550m9/wtap,
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap,
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"YVv" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"YXj" = (
+/obj/machinery/door/poddoor{
+	id = "supermatter_eject"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engine_smes)
+"YYI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/main)
+"YZh" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 6
+	},
+/area/shuttle/ftl/research/lab)
+"Zao" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"Zby" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/shuttle/ftl/space)
+"ZgC" = (
+/obj/machinery/computer/upload/ai,
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"Zhq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"ZiO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"ZkE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
+"ZlU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"Zng" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"Zns" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"Zrg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"ZrC" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "n2_sensor"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine/n2,
+/area/shuttle/ftl/atmos)
+"ZsD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/meeting_room)
+"ZvL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/virology)
+"Zxo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"Zyj" = (
+/obj/structure/closet/wardrobe/botanist,
+/turf/open/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
+/area/shuttle/ftl/hydroponics)
+"ZBD" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/bar)
+"ZCL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"ZCP" = (
+/obj/structure/filingcabinet,
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"ZDE" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"ZDP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"ZEk" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/green/side{
+	dir = 1
+	},
+/area/shuttle/ftl/hydroponics)
+"ZEy" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/shuttle/ftl/atmos)
+"ZFw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/office)
+"ZFx" = (
+/obj/machinery/conveyor{
+	id = "QMLoad";
+	tag = "munitions south"
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"ZGK" = (
+/obj/machinery/door/airlock/external{
+	id_tag = null;
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"ZJS" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
+"ZNE" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/energy/gun/advtaser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/energy/gun/advtaser,
+/obj/item/weapon/gun/energy/gun/advtaser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera/motion{
+	c_tag = "Armory";
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"ZOZ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"ZSA" = (
+/obj/machinery/light_switch{
+	pixel_x = -28;
+	pixel_y = 36
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/server)
+"ZSS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"ZTD" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposal Access";
+	req_access_txt = "40"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"ZUA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"ZVh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
+"ZVC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/shuttle/ftl/security/detectives_office)
+"ZWB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Munitions West";
+	dir = 1;
+	pixel_x = 15
+	},
+/obj/structure/window/reinforced/crosswired{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
+"ZWU" = (
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/disposal)
+"ZXW" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"ZZD" = (
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
+"ZZU" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+
+(1,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(2,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(3,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(4,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(5,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(6,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(7,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(8,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(9,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(10,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(11,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(12,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(13,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(14,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(15,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(16,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(17,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(18,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(19,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(20,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(21,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(22,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(23,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(24,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(25,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(26,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(27,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(28,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(29,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(30,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(31,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(32,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(33,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(34,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(35,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(36,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(37,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(38,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(39,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(40,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(41,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(42,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(43,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(44,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(45,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(46,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(47,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(48,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(49,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(50,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(51,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(52,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(53,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(54,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(55,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(56,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(57,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(58,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(59,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(60,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(61,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(62,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(63,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(64,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(65,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(66,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(67,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(68,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(69,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(70,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(71,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(72,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(73,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(74,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(75,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(76,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(77,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+LnI
+QKY
+toK
+toK
+Rqt
+Rqt
+Rqt
+Rqt
+Rqt
+Rqt
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Rqt
+Rqt
+Rqt
+Rqt
+Rqt
+Rqt
+toK
+toK
+QKY
+aIg
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(78,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Wel
+Wel
+MRa
+MRa
+Wel
+PJZ
+quh
+quh
+quh
+PJZ
+skU
+skU
+LqQ
+ZvL
+skU
+LqQ
+LqQ
+mpz
+mpz
+mpz
+mpz
+mpz
+mpz
+eLy
+eLy
+eLy
+eLy
+eLy
+YXj
+eLy
+eLy
+eLy
+eLy
+eLy
+mpz
+mpz
+mpz
+mpz
+mpz
+mpz
+RaB
+RaB
+gvy
+INT
+RaB
+Buo
+EwJ
+NKS
+EwJ
+mUf
+Yuf
+YaV
+EwJ
+mUf
+Yuf
+YaV
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(79,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Wel
+OMM
+sqF
+UAi
+Cgl
+quh
+ziR
+etd
+TYu
+PJZ
+VfE
+YjW
+fZN
+Xhm
+YjW
+Rkv
+LqQ
+eLy
+eLy
+eLy
+eLy
+eLy
+eLy
+oul
+Ucg
+Ccb
+vgB
+BuO
+MhX
+frO
+Ovg
+OnM
+WBk
+oul
+oul
+tTr
+Xub
+wRW
+VBr
+VBr
+cFF
+lvM
+cPV
+ggB
+HEF
+Geq
+Cjn
+Eyi
+wrr
+KWe
+wLI
+pWc
+EwJ
+KWe
+wLI
+pWc
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(80,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Wel
+TYS
+vLg
+Wsm
+wPt
+quh
+czY
+rNr
+mrp
+PJZ
+ghv
+XgF
+skU
+Xhm
+YjW
+eDI
+LqQ
+eBr
+zcq
+zcq
+zcq
+zcq
+tjj
+blk
+Ucg
+Ccb
+vgB
+FRh
+pSN
+PSO
+Ovg
+tyB
+iER
+oul
+CBE
+kOO
+cTC
+pyf
+cQD
+cQD
+xzH
+nHm
+mQB
+Omk
+RaB
+RaB
+Djz
+gHC
+EwJ
+LqC
+scZ
+pWc
+EwJ
+LqC
+scZ
+pWc
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(81,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Wel
+Axg
+XtV
+ELO
+qyN
+quh
+pxE
+rPO
+qMK
+PJZ
+LqQ
+LqQ
+LqQ
+qCD
+lkk
+rhx
+LqQ
+qSx
+RvY
+RvY
+RvY
+RvY
+qlh
+RmO
+rvi
+exf
+pmQ
+cQY
+qxC
+hyN
+hIe
+Rqm
+QuA
+Glg
+MyF
+kOO
+ELn
+uCT
+iFp
+NOj
+vsF
+vFk
+hAZ
+ZEy
+oFI
+RaB
+TTh
+iiW
+EwJ
+Zxo
+wLI
+pWc
+EwJ
+Zxo
+wLI
+pWc
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(82,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Wel
+TPp
+tBU
+MRa
+MRa
+EZv
+quh
+SuQ
+qfz
+SUD
+HYx
+qgD
+LqQ
+UJr
+Nwt
+dhI
+LqQ
+zxw
+RvY
+RvY
+RvY
+RvY
+qbq
+NQF
+xJQ
+fZp
+eLy
+hju
+sCa
+hju
+eLy
+GiS
+QxK
+iiy
+egr
+kOO
+rLu
+bUD
+gDa
+JfN
+tUq
+Rct
+suM
+qHK
+ZrC
+RaB
+TTh
+tgZ
+EwJ
+dPP
+fZv
+jIS
+VaT
+dPP
+exb
+jIS
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(83,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+gPR
+KEw
+WqO
+WcX
+mYh
+WcX
+rfQ
+GhC
+uNe
+DPP
+PAU
+ybB
+xEA
+LVl
+SVG
+LqQ
+lfy
+hgj
+hgj
+hgj
+hgj
+Ijj
+blk
+EPS
+Rom
+jIe
+ynA
+vxg
+Aks
+nck
+Ueb
+RyM
+Avj
+koK
+kOO
+mkJ
+rQv
+wzt
+OmM
+iTS
+xwa
+hAP
+cCb
+bcM
+RaB
+TTh
+gHC
+KJj
+Sbm
+tix
+fRv
+Oes
+Sbm
+tix
+fRv
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(84,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+njk
+Ohe
+Wip
+Crw
+Crw
+OEe
+nuF
+zDE
+iWl
+eUm
+cXf
+iWl
+iZO
+Xco
+YBU
+LqQ
+dFD
+dnx
+zsz
+ftW
+vFZ
+SdM
+dSy
+pwm
+qVm
+qVm
+whm
+oHQ
+yZe
+kNj
+fCe
+zfq
+brI
+RtE
+kOO
+Qdg
+glH
+iFp
+Xtb
+Aec
+LiV
+Tgc
+ggk
+PUC
+RaB
+iKj
+Rtd
+BSd
+GjT
+bkD
+bwq
+Gdo
+nEX
+eJj
+Xpb
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(85,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+WQx
+RXj
+BHM
+UUh
+UUh
+BHM
+ITK
+BHM
+LqQ
+LqQ
+LqQ
+LqQ
+LqQ
+LqQ
+LqQ
+LqQ
+IDF
+ziY
+cXn
+ziY
+MQH
+SdM
+WJq
+zaO
+zaO
+PVq
+Ugd
+uPL
+nrI
+urw
+sjq
+hzx
+ASK
+sdg
+kOO
+nLu
+xhc
+gDa
+Igh
+Aec
+IDC
+gDa
+puE
+UZs
+RaB
+HhE
+gHC
+chy
+gkL
+NiN
+Mxo
+mOV
+ith
+JIw
+BbM
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(86,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+Eyb
+gUo
+UUh
+Rpc
+wwl
+FrL
+HYj
+yyV
+BHM
+Qwd
+plV
+plV
+plV
+plV
+plV
+cRZ
+Col
+enU
+Opn
+ETj
+AlR
+SdM
+Mky
+JOv
+jnb
+SmV
+yiR
+Dhe
+Pal
+sqU
+QEp
+DJt
+diP
+Ajb
+kOO
+pdL
+XWL
+dko
+OmM
+hYD
+Ais
+hAP
+hLG
+aFw
+RaB
+xnE
+Qre
+yyc
+gkC
+fqg
+UCZ
+VZR
+EwJ
+EwJ
+EwJ
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(87,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+WQx
+fWa
+iyC
+Qfc
+bbc
+aCj
+NMO
+vJk
+idm
+oXs
+IWp
+IWp
+IWp
+IWp
+IWp
+IWp
+Lhu
+zFd
+QaT
+zbL
+HOI
+SdM
+Ixf
+Jxr
+Hfw
+Hfl
+HAh
+egL
+PIX
+pxb
+aTI
+ISU
+tUk
+tUk
+kOO
+BsK
+zIu
+iFp
+NOj
+BQC
+gdu
+bWC
+wpB
+NZO
+RaB
+xnE
+xzn
+cPx
+dzf
+Vve
+FHA
+fUN
+uNy
+QHF
+eJe
+wrr
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(88,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+pLz
+XMe
+lKe
+IiY
+qvI
+sde
+tXV
+pdD
+BHM
+fqS
+IWp
+yQm
+ggE
+ygk
+DvP
+IWp
+JJh
+JJh
+BOB
+JJh
+ahK
+SdM
+eLy
+eLy
+eLy
+eLy
+prz
+nHx
+PvD
+FDK
+FDK
+FDK
+FDK
+FDK
+kOO
+rIA
+eoB
+gDa
+OmM
+vFk
+hAZ
+dnQ
+UyK
+cqd
+RaB
+xnE
+YNf
+RtQ
+MKz
+phh
+faT
+fZa
+VDA
+SaO
+wLI
+wrr
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(89,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+WQx
+fcA
+BHM
+aBO
+Ylj
+ikz
+jsi
+gMC
+BHM
+fqS
+IWp
+rLI
+xhK
+HIo
+nFe
+sny
+sfA
+wdp
+FOa
+sfA
+Hbq
+Pwx
+rir
+sfA
+PKW
+aRz
+WIL
+PtL
+Hbq
+BOH
+UHz
+UHz
+yxE
+UHz
+YDs
+wzC
+TaU
+JRS
+CBc
+Wuy
+Rez
+geS
+IyK
+lyO
+RaB
+xnE
+oCg
+yxX
+BLc
+Ifn
+EUO
+rnz
+mzJ
+vkd
+NRo
+wrr
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(90,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wgR
+Pxz
+Vtr
+BHM
+BHM
+BHM
+BHM
+BHM
+BHM
+BHM
+fqS
+IWp
+qnU
+GHD
+ggd
+rvX
+gBs
+lNI
+SmE
+ZUA
+tLv
+YJx
+hkS
+CRa
+CRa
+xEg
+CGR
+Lnv
+CRa
+zTs
+yUi
+KCY
+tzT
+pab
+qbH
+AJh
+taq
+hBS
+dFQ
+EdF
+nOZ
+JAL
+aOi
+ndH
+WIE
+qFX
+Bzo
+xnE
+xnE
+KAG
+xnE
+xTF
+TBW
+AeT
+EwJ
+EwJ
+EwJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(91,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wgR
+EyZ
+jLE
+wzG
+Zrg
+Zrg
+Zrg
+Zrg
+Zrg
+Zrg
+yda
+Jmd
+xBJ
+fCa
+NKg
+xSv
+IWp
+gQa
+qyy
+bgV
+Ljv
+Ljv
+aBF
+rnu
+yuL
+TWo
+Ljv
+aBF
+ejI
+yuL
+cUb
+Ljv
+aBF
+MzZ
+yuL
+RaB
+RaB
+BzW
+Gpi
+qFN
+NJi
+EKj
+QsI
+nNV
+QsI
+QpL
+UIs
+sBC
+gaq
+ToC
+iLj
+xXc
+JkO
+mTz
+iLj
+hUH
+Umb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(92,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+wgR
+Pxz
+axd
+tBB
+tBB
+tBB
+tBB
+AQw
+AQw
+AQw
+AQw
+IWp
+mBh
+fZt
+KNz
+CXj
+IWp
+ExG
+NKC
+mVM
+Ljv
+cvt
+lms
+HFX
+HFX
+TWo
+URZ
+lms
+HFX
+hTs
+FjM
+Ljv
+lms
+HFX
+HFX
+htp
+RaB
+RaB
+cPn
+gvy
+gvy
+gvy
+gvy
+RaB
+RaB
+yLk
+yLk
+yLk
+LDq
+yLk
+Idm
+Gkx
+Teh
+UTo
+Idm
+yfu
+Umb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(93,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wgR
+oDm
+Qis
+MJv
+ITq
+hqH
+Tqb
+KYC
+sDI
+dvl
+RWM
+IWp
+eXo
+dsX
+nMq
+qga
+IWp
+LQl
+GdN
+Cjj
+Ljv
+vSj
+zaH
+zaH
+zaH
+TWo
+yYq
+zaH
+zaH
+xJT
+ofQ
+Ljv
+zaH
+zaH
+zaH
+PEg
+RaB
+yWs
+kJK
+WuX
+nHm
+Gsm
+Gsm
+RaB
+Cyq
+LLY
+eQf
+tvQ
+rCL
+dTh
+dob
+HSF
+kAF
+cjy
+yLk
+yfu
+Umb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(94,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wgR
+JBF
+BmX
+JlJ
+xin
+Mko
+bOu
+Rui
+tCv
+PEd
+NsG
+IWp
+lzf
+DUl
+dqj
+kUw
+IWp
+iFP
+puf
+oHE
+Ljv
+hrt
+zaH
+zaH
+woa
+Eus
+FRh
+zaH
+iYs
+gKe
+KsF
+Ljv
+zaH
+zaH
+yWt
+zbI
+RaB
+kRY
+GCq
+Kos
+nHm
+jfv
+jfv
+RaB
+mIK
+pxi
+uvL
+LzT
+liU
+LzT
+KjZ
+LzT
+gdI
+eAF
+yLk
+yfu
+Umb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(95,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+nvH
+YOV
+dBi
+olM
+aMQ
+nxt
+KYC
+IlU
+WqN
+trE
+IWp
+VOi
+xhK
+xhK
+zIE
+IWp
+wED
+LwW
+TnY
+Ljv
+FRh
+zaH
+zaH
+zaH
+xbe
+FRh
+zaH
+zaH
+xJT
+HRC
+Ljv
+zaH
+zaH
+zaH
+HRC
+RaB
+CYg
+GCq
+rqu
+pAw
+rlt
+rlt
+RaB
+Ing
+LzT
+LzT
+LzT
+oqd
+cVP
+VCy
+PyY
+KvI
+ZDE
+yLk
+yfu
+kDa
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(96,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+qKP
+fYG
+OkH
+lBJ
+Hbp
+vot
+KYC
+wNV
+eXM
+kJT
+IWp
+yFs
+sgy
+Pcf
+EdS
+IWp
+ExG
+NKC
+mVM
+Ljv
+NPv
+SsW
+iIc
+zoj
+qmL
+NPv
+SsW
+DnD
+yHO
+zKg
+Ljv
+SsW
+SsW
+SsW
+snw
+RaB
+GnE
+Fph
+xCr
+icc
+lJV
+lJV
+RaB
+eAs
+mng
+Mlz
+sHX
+LDp
+EEQ
+eli
+LzT
+gdI
+XtS
+yLk
+yfu
+kDa
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(97,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+qKP
+fYG
+tBB
+vLy
+tBB
+tBB
+KYC
+wXy
+oMU
+aOd
+IWp
+IWp
+IWp
+IWp
+IWp
+IWp
+Kib
+yiw
+FqO
+Ljv
+Ljv
+Ljv
+Ljv
+PbR
+Ljv
+Ljv
+Ljv
+imC
+Ljv
+Ljv
+Ljv
+Ljv
+Ljv
+Ljv
+imC
+RaB
+RaB
+kOO
+RaB
+bGN
+RaB
+RaB
+RaB
+BYI
+yLk
+yLk
+yLk
+LDq
+yLk
+yLk
+zLv
+gdI
+sif
+yLk
+yfu
+kDa
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(98,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+qKP
+mfm
+fRs
+NGa
+WFz
+mwx
+LBD
+ylK
+aNI
+Bqf
+fya
+iAW
+JIU
+JIU
+TbI
+JIU
+uMc
+JUj
+iVe
+emP
+hsa
+rTL
+yUY
+kII
+mDx
+VyX
+rsq
+nGW
+sBF
+VyX
+rsq
+rsq
+rTK
+ZDP
+mnN
+rsq
+uIK
+XsW
+rsq
+mnN
+rsq
+WPz
+Ffg
+qlk
+CtY
+jzH
+XiN
+djI
+PCC
+EEJ
+Yty
+haP
+OhR
+yLk
+cYf
+kDa
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(99,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+ZVh
+jrk
+lIT
+yuU
+afP
+CDf
+aBm
+LBJ
+WZC
+mMn
+DPZ
+CmJ
+eHa
+WBx
+WBx
+WBx
+mfh
+CKU
+NlQ
+sUr
+sUr
+jvU
+jvU
+Hqi
+bnJ
+Wsk
+hUN
+zjh
+ElI
+Wsk
+hUN
+hUN
+hUN
+hUN
+uRY
+hUN
+hUN
+tbZ
+SHr
+hUN
+hUN
+cuL
+lrB
+YSj
+pyY
+zbY
+xqg
+AEM
+OlV
+FRO
+DsB
+tkX
+RgP
+yLk
+yfu
+kDa
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(100,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+vLy
+uaU
+pCL
+NLx
+iiB
+kaR
+yUX
+SNh
+rpU
+rpU
+MJP
+ZiO
+ynW
+LOW
+SHL
+rIG
+rIG
+ynW
+vZs
+Vmm
+Vmm
+Vmm
+rIG
+SHL
+pzf
+ZZU
+yTv
+rrm
+oRz
+SJH
+JwC
+rIG
+VZe
+sfK
+sfK
+Ysw
+NhU
+rIG
+Vmm
+rIG
+SHL
+rIG
+nKk
+Tam
+nBj
+TFG
+Nyh
+fyw
+Gte
+YZh
+yLk
+LzT
+HqT
+DUG
+yLk
+yfu
+kDa
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(101,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wgR
+tBB
+sBl
+QNE
+KgN
+Kdw
+mwx
+FeZ
+MsS
+TTc
+Aqw
+fya
+iUf
+kOG
+Yzp
+BTZ
+BTZ
+Vmo
+MDH
+BTZ
+BTZ
+qia
+qia
+UFa
+bxt
+qia
+qia
+wUj
+oAv
+svT
+Wpv
+CZq
+kKl
+nGM
+LHf
+iFd
+cwW
+GEw
+GEw
+GEw
+beF
+GEw
+JWB
+SHq
+eJk
+meg
+LJU
+meg
+meg
+meg
+meg
+LzT
+HqT
+NOS
+yLk
+yfu
+Umb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(102,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wgR
+tBB
+Xrl
+ffm
+ljX
+uac
+NhK
+hTh
+UPm
+lrV
+TuO
+mwx
+Utw
+feJ
+Njc
+BTZ
+sNJ
+xwz
+dKg
+ehY
+fkN
+qia
+hIC
+uZf
+SEL
+APj
+ZkE
+YSj
+BTL
+qkp
+Wpv
+CZq
+NqJ
+DGq
+GAi
+JRp
+cwW
+wbV
+vTh
+TgV
+Kdk
+GEw
+DkK
+jyg
+uKn
+meg
+lrM
+uUb
+ApK
+Vxj
+tyG
+tHR
+jDd
+LAt
+yLk
+anE
+Umb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(103,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wgR
+tBB
+tBB
+tBB
+tBB
+TeY
+uRl
+mwx
+mwx
+mwx
+mwx
+mwx
+sxq
+kJy
+Njc
+BTZ
+kgR
+tgR
+sWQ
+ULZ
+eKM
+qia
+YFi
+FwT
+PaT
+ujx
+hyH
+qlk
+yJb
+TCP
+Wpv
+CZq
+pRq
+aFm
+kBM
+svS
+cwW
+GEw
+GEw
+idy
+cUS
+OoQ
+dvb
+jyg
+Wzi
+meg
+hVN
+uXV
+NmY
+QKR
+meg
+SAW
+CJG
+SAW
+RMv
+yfu
+Umb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(104,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+sIZ
+HfQ
+wmS
+WmR
+rkt
+ffQ
+MYw
+isP
+Msv
+Msv
+xcS
+NNb
+xVZ
+RBX
+Woe
+nPK
+DJC
+OxN
+nVA
+QoV
+Inb
+qia
+EEM
+eqy
+TqV
+APj
+qia
+Lke
+RCk
+dFF
+Wpv
+CZq
+VLK
+fxe
+yBF
+jqV
+FeB
+Wol
+NdA
+bKy
+mGb
+GEw
+DkK
+jyg
+uKn
+meg
+ZSA
+tPZ
+Bgk
+rhM
+meg
+NjO
+JOJ
+lWt
+Cof
+vYr
+Umb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(105,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+LjX
+dJQ
+xcD
+wNp
+BXi
+ffQ
+SoC
+zSE
+SoC
+SoC
+wGe
+ajG
+bsL
+feJ
+Njc
+jSB
+jSB
+jSB
+jSB
+jSB
+Sod
+Sod
+Sod
+Sod
+Sod
+Sod
+exC
+SOj
+iMj
+GCi
+CZq
+CZq
+CZq
+AJB
+CZq
+CZq
+SgU
+ODE
+ODE
+RrB
+ODE
+ODE
+QVV
+HaK
+ypb
+meg
+meg
+meg
+meg
+meg
+meg
+LYf
+JXB
+XOB
+RMv
+yZl
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(106,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+LjX
+dJQ
+dJQ
+MNx
+cxe
+jpc
+sHB
+MKx
+omz
+SoC
+wGe
+ajG
+bsL
+feJ
+Njc
+jSB
+nfO
+HUt
+Whr
+rwN
+jIj
+jkY
+bFY
+JdP
+ogE
+toK
+cVj
+YaA
+bLL
+kQi
+Nwc
+toK
+Uej
+jgv
+hBe
+ETM
+Dcv
+IyN
+VDq
+WyF
+vuM
+ODE
+DkK
+jyg
+uKn
+eKt
+YIx
+eLg
+mle
+Fqz
+FgG
+BnO
+xHB
+Qop
+RMv
+yZl
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(107,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+LjX
+RoS
+Awn
+oqf
+eBD
+Yza
+lEE
+MKx
+yMC
+SoC
+wGe
+ajG
+ZlU
+wWs
+iCk
+jSB
+nfO
+uPj
+Xsm
+rwN
+ksv
+TVq
+zCY
+nol
+ogE
+toK
+FfR
+drc
+BaM
+Fpk
+FfR
+toK
+Uej
+jgv
+sTh
+mzu
+wUD
+IyN
+SNg
+biE
+qGz
+ODE
+ChJ
+NuR
+uKn
+MWZ
+gti
+HqV
+rKL
+rKL
+FvO
+osT
+osT
+dlC
+RMv
+yZl
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(108,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+SoC
+SoC
+SoC
+VUS
+SoC
+ffQ
+PYD
+JAF
+bRg
+Dkp
+rKs
+OYV
+aJq
+vjV
+Xqz
+rwN
+nfO
+aWf
+Xsm
+rwN
+ZFw
+Epv
+EQk
+LUK
+THW
+TXg
+BIw
+FgV
+wDl
+vYf
+BIw
+vlC
+vlC
+tOF
+dhU
+dhU
+cvD
+IyN
+KAj
+ODE
+RrB
+ODE
+Xmo
+KcV
+uKn
+eKt
+qes
+YIn
+uEo
+gcj
+WfU
+CRO
+XkS
+uOS
+RMv
+pPc
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(109,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+con
+vzM
+Rrx
+ewT
+ZXW
+RGl
+TgU
+soj
+AKi
+aRQ
+XEW
+EMC
+KJo
+GYU
+tLn
+WZD
+uAi
+tbf
+Xsm
+rwN
+Lbz
+WsH
+mbB
+aFn
+KmK
+dVH
+oFb
+XOi
+uCb
+qhq
+Bdg
+EkD
+HWr
+jwd
+PHS
+jVe
+ZsD
+Lmw
+Vuy
+rHO
+vJQ
+sJG
+AEx
+tuM
+iZz
+uLm
+rmc
+YiH
+QYB
+CBG
+nWz
+Ury
+rVq
+FbC
+RMv
+yZl
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(110,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+con
+ndF
+rry
+sqe
+VLJ
+ffQ
+QtG
+MKx
+tsU
+SoC
+wGe
+ajG
+tpQ
+LWv
+OIp
+rwN
+nfO
+lCx
+Xsm
+rwN
+BvL
+Ylu
+xPe
+aHT
+rUB
+DNb
+lXg
+VTB
+ECy
+szy
+jUC
+sSh
+dvY
+rVI
+oTq
+FPi
+JwF
+ENt
+ftT
+LCi
+Lwd
+edL
+bsR
+hNA
+Wzi
+RMv
+hjW
+Kfi
+kPO
+pdi
+rhO
+WyW
+XHC
+zmt
+RMv
+yZl
+FeJ
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(111,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wLM
+wLM
+buT
+LDH
+rDG
+koy
+ffQ
+HzF
+HoD
+YJq
+SoC
+VUo
+ajG
+bsL
+xmw
+rBU
+tLE
+BDq
+tsM
+Xsm
+rwN
+zHn
+hxQ
+mKX
+ZWB
+TXg
+TXg
+BIw
+Cyk
+mwU
+Xye
+BIw
+vlC
+vlC
+GrT
+cWf
+xkC
+BxU
+CWZ
+FAw
+iax
+KNI
+edL
+byG
+YRv
+uKn
+bqM
+sHh
+gsZ
+nyD
+xEE
+nLQ
+RMv
+RMv
+RMv
+RMv
+yZl
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(112,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+kvp
+ZFx
+PsY
+PsY
+SxW
+LHD
+Akp
+Stf
+oUK
+YJq
+SoC
+VUo
+ajG
+Utw
+KUx
+AyP
+rwN
+nfO
+CWX
+Oqr
+TAv
+scX
+hFV
+wGi
+UrM
+Oqn
+toK
+WTG
+mii
+YRZ
+Unn
+JrE
+toK
+Uej
+nfJ
+xzQ
+LgD
+biK
+sJG
+jQA
+KTq
+pmw
+edL
+REb
+qGw
+Yoc
+sbX
+Lun
+EXf
+EXf
+EXf
+eHp
+yZl
+yZl
+PZL
+yZl
+yZl
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(113,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+wLM
+wLM
+FdA
+jRU
+CUo
+CVE
+tuY
+bzU
+yGq
+YJq
+SoC
+VUo
+ajG
+bsL
+gQp
+YAM
+rwN
+nfO
+VxJ
+rwN
+rwN
+Xmh
+Pzj
+fgI
+vpt
+Oqn
+toK
+FfR
+uIQ
+kxH
+kQU
+FfR
+toK
+Uej
+Shu
+xZs
+pYR
+MYh
+cEJ
+Vwg
+FOm
+cze
+exk
+jGm
+tWy
+uKn
+anO
+PWG
+JPm
+ecK
+qtS
+nLQ
+yZl
+yZl
+yZl
+yZl
+yZl
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(114,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wLM
+SRF
+nbC
+lMV
+CsA
+GRL
+xif
+aRQ
+aRQ
+aRQ
+RdD
+EAt
+KJo
+DpH
+jSH
+rwN
+nfO
+MKf
+KDH
+lCa
+due
+OLV
+TXg
+JRT
+exC
+exC
+exC
+GTE
+BTe
+RTo
+exC
+SgU
+SgU
+SgU
+SgU
+SgU
+SgU
+XLe
+eaq
+XLe
+zaI
+XLe
+DkK
+IRA
+eOL
+nLQ
+CSr
+nLQ
+nLQ
+nLQ
+nLQ
+GeI
+GeI
+yZl
+yZl
+GeI
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(115,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wLM
+ftf
+zRv
+yfx
+iQr
+rUa
+uDV
+UkH
+Mfg
+naG
+rSZ
+wvm
+bsL
+feJ
+OoS
+jSB
+AXu
+WRx
+rwN
+YNO
+TUT
+BcZ
+TXg
+MRO
+UXj
+FbA
+QCu
+hLy
+vHa
+cJK
+upk
+IIk
+UXj
+XLe
+XLe
+EOy
+ZgC
+pIG
+aed
+pIG
+mAh
+XLe
+DkK
+jyg
+uKn
+myF
+Par
+wwT
+DHC
+GeI
+pPc
+yZl
+GeI
+yZl
+yZl
+GeI
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(116,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+con
+Lfx
+Ptu
+gMx
+Ivq
+rgR
+wvm
+LNf
+OgC
+eqJ
+HTO
+wvm
+sxq
+eQe
+LWW
+EjI
+mTi
+aOb
+Qoi
+Dox
+hEp
+qvU
+Oqn
+MRO
+UXj
+irM
+Isw
+duK
+YPi
+edm
+mgL
+tXR
+vyq
+atG
+XLe
+WTe
+YAp
+YAp
+CwT
+YAp
+wRt
+XLe
+DkK
+jyg
+HAq
+LID
+MHx
+bJw
+kpe
+GeI
+Tfc
+yZl
+yZl
+yZl
+yZl
+PZL
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(117,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+con
+Mjw
+fDr
+jCu
+UZA
+iSF
+fVJ
+Pge
+xac
+eqJ
+xFh
+wvm
+bsL
+feJ
+VfF
+tuI
+rVb
+bJU
+aHi
+Gdn
+TUT
+NGr
+Oqn
+MRO
+UXj
+fuv
+Aiu
+MNB
+Fzf
+rbh
+enn
+MNB
+UXj
+BvF
+XLe
+kXJ
+OKd
+OKd
+SmX
+YAp
+NFA
+XLe
+DkK
+jyg
+uKn
+myF
+Bwo
+PtQ
+DJK
+GeI
+PZL
+yZl
+YVv
+yZl
+yZl
+PZL
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(118,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+con
+VVU
+nxr
+nZj
+pAF
+AsB
+wvm
+oej
+OgC
+eqJ
+kiD
+wvm
+bsL
+feJ
+OoS
+tuI
+fYX
+hEf
+Cht
+WTD
+TUT
+reK
+Oqn
+MRO
+UXj
+bAr
+Aiu
+JOB
+zhw
+tMN
+enn
+iLu
+UXj
+BvF
+XLe
+pQB
+OKd
+BnR
+UJS
+XLe
+XLe
+XLe
+BtK
+jyg
+uKn
+GeI
+XwR
+GeI
+GeI
+GeI
+yZl
+yZl
+GeI
+GeI
+GeI
+GeI
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(119,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+con
+bkr
+ylA
+lMV
+Qyh
+gXM
+wvm
+dBS
+OgC
+eqJ
+dru
+wvm
+bsL
+uzo
+osA
+oxp
+Sdw
+UOd
+Vde
+uhj
+tBw
+QjT
+Oqn
+MRO
+UXj
+EFO
+Aiu
+duK
+Tiz
+duK
+enn
+VCA
+UXj
+BvF
+XLe
+piJ
+OKd
+Fdx
+Knk
+DDS
+XLe
+XLe
+DkK
+jyg
+uKn
+YNY
+dbJ
+gaa
+gaa
+gaa
+gaa
+gaa
+gaa
+gaa
+gaa
+HJm
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(120,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wLM
+jfw
+con
+hJI
+NRU
+Alx
+wvm
+iUt
+vpm
+RFL
+AbS
+wvm
+EFk
+feJ
+VfF
+tuI
+tuI
+tuI
+tuI
+tuI
+tuI
+tuI
+tuI
+MRO
+UXj
+tVX
+eOq
+PTO
+hjC
+PTO
+rzA
+RxZ
+UXj
+BvF
+XLe
+akx
+YAp
+BCG
+GIV
+XLe
+XLe
+XLe
+svX
+jyg
+uKn
+XNB
+XNB
+XNB
+XNB
+xNR
+xNR
+xNR
+xNR
+xNR
+xNR
+aXV
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(121,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+sLN
+AnY
+SqJ
+NjF
+smE
+Gae
+wvm
+wvm
+wvm
+wvm
+wvm
+wvm
+Utw
+feJ
+lKj
+eBt
+JyU
+peW
+uPS
+hsW
+Sel
+IFL
+tuI
+jVM
+UXj
+cDi
+DcH
+VCA
+Uhi
+MNB
+GiP
+MNB
+UXj
+JPN
+XBo
+XBo
+XBo
+XBo
+XBo
+XBo
+CDP
+XBo
+Frh
+Gso
+SZi
+zXj
+VwL
+TDy
+qbf
+rYI
+RiJ
+FWG
+oCQ
+sMX
+xNR
+REW
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(122,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+OcT
+AnY
+con
+oxh
+yQb
+Ewc
+nKE
+AAR
+iMI
+AAR
+GVw
+wvC
+sHH
+zUw
+pmE
+IFL
+yDR
+tlF
+ZWU
+qjX
+CPz
+IFL
+tuI
+MRO
+UXj
+UXj
+UXj
+UXj
+UXj
+UXj
+UXj
+UXj
+UXj
+hlx
+ySj
+Fyi
+AoV
+wvI
+wvI
+PKf
+pzc
+OXp
+PSp
+jyg
+ypb
+cPk
+KJT
+FuH
+VbE
+biH
+gTV
+yHo
+oLy
+xUQ
+xNR
+REW
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(123,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+ThN
+AnY
+SqJ
+IgU
+OOl
+ewm
+cfA
+yWi
+cJS
+DRe
+tVP
+NYn
+ooa
+WEf
+Njc
+IFL
+cxt
+tlF
+QCq
+zCl
+GwN
+IFL
+tuI
+pas
+tuI
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+yZZ
+bzd
+yZZ
+YbP
+YbP
+YbP
+YbP
+Gsr
+pyN
+Gsr
+arA
+jyg
+uKn
+kTI
+AHk
+oti
+tcX
+flO
+XQs
+AEh
+yYS
+htG
+xNR
+REW
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(124,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+wLM
+OnF
+nzl
+nzl
+nzl
+OnF
+nzl
+nzl
+nzl
+nzl
+ybq
+nzl
+gQB
+feJ
+Njc
+IFL
+EAP
+tlF
+tlF
+YyT
+toK
+toK
+SWb
+bgy
+SWb
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+YbP
+rfV
+YbP
+wDT
+wDT
+wDT
+wDT
+XBo
+PDg
+pXc
+arA
+jyg
+uKn
+kTI
+wRm
+xRn
+qlq
+DXq
+zIv
+zIv
+zIv
+wJO
+aVv
+NVg
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(125,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+nXw
+GYj
+kDx
+UIt
+UIt
+UIt
+dPX
+UIt
+UIt
+bxO
+xXx
+vGh
+xXx
+bsL
+feJ
+Njc
+IFL
+CCX
+LIS
+JbD
+YyT
+toK
+toK
+Nby
+toK
+Nby
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+YbP
+toK
+YbP
+toK
+toK
+toK
+wDT
+wDT
+wDT
+pXc
+arA
+jyg
+uKn
+kTI
+EOG
+HRt
+tEx
+CQz
+BDY
+oJn
+ojz
+lZT
+xNR
+REW
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(126,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+rhJ
+Syi
+DbX
+HsN
+xXx
+xXx
+xXx
+DqA
+UIt
+DjH
+mac
+loo
+feJ
+Njc
+IFL
+qjc
+CJX
+OtE
+YyT
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Uux
+cVK
+IDX
+Wzi
+XNB
+XNB
+XNB
+XNB
+xNR
+xNR
+xNR
+xNR
+xNR
+xNR
+REW
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(127,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+UXO
+MTL
+MTL
+MTL
+MTL
+MTL
+MTL
+HMG
+MTL
+Vto
+MTL
+ZlU
+PDK
+Woe
+ZTD
+zSr
+LBA
+WPu
+xjC
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+rFw
+vId
+vId
+eDM
+bxl
+toK
+Uux
+jyi
+rVA
+uKn
+qqG
+xmU
+Zyj
+Ins
+PuJ
+hOS
+xnf
+DNy
+GeI
+rER
+REW
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(128,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+rhJ
+MTL
+Dgi
+oUM
+XOX
+HwP
+ZNE
+YUs
+byX
+lcz
+MTL
+sxq
+kJy
+Njc
+gYy
+ajZ
+gYy
+gYy
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+VzP
+yaY
+yaY
+yaY
+mxX
+yaY
+VzP
+xSH
+sQz
+sPo
+pZO
+TQH
+GaQ
+xLN
+Lxc
+Lxc
+IVV
+Lxc
+Rgr
+SNf
+gJb
+kuk
+FeJ
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(129,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+GYj
+rhJ
+MTL
+zis
+UYl
+WZg
+ddq
+WZg
+nQJ
+WZg
+sBs
+MTL
+iUf
+kOG
+Yzp
+uaf
+yti
+GcL
+tUg
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+hdr
+yaY
+oQd
+jqA
+NDY
+REL
+KMG
+KWI
+jyi
+rVA
+uKn
+dft
+pTP
+YIH
+LrP
+isr
+irG
+lyr
+njp
+KAu
+cfZ
+hTc
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(130,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+rhJ
+MTL
+uxq
+hmz
+DtJ
+TQd
+iwP
+poc
+SSW
+eSu
+MTL
+uOp
+uJn
+lNX
+XDv
+HAt
+yFi
+lcy
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Qah
+FBz
+Tbn
+ivg
+OHS
+Txn
+iqA
+eFz
+OUZ
+yhQ
+Hpg
+yHj
+odj
+BQx
+ZJS
+UXb
+Lxc
+YIH
+Pdm
+GeI
+VCb
+icW
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(131,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+rhJ
+MTL
+MTL
+MTL
+MTL
+iSc
+MTL
+MTL
+Pvg
+VBF
+MTL
+bsL
+Rge
+CqX
+yaN
+JUH
+JUH
+nPG
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+jIc
+yaY
+xwF
+CIc
+kUO
+yaY
+ZCL
+Uux
+vAY
+ueD
+uKn
+qqG
+ZEk
+ScX
+Lxc
+Lxc
+Lxc
+ode
+gwz
+Jva
+NVg
+GeI
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(132,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+rhJ
+WpP
+LCv
+dmg
+xzv
+KyF
+GbN
+Nzv
+nkI
+yDE
+sWF
+bsL
+feJ
+AlA
+rFr
+POg
+nNl
+hWG
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+guC
+yaY
+yaY
+yaY
+mxX
+yaY
+guC
+Uux
+Iqe
+rVA
+uKn
+qqG
+OhQ
+iZg
+odV
+Rcd
+gAw
+pVB
+fOZ
+GeI
+Bpu
+HJm
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(133,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+rhJ
+WpP
+URL
+NPj
+sYA
+ZOZ
+tTX
+DGf
+nkI
+yDE
+sWF
+bsL
+feJ
+Njc
+RLN
+cfj
+GcL
+AzE
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+gMA
+vId
+vId
+bnD
+bxl
+toK
+Uux
+qco
+cMt
+eJk
+QSR
+QSR
+QSR
+QSR
+QSR
+QSR
+kCF
+Hmf
+QSR
+QSR
+REW
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(134,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+Hif
+lTL
+JaY
+Gbs
+zsE
+Vml
+iWu
+HAM
+FCX
+MCS
+sWF
+bsL
+feJ
+Njc
+RLN
+RZg
+GcL
+dfx
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Uux
+jyi
+rVA
+Wzi
+QSR
+fPz
+tcr
+OkM
+MKU
+FDu
+kyW
+kyW
+kRm
+QSR
+REW
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(135,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+eVP
+rhJ
+WpP
+YpK
+efi
+VnM
+MiH
+YoA
+PDA
+NpH
+QHw
+sWF
+gQB
+feJ
+Njc
+gYy
+gYy
+JqC
+gYy
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Uux
+jyi
+rVA
+HAq
+Len
+yqN
+yqN
+yqN
+FBB
+Ynq
+kyW
+kyW
+PNa
+QSR
+rzr
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(136,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+eVP
+rhJ
+WpP
+WpP
+WpP
+WpP
+qVk
+WpP
+WpP
+Zao
+nuI
+sWF
+bsL
+feJ
+Njc
+gYy
+hSI
+XSp
+HPm
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
+iYx
+rVA
+uKn
+EIr
+hqi
+kyW
+JYK
+VaN
+UWx
+Bdw
+kyW
+OER
+QSR
+srO
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(137,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+rhJ
+GYj
+RuS
+LNI
+geG
+cKS
+Sok
+Rzi
+IaT
+KFz
+sWF
+bsL
+feJ
+lor
+gYy
+yiI
+VvI
+ANA
+gYy
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
+jyi
+rVA
+uKn
+EIr
+hqi
+kyW
+Bdw
+rai
+Bdw
+Zns
+kyW
+BGz
+mHa
+Fzw
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(138,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+Zhq
+GYj
+sXZ
+khZ
+nkI
+leo
+EFU
+qwF
+oxB
+SOs
+sWF
+bsL
+feJ
+Njc
+gYy
+gYy
+gYy
+gYy
+gYy
+Zby
+QKY
+HAv
+EYH
+HQu
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+HQu
+QKY
+Zby
+QKY
+QKY
+QKY
+QKY
+pXc
+EFV
+rVA
+uKn
+EIr
+kyW
+kyW
+kyW
+yEf
+cCd
+ioZ
+ioZ
+nBp
+HRy
+Pxk
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(139,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+yhI
+NoR
+dwo
+dwo
+dwo
+omN
+Ahq
+MoM
+MoM
+MoM
+sWF
+bsL
+ZSS
+Njc
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+jyi
+uEc
+uKn
+QSR
+Bsg
+Deu
+kyW
+kyW
+kyW
+kyW
+ZZD
+xag
+QSR
+rzr
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(140,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+HlQ
+GYj
+Wuw
+OLp
+Eii
+Jtg
+KFz
+mHZ
+mHZ
+mHZ
+sWF
+bsL
+ZSS
+Njc
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+jyi
+uEc
+ypb
+QSR
+QSR
+QSR
+Cqh
+Cqh
+Cqh
+Cqh
+QSR
+UES
+QSR
+gLv
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(141,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+HlQ
+GYj
+iRw
+EKN
+eVt
+lJq
+tPQ
+sWF
+sWF
+sWF
+sWF
+bsL
+ZSS
+Njc
+oXv
+toK
+toK
+toK
+toK
+uZs
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+jyi
+uEc
+uKn
+Tpn
+vEV
+DBA
+ACU
+ACU
+ACU
+ACU
+gFN
+gpm
+Mdv
+ITf
+nVF
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(142,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+HlQ
+GYj
+poG
+NPU
+uam
+Jtg
+KFz
+AyR
+KGt
+zkZ
+rkr
+bsL
+ZSS
+Njc
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+jyi
+uEc
+HAq
+Naw
+bBN
+TUZ
+TUZ
+TUZ
+YSZ
+gFN
+gFN
+PGY
+UzV
+xVT
+KgE
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(143,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+GYj
+HlQ
+GYj
+enG
+wev
+ftL
+Jtg
+KFz
+YYI
+yGe
+vzu
+atv
+bsL
+feJ
+Njc
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+jyi
+rVA
+uKn
+Tpn
+gFN
+gFN
+Lpz
+Lpz
+Lpz
+Lpz
+Lpz
+Lpz
+gFN
+VOt
+KgE
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(144,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uby
+cgZ
+uby
+uby
+uby
+HOh
+vtM
+AVW
+kJm
+VYp
+Inm
+kJm
+yvg
+feJ
+Njc
+jqx
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+Uux
+jyi
+rVA
+uKn
+tXa
+gFN
+Lpz
+lEr
+Slq
+DDF
+lEr
+lEr
+lEr
+gFN
+VOt
+KgE
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(145,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+hLw
+mvR
+wjB
+ZVC
+AYP
+YmT
+QpJ
+nmO
+gdp
+fzw
+fzw
+oqL
+zxR
+djX
+pmE
+jqx
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+Uux
+jyi
+rVA
+kFR
+wyH
+gFN
+Lpz
+lEr
+WdZ
+WdZ
+WdZ
+ina
+AHc
+gFN
+VOt
+KgE
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(146,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+hLw
+mYO
+spW
+CON
+ubP
+zKB
+vfa
+lha
+xkS
+bJu
+pII
+UiY
+KJo
+AnB
+smL
+jqx
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+Uux
+haZ
+tin
+soP
+uAP
+wui
+ZBD
+STo
+hSl
+hSl
+hSl
+hLI
+rJS
+wui
+TJD
+KgE
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(147,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+hLw
+mYO
+wgC
+vKw
+wax
+Byz
+wTY
+kJm
+kJm
+kJm
+kJm
+PZZ
+sxq
+lNX
+iQL
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+akJ
+aul
+eOL
+Prr
+gFN
+gFN
+VEP
+PyT
+eZf
+WdZ
+WdZ
+LpT
+gFN
+umG
+KgE
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(148,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uby
+GrD
+LoK
+iHz
+Gqc
+keN
+zXy
+fVp
+Xwg
+wAk
+kjj
+uQy
+sxq
+lNX
+PNU
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+jNj
+aul
+eOL
+wyH
+ooG
+iTk
+wyH
+vyh
+ofm
+HXN
+twV
+wyH
+EEd
+Qsq
+nVF
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(149,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uby
+Sru
+HSB
+rXT
+dqZ
+hGW
+InZ
+pBR
+efc
+RhE
+ozU
+cLJ
+bsL
+xRZ
+MlW
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+Fhn
+tNP
+uKn
+wyH
+wyH
+wyH
+wyH
+wyH
+wyH
+wyH
+wyH
+wyH
+wyH
+jqE
+nVF
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(150,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uby
+ZCP
+Woh
+BGl
+xSE
+zKB
+QrW
+kJm
+kJm
+kJm
+kJm
+Vdy
+bsL
+vOR
+tOP
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+GHq
+tNP
+uKn
+qgT
+gFg
+DKa
+DKa
+DKa
+DKa
+DKa
+DKa
+nqN
+qgT
+twP
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(151,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+kJm
+kJm
+kJm
+kJm
+kJm
+XJo
+ycQ
+pui
+oqn
+QPF
+kjj
+uQy
+bsL
+mnO
+mnO
+jqx
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+Uux
+hGk
+xhl
+uKn
+qgT
+Abo
+Mta
+Mta
+Mta
+Mta
+Mta
+Mta
+UIM
+qgT
+FQK
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(152,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+kJm
+DaF
+PQN
+wwq
+kJm
+czw
+VfU
+pBR
+wcK
+RhE
+ozU
+cLJ
+bsL
+mnO
+mnO
+jqx
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+Uux
+jyi
+ctI
+uKn
+qgT
+Ksg
+Zng
+Zng
+Zng
+Zng
+Zng
+Zng
+Zng
+qgT
+FQK
+rHc
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(153,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+VwM
+UiW
+UiW
+UiW
+kJm
+vWP
+VNx
+kJm
+kJm
+kJm
+kJm
+Vdy
+OKo
+mnO
+mnO
+jqx
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+QKY
+toK
+toK
+toK
+toK
+Uux
+jyi
+LWb
+Wzi
+qgT
+ExZ
+Zng
+UEZ
+UEZ
+Zng
+Zng
+Zng
+Sln
+qgT
+FQK
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(154,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+OKM
+sGG
+CrN
+Fjm
+Qgr
+JVY
+xUH
+PuZ
+GWG
+GTm
+kjj
+uQy
+bsL
+cbx
+mnO
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+jyi
+Bdj
+oNT
+Kyy
+pOb
+eYt
+DZT
+LVg
+nRp
+pOb
+rge
+zRQ
+miw
+Edc
+FeJ
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(155,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+kJm
+sAY
+NZG
+bCV
+xts
+Vkq
+XDo
+pBR
+Mbv
+RhE
+ozU
+cLJ
+zuO
+dun
+mnO
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+vAY
+iIe
+Jds
+JPd
+IsU
+HSM
+GkJ
+kat
+wlA
+Lpy
+vaT
+qbo
+qgT
+yZl
+FeJ
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(156,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+wvO
+wvO
+wvO
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+pYP
+ryL
+iiT
+QXd
+QXd
+QXd
+UME
+QXd
+QXd
+QXd
+QXd
+QXd
+QXd
+QXd
+QXd
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(157,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+atQ
+iUQ
+eQc
+eQc
+eQc
+iUQ
+eQc
+eQc
+eQc
+iUQ
+Ewk
+oXv
+Msa
+mnO
+woq
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+pXc
+OOV
+arA
+GWJ
+QXd
+Hit
+osO
+kLU
+Ogq
+rJN
+Tpi
+Tpi
+mfa
+SRq
+JGZ
+QXd
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(158,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+ILx
+Ugc
+FUk
+tWa
+ESv
+SJb
+ESv
+ESv
+ESv
+XHb
+gKx
+oXv
+zRI
+mnO
+Bpe
+jqx
+toK
+toK
+uZs
+toK
+toK
+toK
+QKY
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+QKY
+QKY
+BBw
+toK
+toK
+Uux
+hup
+arA
+Hdj
+UUP
+Nqs
+qPc
+Boj
+Xjg
+DjW
+ffa
+ffa
+cCk
+kmh
+kgt
+QXd
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(159,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+ILx
+ReI
+yAe
+aUj
+vFM
+Uua
+Uua
+Uua
+ESv
+ESv
+zjf
+GpF
+YJU
+mnO
+Bpe
+jqx
+QKY
+QKY
+QKY
+QKY
+QKY
+QKY
+HAv
+EYH
+wgr
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+HQu
+QKY
+QKY
+QKY
+QKY
+QKY
+QKY
+Uux
+hup
+Mii
+WOH
+Ail
+Ppu
+hXo
+Ppu
+Ppu
+piz
+hZc
+OvE
+sTG
+sTG
+sTG
+QXd
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(160,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+eQc
+NWj
+RXn
+YEC
+Ejl
+pNY
+pNY
+pNY
+ESv
+lZN
+Ewk
+oXv
+sTR
+Cec
+Bpe
+jqx
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Uux
+hup
+oQP
+wno
+QXd
+oqN
+niY
+iZx
+Hit
+rJN
+FvT
+pUz
+Usl
+Usl
+Usl
+RPA
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(161,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+eQc
+paa
+AQM
+Onw
+ESv
+ESv
+ESv
+ESv
+ESv
+Uev
+kNl
+oXv
+jBN
+mnO
+QRs
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
+yfA
+Hdj
+Ome
+QXd
+rJN
+rJN
+rJN
+rJN
+rJN
+myV
+pUz
+GmA
+GmA
+GmA
+RPA
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(162,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+eQc
+nNd
+pBY
+sYF
+jub
+Uua
+Uua
+Uua
+ESv
+lZN
+gKx
+oXv
+KOB
+mnO
+Bpe
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
+hup
+Hdj
+Hdj
+RPA
+wKN
+wKN
+cGP
+YRP
+YRP
+OVK
+pUz
+Usl
+Usl
+Usl
+RPA
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(163,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+ILx
+VXS
+mPV
+XLd
+pHm
+pNY
+pNY
+pNY
+ESv
+ESv
+Plh
+GpF
+YJU
+mnO
+feg
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
+Lzs
+Hdj
+Hdj
+RPA
+aoY
+kmh
+kmh
+kmh
+kmh
+BSz
+pUz
+GmA
+GmA
+GmA
+QXd
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(164,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+ILx
+WUc
+TsQ
+ALq
+ESv
+ClH
+ESv
+ESv
+ESv
+XHb
+Ewk
+oXv
+UpV
+EEU
+jqx
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
+PNM
+ZGK
+Uux
+QXd
+KmZ
+kmh
+kmh
+kmh
+kmh
+kmh
+wrD
+sTG
+sTG
+sTG
+QXd
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(165,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+ISa
+iUQ
+eQc
+eQc
+eQc
+iUQ
+eQc
+eQc
+eQc
+iUQ
+gKx
+oXv
+jqx
+iFk
+jqx
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
+Uux
+QRu
+Uux
+QXd
+RwE
+rQN
+alm
+ayz
+lzW
+TRO
+QXd
+kyQ
+kyQ
+kyQ
+QXd
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(166,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+oXv
+oXv
+oXv
+oXv
+oXv
+oXv
+oXv
+oXv
+oXv
+oXv
+oXv
+oXv
+jqx
+mvH
+jqx
+oXv
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
+Uux
+fsj
+Uux
+QXd
+QXd
+QXd
+RPA
+RPA
+RPA
+QXd
+QXd
+Ods
+Ods
+Ods
+QXd
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(167,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+iaF
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+YwP
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(168,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(169,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+uZs
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(170,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(171,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+KuF
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(172,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(173,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(174,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(175,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(176,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(177,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(178,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(179,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(180,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(181,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(182,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(183,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(184,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(185,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(186,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(187,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(188,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(189,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(190,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(191,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(192,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(193,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(194,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(195,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(196,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(197,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(198,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(199,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(200,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(201,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(202,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(203,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(204,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(205,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(206,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(207,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(208,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(209,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(210,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(211,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(212,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(213,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(214,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(215,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(216,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(217,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(218,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(219,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(220,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(221,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(222,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(223,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(224,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(225,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(226,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(227,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(228,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(229,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(230,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(231,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(232,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(233,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(234,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(235,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(236,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(237,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(238,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(239,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(240,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(241,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(242,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(243,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(244,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(245,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(246,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(247,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(248,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(249,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(250,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(251,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(252,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(253,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(254,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}
+(255,1,1) = {"
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+Kky
+"}

--- a/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
+++ b/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
@@ -1119,6 +1119,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"cCk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/item/weapon/banner,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
 "cDi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -1266,6 +1273,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"cPx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "cPV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /mob/living/simple_animal/mouse,
@@ -1883,12 +1901,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"dQJ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "dSy" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	tag = "icon-pump_map (EAST)";
@@ -2175,26 +2187,6 @@
 	},
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/cargo/office)
-"exb" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen";
-	req_access_txt = "28"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "containment blast door"
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/xenobiology)
 "exf" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -2333,6 +2325,27 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/assembly/chargebay)
+"eJe" = (
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
+"eJj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "eJk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -2506,6 +2519,29 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"faT" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/landmark/start{
+	name = "Scientist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Research Division";
+	network = list("SS13","RD")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "fcA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -2719,6 +2755,18 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"fCa" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/weapon/book/manual/ftl_wiki/supermatter,
+/obj/item/device/lightreplacer,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
 "fCe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -2760,13 +2808,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"fRl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "fRs" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -2871,6 +2912,25 @@
 	dir = 9
 	},
 /area/shuttle/ftl/munitions)
+"fZa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "fZp" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -2888,6 +2948,27 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"fZv" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen";
+	req_access_txt = "28"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/machinery/atmospherics,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "fZN" = (
 /obj/machinery/door/airlock/glass_virology{
 	name = "Isolation A";
@@ -2977,6 +3058,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"gfS" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen";
+	req_access_txt = "28"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/lab)
 "ggd" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer";
@@ -3095,9 +3196,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/space)
-"guL" = (
-/turf/open/floor/plasteel/darkwarning,
-/area/shuttle/ftl/engine/engine_smes)
 "gvy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -4204,18 +4302,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"iKD" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "iLj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
@@ -4435,16 +4521,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"iZp" = (
-/obj/machinery/computer/aifixer,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "iZx" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/camera{
@@ -4961,6 +5037,24 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
+"kgR" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/lights/mixed{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/box/mousetraps{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/item/device/lightreplacer,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
 "khZ" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -5069,19 +5163,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"kxm" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "kxH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5172,25 +5253,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"kFX" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start{
-	name = "Research Director";
-	shuttle_abstract_movable = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "kII" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5277,18 +5339,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"kLD" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "kLU" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5823,6 +5873,12 @@
 "meg" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/server)
+"mfa" = (
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/bridge/eva)
 "mfh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6032,6 +6088,18 @@
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
+"mzJ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "mAh" = (
 /obj/machinery/computer/upload/borg,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6274,23 +6342,6 @@
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"neN" = (
-/obj/structure/closet/secure_closet/RD,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 1;
-	pixel_y = 23
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "nfJ" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c";
@@ -7002,32 +7053,6 @@
 "oul" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"ovj" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_command{
-	name = "Research Director";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "oxh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -7381,14 +7406,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"pgR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
+"phh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel{
-	icon_state = "white"
+	icon_state = "cafeteria"
 	},
-/area/shuttle/ftl/research/division)
+/area/shuttle/ftl/crew_quarters/hor)
 "piz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -7746,6 +7770,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
+"pSN" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	id = "supermatter_eject"
+	},
+/obj/machinery/power/supermatter_shard,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "pTP" = (
 /turf/open/floor/plasteel/green/corner{
 	tag = "icon-greencorner (NORTH)";
@@ -7816,6 +7848,23 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
+"qbo" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
 "qbq" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -8961,23 +9010,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"smm" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/lights/mixed{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/box/mousetraps{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/janitor)
 "smE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10204,6 +10236,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"uxq" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
+/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
+/obj/item/ammo_box/magazine/sniper_rounds/soporific,
+/obj/structure/window/reinforced,
+/obj/item/ammo_box/magazine/sniper_rounds/soporific,
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle,
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/security/armory)
 "uzo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10404,6 +10446,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"uNy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "uOp" = (
 /obj/machinery/light{
 	dir = 1
@@ -10510,13 +10560,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/research/server)
-"uYM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "uZf" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -10540,6 +10583,16 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/space)
+"vaT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
 "vfa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10573,6 +10626,27 @@
 	icon_state = "L3"
 	},
 /area/shuttle/ftl/hallway/primary/port)
+"vkd" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 38
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "vlC" = (
 /turf/closed/wall,
 /area/shuttle/ftl/bridge/meeting_room)
@@ -10617,14 +10691,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"vtK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/division)
 "vtM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10642,17 +10708,6 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"vuL" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/mob/living/simple_animal/pet/cat{
-	name = "Schrodinger"
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge)
 "vuM" = (
 /obj/structure/dresser,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -10962,6 +11017,16 @@
 	dir = 4
 	},
 /area/shuttle/ftl/security/main)
+"wgr" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF WEAPONS AREA'.";
+	layer = 2.9;
+	name = "KEEP CLEAR OF WEAPONS AREA";
+	pixel_y = 0
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/space)
 "wgC" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -11044,6 +11109,11 @@
 	dir = 10
 	},
 /area/shuttle/ftl/atmos)
+"wrr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/xenobiology)
 "wrD" = (
 /obj/machinery/button/door{
 	id = "EvaGarage";
@@ -11503,12 +11573,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
-"xvp" = (
-/obj/item/weapon/banner,
-/turf/open/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/ftl/bridge/eva)
 "xwa" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
@@ -11536,6 +11600,20 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/nuke_storage)
+"xzn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/structure/closet/secure_closet/RD,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "xzv" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green{
@@ -11587,47 +11665,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"xDg" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/table,
-/obj/item/device/taperecorder{
-	pixel_x = -3
-	},
-/obj/item/device/paicard{
-	pixel_x = 4
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/weapon/pen,
-/obj/item/weapon/folder/white{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/item/weapon/stamp/rd{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "xEg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -12064,29 +12101,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"ynp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division";
-	network = list("SS13","RD")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "ynA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/button/door{
@@ -12188,6 +12202,34 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"yxX" = (
+/obj/structure/table,
+/obj/item/device/taperecorder{
+	pixel_x = -3
+	},
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/folder/white{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/weapon/stamp/rd{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/device/taperecorder{
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "yyc" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/hor)
@@ -12312,13 +12354,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"yII" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "yJb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12733,9 +12768,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"zDD" = (
-/turf/closed/wall,
-/area/shuttle/ftl/research/division)
 "zDE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -12938,6 +12970,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"AeT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
 "Ahq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
@@ -12947,17 +12985,6 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"AhU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/weapon/book/manual/ftl_wiki/supermatter,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
 "Ail" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13233,20 +13260,6 @@
 	icon_state = "L5"
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
-"AEF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/hor)
 "AEM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -13272,20 +13285,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"AHv" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start{
-	name = "Scientist";
-	shuttle_abstract_movable = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "AJh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -13434,6 +13433,22 @@
 	icon_state = "L1"
 	},
 /area/shuttle/ftl/bridge)
+"BbM" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "BcZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13692,6 +13707,13 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"Bzo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/hor)
 "BzW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -13711,6 +13733,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"BBw" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/space)
 "BCG" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -13753,6 +13779,28 @@
 "BIw" = (
 /turf/closed/wall,
 /area/shuttle/ftl/bridge)
+"BLc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/computer/aifixer,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "BOB" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -13956,6 +14004,14 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/engine/engineering)
+"Cjn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
 "ClH" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14358,15 +14414,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"Dcp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "36"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/atmos)
 "Dcv" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
@@ -14408,6 +14455,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
+"Djz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/research/xenobiology)
 "DjH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -14544,18 +14597,6 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"DCl" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/ftl/cargo/mining)
 "DDF" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/cards/deck,
@@ -14912,6 +14953,13 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
+"Eyi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "EyZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15176,9 +15224,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
+"EUO" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "EXf" = (
 /turf/open/floor/bluegrid,
 /area/shuttle/ftl/assembly/chargebay)
+"EYH" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/space)
 "EZv" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/cmo)
@@ -15615,25 +15683,22 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"FKW" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+"FHA" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 38
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -15789,21 +15854,6 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/engine/engineering)
-"GdU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "Geq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -16011,14 +16061,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"GAf" = (
-/obj/machinery/mass_driver{
-	dir = 8;
-	id = "supermatter_eject"
-	},
-/obj/machinery/power/supermatter_shard,
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engine_smes)
 "GAi" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -16131,16 +16173,6 @@
 	dir = 10
 	},
 /area/shuttle/ftl/cargo/office)
-"GWF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "GWG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -16351,6 +16383,21 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
+"HzF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/hardsuit_jetpack,
+/obj/item/hardsuit_jetpack,
+/obj/item/hardsuit_jetpack,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
 "HAh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16397,6 +16444,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"HAv" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF WEAPONS AREA'.";
+	layer = 2.9;
+	name = "KEEP CLEAR OF WEAPONS AREA";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/space)
 "HAM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -16412,6 +16471,11 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/hos)
+"HEF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
 "HFX" = (
 /turf/open/floor/plasteel/darkwarning{
 	dir = 4
@@ -16436,12 +16500,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"HKd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/bridge/eva)
 "HMG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16470,6 +16528,16 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"HQu" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF WEAPONS AREA'.";
+	layer = 2.9;
+	name = "KEEP CLEAR OF WEAPONS AREA";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/space)
 "HRt" = (
 /obj/machinery/light{
 	dir = 4
@@ -16594,6 +16662,17 @@
 "Idm" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/division)
+"Ifn" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "Igh" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	tag = "icon-manifold (NORTH)";
@@ -16924,12 +17003,6 @@
 "IWp" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/break_room)
-"IWs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/crew_quarters/hor)
 "JaY" = (
 /obj/machinery/computer/card/minor/hos,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -17031,15 +17104,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"Jqq" = (
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
-/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
-/obj/item/ammo_box/magazine/sniper_rounds/soporific,
-/obj/item/weapon/gun/projectile/automatic/sniper_rifle,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/darkwarning,
-/area/shuttle/ftl/security/armory)
 "JqC" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Tech Storage";
@@ -17363,11 +17427,6 @@
 /obj/item/weapon/kitchen/rollingpin,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"KbF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/hor)
 "KcV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17758,12 +17817,6 @@
 	icon_state = "L11"
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"KVT" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "KWe" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -18544,6 +18597,27 @@
 "MKx" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"MKz" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start{
+	name = "Research Director";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/computer/card/minor/rd,
+/obj/machinery/computer/card/minor/rd,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "MKU" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
@@ -18949,6 +19023,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"NKS" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/xenobiology)
 "NLx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -19028,6 +19106,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
+"NRo" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/landmark/event_spawn,
+/mob/living/simple_animal/slime,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "NRU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -19229,6 +19317,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"Omk" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
 "OmM" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -19499,21 +19593,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/cargo/office)
-"OOy" = (
-/obj/machinery/camera{
-	c_tag = "Mining Equipment";
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/ftl/cargo/mining)
 "OOV" = (
 /turf/open/floor/plasteel/arrival/corner{
 	tag = "icon-arrivalcorner (EAST)";
@@ -19972,27 +20051,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"PMC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"PMN" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/sleep)
 "PNa" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -20332,12 +20390,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/hor)
-"QrS" = (
-/obj/machinery/computer/card/minor/rd,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "QrW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20385,6 +20437,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"QtG" = (
+/obj/machinery/camera{
+	c_tag = "Mining Equipment";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
 "QuA" = (
 /obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/plasteel,
@@ -20411,16 +20479,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"QxP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "Qyh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20510,6 +20568,13 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
+"QHF" = (
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = -30
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "QKR" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/structure/window/reinforced{
@@ -20783,6 +20848,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
+"RtQ" = (
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	network = list("SS13","RD")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "Rui" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21021,6 +21095,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"SaO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "Sbm" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -21181,6 +21263,29 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
+"Stf" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
 "SuQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -22013,6 +22118,20 @@
 	dir = 2
 	},
 /area/shuttle/ftl/medical/surgery)
+"UCZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
 "UES" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -22144,14 +22263,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"UPX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "URL" = (
 /obj/machinery/computer/security,
 /obj/item/device/radio/intercom{
@@ -22419,6 +22530,24 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
+"Vve" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "Research Director";
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "VvI" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/computer/communications{
@@ -22517,19 +22646,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"Vzb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "VzP" = (
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -22595,6 +22711,24 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
+"VDA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/machinery/door/window/southleft{
+	
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "VEP" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/book/manual/barman_recipes,
@@ -22782,21 +22916,6 @@
 "Wel" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/surgery)
-"Wet" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/hor)
 "WfU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -23576,19 +23695,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"XUn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "XWL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/window/reinforced{
@@ -23892,6 +23998,20 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hallway/primary/port)
+"YNf" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	name = "Research Director RC";
+	pixel_x = -2;
+	pixel_y = 30
+	},
+/obj/machinery/suit_storage_unit/rd,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "YNO" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/ftl_wiki/munitions_manual,
@@ -23914,6 +24034,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
+"YPi" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/mob/living/simple_animal/hostile/lizard{
+	desc = "That's Faster-Than-Lizard (13). The Shuttle's lovable Mascot. Eats those pesky cockroaches, too. Bonus!";
+	name = "Faster-Than-Lizard"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
 "YRv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23987,24 +24119,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"YWs" = (
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	network = list("SS13","RD")
-	},
-/obj/machinery/suit_storage_unit/rd,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Research Director's Desk";
-	departmentType = 5;
-	name = "Research Director RC";
-	pixel_x = -2;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "YXj" = (
 /obj/machinery/door/poddoor{
 	id = "supermatter_eject"
@@ -24034,6 +24148,11 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
+"Zby" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/shuttle/ftl/space)
 "ZgC" = (
 /obj/machinery/computer/upload/ai,
 /turf/open/floor/plasteel/circuit,
@@ -44359,10 +44478,10 @@ RaB
 RaB
 gvy
 INT
-gvy
+RaB
 Buo
-PMC
-PMC
+EwJ
+NKS
 EwJ
 mUf
 Yuf
@@ -44616,11 +44735,11 @@ cFF
 lvM
 cPV
 ggB
-Dcp
+HEF
 Geq
-UPX
-yII
-EwJ
+Cjn
+Eyi
+wrr
 KWe
 wLI
 pWc
@@ -44856,8 +44975,8 @@ blk
 Ucg
 Ccb
 vgB
-guL
-GAf
+FRh
+pSN
 PSO
 Ovg
 tyB
@@ -44872,11 +44991,11 @@ cQD
 xzH
 nHm
 mQB
-dQJ
+Omk
 RaB
 RaB
-TTh
-fRl
+Djz
+gHC
 EwJ
 LqC
 scZ
@@ -45393,11 +45512,11 @@ TTh
 tgZ
 EwJ
 dPP
-exb
+fZv
 jIS
 VaT
 dPP
-exb
+gfS
 jIS
 EwJ
 toK
@@ -45911,7 +46030,7 @@ bkD
 bwq
 Gdo
 nEX
-GWF
+eJj
 Xpb
 EwJ
 toK
@@ -46169,7 +46288,7 @@ Mxo
 mOV
 ith
 JIw
-KVT
+BbM
 EwJ
 toK
 toK
@@ -46417,17 +46536,17 @@ hAP
 hLG
 aFw
 RaB
-HhE
+xnE
 Qre
 yyc
 gkC
 fqg
-AEF
+UCZ
 VZR
-xTF
-xTF
-zDD
-Idm
+EwJ
+EwJ
+EwJ
+EwJ
 toK
 toK
 toK
@@ -46674,17 +46793,17 @@ bWC
 wpB
 NZO
 RaB
-HhE
-IWs
-neN
+xnE
+xzn
+cPx
 dzf
-XUn
-ovj
+Vve
+FHA
 fUN
-pgR
-AHv
-kxm
-xTF
+uNy
+QHF
+eJe
+wrr
 toK
 toK
 toK
@@ -46931,17 +47050,17 @@ dnQ
 UyK
 cqd
 RaB
-HhE
 xnE
-YWs
-kFX
-QrS
-Wet
-ynp
-Vzb
-QxP
-GdU
-xTF
+YNf
+RtQ
+MKz
+phh
+faT
+fZa
+VDA
+SaO
+wLI
+wrr
 toK
 toK
 toK
@@ -47188,17 +47307,17 @@ geS
 IyK
 lyO
 RaB
-HhE
 xnE
 oCg
-xDg
-iZp
-Wet
+yxX
+BLc
+Ifn
+EUO
 rnz
-kLD
-FKW
-iKD
-xTF
+mzJ
+vkd
+NRo
+wrr
 toK
 toK
 toK
@@ -47445,17 +47564,17 @@ aOi
 ndH
 WIE
 qFX
-uYM
+Bzo
 xnE
 xnE
 KAG
 xnE
-KbF
+xTF
 TBW
-vtK
-Idm
-Idm
-Idm
+AeT
+EwJ
+EwJ
+EwJ
 toK
 toK
 toK
@@ -47669,7 +47788,7 @@ Zrg
 yda
 Jmd
 xBJ
-AhU
+fCa
 NKg
 xSv
 IWp
@@ -50756,7 +50875,7 @@ sxq
 kJy
 Njc
 BTZ
-smm
+kgR
 tgR
 sWQ
 ULZ
@@ -52545,7 +52664,7 @@ rry
 sqe
 VLJ
 ffQ
-OOy
+QtG
 MKx
 tsU
 SoC
@@ -52802,7 +52921,7 @@ LDH
 rDG
 koy
 ffQ
-PYD
+HzF
 HoD
 YJq
 SoC
@@ -53059,7 +53178,7 @@ PsY
 SxW
 LHD
 Akp
-DCl
+Stf
 oUK
 YJq
 SoC
@@ -54109,7 +54228,7 @@ UXj
 irM
 Isw
 duK
-vuL
+YPi
 edm
 mgL
 tXR
@@ -57682,7 +57801,7 @@ toK
 GYj
 rhJ
 MTL
-Jqq
+uxq
 hmz
 DtJ
 TQd
@@ -59755,27 +59874,27 @@ gYy
 gYy
 gYy
 gYy
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
+Zby
+QKY
+HAv
+EYH
+HQu
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+HQu
+QKY
+Zby
+QKY
+QKY
+QKY
+QKY
 pXc
 EFV
 rVA
@@ -60014,6 +60133,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -60027,8 +60147,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -60271,6 +60390,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -60284,8 +60404,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -60528,6 +60647,7 @@ toK
 toK
 uZs
 toK
+QKY
 toK
 toK
 toK
@@ -60541,8 +60661,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -60785,6 +60904,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -60798,8 +60918,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -61042,6 +61161,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -61055,8 +61175,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -61299,6 +61418,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -61312,8 +61432,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -61556,6 +61675,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -61569,8 +61689,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -61813,6 +61932,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -61826,8 +61946,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -62070,6 +62189,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -62083,8 +62203,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -62327,6 +62446,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -62340,8 +62460,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -62584,6 +62703,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -62597,8 +62717,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -62841,6 +62960,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -62854,8 +62974,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -63098,6 +63217,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -63111,8 +63231,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -63355,6 +63474,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -63368,8 +63488,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -63612,7 +63731,7 @@ toK
 toK
 toK
 toK
-toK
+QKY
 toK
 toK
 toK
@@ -63626,7 +63745,7 @@ toK
 toK
 toK
 uZs
-toK
+QKY
 toK
 toK
 toK
@@ -63869,6 +63988,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -63882,8 +64002,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -64126,6 +64245,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -64139,8 +64259,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -64156,8 +64275,8 @@ GkJ
 kat
 wlA
 Lpy
-Lpy
-PMN
+vaT
+qbo
 qgT
 yZl
 FeJ
@@ -64383,6 +64502,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -64396,8 +64516,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -64640,6 +64759,7 @@ toK
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -64653,8 +64773,7 @@ toK
 toK
 toK
 toK
-toK
-toK
+QKY
 toK
 toK
 toK
@@ -64671,7 +64790,7 @@ Ogq
 rJN
 Tpi
 Tpi
-xvp
+mfa
 SRq
 JGZ
 QXd
@@ -64897,6 +65016,7 @@ uZs
 toK
 toK
 toK
+QKY
 toK
 toK
 toK
@@ -64910,10 +65030,9 @@ toK
 toK
 toK
 toK
-toK
-toK
-toK
-toK
+QKY
+QKY
+BBw
 toK
 toK
 Uux
@@ -64928,7 +65047,7 @@ Xjg
 DjW
 ffa
 ffa
-HKd
+cCk
 kmh
 kgt
 QXd
@@ -65148,31 +65267,31 @@ YJU
 mnO
 Bpe
 jqx
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
-toK
+QKY
+QKY
+QKY
+QKY
+QKY
+QKY
+HAv
+EYH
+wgr
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+BBw
+HQu
+QKY
+QKY
+QKY
+QKY
+QKY
+QKY
 Uux
 hup
 Mii


### PR DESCRIPTION
:cl:Pascal125
Replaces Schrodinger from the bridge with Faster-Than-Lizard (13). Our lovable mascot. 

Adds description to Faster-Than-Lizard (13) "That's Faster-Than-Lizard (13). The Shuttle's lovable Mascot... Eats those pesky cockroaches, too. Bonus!"

Adds an Autodrobe and Clothesmate to the Sleep Room, replacing two Personal Lockers.

Adds an Athletic mixed locker to the EVA Hangar.

Adds an extra Tranquilizer Magazine to the Armory for the Sniper Rifle

Adds a Light Replacer to the table in the Engineering Foyer and Custodial Closet

Added two racks to the "Mining Equipment" room. One containing three Hardsuit Jetpack upgrades, the other containing Three Magboots.

Adds a Grille and Catwalk combination to the space outside of the bridge, indicating the potential weapons area's of the ships Phase Cannon(s)/MAC Cannon

Moved the RD's office around slightly, making room for an extra slime pen, moved the biohazard suit, plasma, and all-in-one grinder to Xenobiology. Added a grey baby slime to the new pen. Not perfect, but it should serve it's purpose... Might need a bit of tweaking at a later date.

Added a very small Xenobiology slime "Killpen" to Xenobiology.
/:cl:
