### PR TITLE
revert+movement

### DIFF
--- a/_maps/map_files/Trailblazer/Trailblazer.dmm
+++ b/_maps/map_files/Trailblazer/Trailblazer.dmm
@@ -4212,6 +4212,26 @@
 	dir = 4
 	},
 /area/shuttle/ftl/security/main)
+"iFV" = (
+/obj/structure/safe,
+/obj/item/clothing/head/bearpelt,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/weapon/gun/projectile/revolver/russian,
+/obj/item/ammo_box/a357,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Vault";
+	dir = 10
+	},
+/obj/item/weapon/card/emag,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "iGS" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/whiteblue/side{
@@ -22807,25 +22827,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
-"XsG" = (
-/obj/structure/safe,
-/obj/item/clothing/head/bearpelt,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/weapon/gun/projectile/revolver/russian,
-/obj/item/ammo_box/a357,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Vault";
-	dir = 10
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/nuke_storage)
 "Xup" = (
 /obj/machinery/computer/aifixer,
 /obj/structure/cable{
@@ -58872,7 +58873,7 @@ GZC
 LdK
 ijc
 ueH
-XsG
+iFV
 LdK
 GZC
 sme

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -246,7 +246,7 @@
 			/obj/item/weapon/grenade/clusterbuster = 1,
 			/obj/item/weapon/gun/medbeam = 1,
 			/obj/item/weapon/gun/energy/floragun = 2,
-			/obj/item/weapon/card/emag = 1,
+			/obj/item/weapon/gun/energy/pulse = 3,
 			/obj/item/weapon/gun/magic/staff/honk = 1,
 			/obj/item/weapon/gun/projectile/shotgun/automatic/combat = 1,
 			/obj/item/weapon/gun/projectile/revolver/golden = 1,


### PR DESCRIPTION
:cl: hits
add: emag to safe, is kept there for safety reasons
revert: #106 
/:cl:
i did this, due to the results of the player polls i ran last night, and the fact that it being set to "1" along with 50 million other things, which makes acquiring it downright an impossibility, due to how current rounds are playing out.
also, notice how i allowed edits from maintainers.
if you want to toy with the pulse rifle chances in this pr, go ahead.