### PR TITLE
Power nerf nerf

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -12,7 +12,7 @@
 	throw_range = 5
 	w_class = 2
 	var/charge = 0	// note %age conveted to actual charge in New
-	var/maxcharge = 10000
+	var/maxcharge = 2000
 	materials = list(MAT_METAL=700, MAT_GLASS=50)
 	var/rigged = 0		// true if rigged to explode
 	var/chargerate = 100 //how much power is given every tick in a (weapon)recharger
@@ -196,17 +196,17 @@
 	name = "high-capacity power cell"
 	origin_tech = "powerstorage=2"
 	icon_state = "hcell"
-	maxcharge = 12500
+	maxcharge = 2500
 	materials = list(MAT_GLASS=60)
 	rating = 3
-	chargerate = 1250
+	chargerate = 500
 
 /obj/item/weapon/stock_parts/cell/high/plus
 	name = "high-capacity power cell+"
 	desc = "Where did these come from?"
 	icon_state = "h+cell"
-	maxcharge = 13000
-	chargerate = 2250
+	maxcharge = 4500
+	chargerate = 900
 
 /obj/item/weapon/stock_parts/cell/high/empty/New()
 	..()
@@ -216,10 +216,10 @@
 	name = "super-capacity power cell"
 	origin_tech = "powerstorage=3;materials=3"
 	icon_state = "scell"
-	maxcharge = 15000
+	maxcharge = 3000
 	materials = list(MAT_GLASS=300)
 	rating = 4
-	chargerate = 2500
+	chargerate = 600
 
 /obj/item/weapon/stock_parts/cell/super/empty/New()
 	..()
@@ -229,10 +229,10 @@
 	name = "hyper-capacity power cell"
 	origin_tech = "powerstorage=4;engineering=4;materials=4"
 	icon_state = "hpcell"
-	maxcharge = 17500
+	maxcharge = 3500
 	materials = list(MAT_GLASS=400)
 	rating = 5
-	chargerate = 2750
+	chargerate = 700
 
 /obj/item/weapon/stock_parts/cell/hyper/empty/New()
 	..()
@@ -243,10 +243,10 @@
 	desc = "A rechargable transdimensional power cell."
 	origin_tech = "powerstorage=5;bluespace=4;materials=4;engineering=4"
 	icon_state = "bscell"
-	maxcharge = 22500
+	maxcharge = 4500
 	materials = list(MAT_GLASS=600)
 	rating = 6
-	chargerate = 3000
+	chargerate = 900
 
 /obj/item/weapon/stock_parts/cell/bluespace/empty/New()
 	..()

--- a/code/modules/power/phase_cannon.dm
+++ b/code/modules/power/phase_cannon.dm
@@ -9,7 +9,7 @@
 	anchored = 0
 	density = 1
 	var/obj/item/weapon/stock_parts/cell/cell
-	var/charge_rate = 30000
+	var/charge_rate = 60000
 	var/charge_per_shot = 400
 
 	var/state = 0

--- a/code/modules/power/phase_cannon.dm
+++ b/code/modules/power/phase_cannon.dm
@@ -10,6 +10,7 @@
 	density = 1
 	var/obj/item/weapon/stock_parts/cell/cell
 	var/charge_rate = 30000
+	var/charge_per_shot = 400
 
 	var/state = 0
 	var/locked = 0
@@ -54,12 +55,12 @@
 /obj/machinery/power/shipweapon/proc/can_fire()
 	if(state != 2)
 		return 0
-	return cell.charge >= 2000
+	return cell.charge >= charge_per_shot
 
 /obj/machinery/power/shipweapon/proc/attempt_fire(var/datum/component/target_component)
 	if(!can_fire())
 		return 0
-	cell.use(2000)
+	cell.use(charge_per_shot)
 
 	var/obj/item/projectile/ship_projectile/A = PoolOrNew(projectile_type,src.loc)
 


### PR DESCRIPTION
Cell charge is doubled of their base capacity.
Phase cannons use double their old shot charge.
Phase cannons' charge per shot is now also a variable.


:cl: EvilJackCarver
tweak: nerfed the power nerf by 80%
/:cl:
