### PR TITLE
Removes safety check from firelocks

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -18,6 +18,7 @@
 	glass = 1
 	var/nextstate = null
 	sub_door = 1
+	safe = FALSE
 	closingLayer = CLOSED_FIREDOOR_LAYER
 	assemblytype = /obj/structure/firelock_frame
 


### PR DESCRIPTION
:cl: EvilJackCarver
del: Removes safety check from firelocks
/:cl:

Theoretically should cause firelocks to close over the windows, but I don't know well it'd work in practice (if at all)