### PR TITLE
Another Basilisk update

### DIFF
--- a/_maps/map_files/Trailblazer/Trailblazer.dmm
+++ b/_maps/map_files/Trailblazer/Trailblazer.dmm
@@ -8,24 +8,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/fore)
-"abC" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "ace" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/black,
@@ -76,20 +58,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"aea" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
 "agv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -195,6 +163,17 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"aqk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "aqq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -306,6 +285,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/starboard)
+"axG" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "axL" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4;
@@ -330,25 +315,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"aDP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"aDL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/crew_quarters/locker)
-"aGe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (SOUTHEAST)";
-	icon_state = "whiteblue";
-	dir = 6
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
 	},
-/area/shuttle/ftl/medical/medbay)
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "aGg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -364,24 +345,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/cargo/mining)
-"aKg" = (
-/obj/machinery/nuclearbomb/selfdestruct,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 1
-	},
-/area/shuttle/ftl/security/nuke_storage)
 "aLZ" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -419,6 +382,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
+"aRb" = (
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "aRR" = (
 /obj/structure/table,
 /obj/item/weapon/crowbar,
@@ -427,17 +402,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/yellow,
 /area/shuttle/ftl/engine/tool_storage)
-"aSC" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/research/server)
 "aTh" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -524,6 +488,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"aZY" = (
+/obj/machinery/camera{
+	c_tag = "Tool Storage";
+	dir = 1
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
 "baI" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -533,6 +507,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
+"bbQ" = (
+/obj/machinery/porta_turret_cover,
+/obj/machinery/porta_turret/ai{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai)
 "bbS" = (
 /obj/effect/landmark/start{
 	name = "Botanist";
@@ -763,6 +750,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/cmo)
+"bvB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/ftl/assembly/robotics)
 "bvC" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/hallway/primary/port)
@@ -814,6 +805,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/medbay)
+"bBb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/office)
 "bBd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -836,22 +837,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"bEs" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
 "bJs" = (
 /obj/machinery/meter,
 /obj/structure/window/reinforced,
@@ -887,21 +872,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
-"bRz" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (SOUTHWEST)";
-	icon_state = "whiteblue";
-	dir = 10
-	},
-/area/shuttle/ftl/medical/medbay)
 "bSy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -930,6 +900,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
+"bVB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/bar)
 "bVR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -1055,6 +1032,18 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"cba" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "cbF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -1107,6 +1096,16 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"cfG" = (
+/obj/structure/sign/directions/evac{
+	dir = 1
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall/rust,
+/area/shuttle/ftl/security/armory)
 "cgo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -1140,6 +1139,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/telecomms/server)
+"cju" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/shuttle/red,
+/area/shuttle/ftl/subshuttle/pod_3)
 "cjN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1289,6 +1304,17 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
+"csS" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "cti" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1370,6 +1396,21 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"cGF" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTHWEST)";
+	icon_state = "whiteblue";
+	dir = 9
+	},
+/area/shuttle/ftl/medical/medbay)
 "cHM" = (
 /obj/effect/landmark/start{
 	name = "Botanist";
@@ -1471,17 +1512,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"cVa" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
 "cVx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1495,34 +1525,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
-"cWh" = (
-/obj/structure/table/glass,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/weapon/storage/box/syringes{
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 10
-	},
-/area/shuttle/ftl/medical/chemistry)
 "cWq" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1562,6 +1564,30 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/security/nuke_storage)
+"dcH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay doors.";
+	id = "medbay_r";
+	name = "Medbay Exit Button";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/whiteblue/corner{
+	tag = "icon-whitebluecorner (EAST)";
+	icon_state = "whitebluecorner";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay)
 "dcI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -1604,32 +1630,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"dkv" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/monkeycubes{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/structure/reagent_dispensers/virusfood{
-	density = 0;
-	pixel_x = -1;
-	pixel_y = -30
-	},
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/pen/red,
-/obj/item/weapon/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "dld" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /obj/effect/decal/cleanable/dirt,
@@ -1733,19 +1733,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"doi" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "doq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -1785,18 +1772,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"dpM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/pet/cat/Runtime,
-/turf/open/floor/wood,
-/area/shuttle/ftl/medical/cmo)
 "dre" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -1879,16 +1854,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"dyf" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
-	},
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/assembly/robotics)
 "dyh" = (
 /obj/item/device/analyzer,
 /obj/item/device/healthanalyzer{
@@ -1984,17 +1949,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"dIm" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
 "dJp" = (
 /obj/machinery/ammo_rack/full/smart_homing,
 /obj/effect/decal/cleanable/dirt,
@@ -2006,21 +1960,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"dKd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (NORTH)";
-	icon_state = "whiteblue";
-	dir = 1
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
 "dLc" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	tag = "icon-manifold (NORTH)";
@@ -2030,24 +1969,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"dOA" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/weapon/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/weapon/storage/lockbox/loyalty,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
 "dPR" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/bridge)
@@ -2112,6 +2033,36 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
+"ecS" = (
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/item/weapon/storage/box/pillbottles,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/chemistry)
 "eeE" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/effect/decal/cleanable/dirt,
@@ -2190,6 +2141,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
+"emP" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/weapon/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/weapon/storage/lockbox/loyalty,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "emY" = (
 /obj/machinery/conveyor_switch{
 	id = "CargoMunitions"
@@ -2251,15 +2219,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"etk" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
 "etS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2338,17 +2297,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"eyv" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai)
-"eyy" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/crew_quarters/locker)
 "eAF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2422,6 +2370,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
+"eIo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "eJj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenence Hatch";
@@ -2446,18 +2408,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"eKR" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/suit_storage_unit/rd,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/hor)
 "eLe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2579,14 +2529,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
-"eQs" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/janitor)
 "eQt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2674,6 +2616,9 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/eva)
+"few" = (
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/locker)
 "ffs" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/office)
@@ -2720,19 +2665,14 @@
 "fjt" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"fjV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "fka" = (
 /obj/structure/chair,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"fln" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai_upload)
 "fmR" = (
 /obj/structure/chair{
 	dir = 4
@@ -2774,6 +2714,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
+"foI" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "frF" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/medbay)
@@ -2794,6 +2742,27 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/brig)
+"ftj" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/masks{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
 "fvF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -2873,6 +2842,15 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
+"fCS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
 "fCZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -3004,6 +2982,19 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"fMG" = (
+/obj/structure/table/glass,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
 "fNe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3027,13 +3018,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"fOL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/fore)
 "fPW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3071,19 +3055,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"fSA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "fTJ" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -3174,18 +3145,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"fZy" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/shuttle/ftl/telecomms/server)
 "fZS" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3256,32 +3215,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
-"gcd" = (
-/obj/structure/rack,
-/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
-	pixel_x = 2;
-	pixel_y = 9
-	},
-/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
-	pixel_x = 0;
-	pixel_y = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
 "gcK" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3335,16 +3268,6 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"glp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/shuttle/ftl/research/division)
 "glv" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -3388,6 +3311,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
+"gos" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/hor)
 "goE" = (
 /obj/structure/rack{
 	dir = 8;
@@ -3521,6 +3453,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
+"gCb" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	tag = "icon-pump_map (EAST)";
+	icon_state = "pump_map";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "gCF" = (
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
@@ -3570,27 +3512,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"gEm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "gEH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -3609,18 +3530,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"gHe" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "gHo" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/o2{
@@ -3734,12 +3643,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"gPT" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/mob/living/simple_animal/slime,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "gQY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
+"gRr" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
 "gSU" = (
@@ -3894,6 +3823,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"hhr" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/weapon/shovel/spade,
+/obj/item/weapon/wrench,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/green/side,
+/area/shuttle/ftl/hydroponics)
 "hhR" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -3908,6 +3846,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos/equipment)
+"hin" = (
+/obj/structure/tank_dispenser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "hiO" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/weapon/storage/toolbox/mechanical{
@@ -3963,15 +3906,6 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"hqF" = (
-/obj/structure/closet/secure_closet/hop,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "hqO" = (
 /obj/effect/landmark/start{
 	name = "Cyborg";
@@ -3994,23 +3928,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"hrH" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8;
-	filter_type = "plasma";
-	on = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering North";
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (SOUTHWEST)";
-	icon_state = "darkblue";
-	dir = 10
-	},
-/area/shuttle/ftl/engine/engine_smes)
 "hrJ" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/item/device/camera/detective,
@@ -4049,13 +3966,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"hsY" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/gravity_generator)
 "hub" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4069,16 +3979,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"huV" = (
-/obj/structure/closet/wardrobe/botanist,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side{
-	dir = 1
-	},
-/area/shuttle/ftl/hydroponics)
 "hvy" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/decal/cleanable/dirt,
@@ -4129,6 +4029,17 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"hCn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "hCA" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/server)
@@ -4159,6 +4070,16 @@
 	},
 /turf/open/floor/plasteel/darkyellow,
 /area/shuttle/ftl/engine/tool_storage)
+"hDn" = (
+/obj/structure/sign/directions/engineering{
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall/rust,
+/area/shuttle/ftl/hallway/primary/fore)
 "hDv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
@@ -4226,6 +4147,18 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
+"hJQ" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 1
+	},
+/area/shuttle/ftl/hydroponics)
 "hOS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4277,20 +4210,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"hVz" = (
-/obj/machinery/camera{
-	c_tag = "R&D Server Room";
-	name = "security camera";
-	network = list("SS13","RD")
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 2;
-	on = 1;
-	target_temperature = 80
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/research/server)
 "hXz" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/electrical,
@@ -4378,15 +4297,14 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"ifP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay)
+"iek" = (
+/obj/structure/table/wood,
+/obj/item/device/taperecorder,
+/obj/item/weapon/storage/briefcase,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "igx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4438,6 +4356,31 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/loading)
+"ijL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Research and Development";
+	dir = 8;
+	name = "security camera";
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
 "ijO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4481,6 +4424,16 @@
 	},
 /turf/open/floor/plasteel/darkyellow,
 /area/shuttle/ftl/engine/tool_storage)
+"inK" = (
+/obj/machinery/computer/telecomms/server{
+	network = "tcommsat"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/telecomms/computer)
 "ios" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4552,18 +4505,6 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"ixz" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
 "ixJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4575,6 +4516,15 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"iyj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "iyk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	tag = "icon-intact (NORTH)";
@@ -4611,6 +4561,16 @@
 	},
 /turf/open/floor/plasteel/warnwhite,
 /area/shuttle/ftl/research/lab)
+"iFd" = (
+/obj/machinery/vending/snack,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "iFp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -4659,6 +4619,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
+"iJj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	tag = "icon-manifold (EAST)";
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "iKr" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -4691,6 +4660,31 @@
 	},
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/turret_protected/ai_upload)
+"iOj" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
+"iPh" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/xenobiology)
 "iPT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -4818,14 +4812,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"jgg" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/hydroponics)
 "jgM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4992,6 +4978,25 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
+"jvr" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/fancy/donut_box,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "jvV" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -5005,14 +5010,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
-"jwi" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/munitions/office)
 "jxC" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/captain)
@@ -5108,14 +5105,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"jMN" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/security/detectives_office)
 "jNA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -5197,14 +5186,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"jXK" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "jXL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -5297,6 +5278,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
+"kcn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "kcx" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/medical,
@@ -5333,6 +5321,17 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"kjJ" = (
+/obj/structure/table/wood,
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "kkD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5353,14 +5352,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/research/lab)
-"klM" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/crew_quarters/captain)
 "kqs" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -5376,6 +5367,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"krd" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "ksn" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -5428,20 +5429,6 @@
 "kAI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
-"kBK" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics West";
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
@@ -5512,6 +5499,22 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
+"kIk" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/office)
+"kIB" = (
+/obj/structure/closet/wardrobe/botanist,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/green/side{
+	dir = 1
+	},
+/area/shuttle/ftl/hydroponics)
 "kIQ" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -5754,19 +5757,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/cmo)
-"lpp" = (
-/obj/structure/disposaloutlet{
-	dir = 4;
-	name = "Corpse dispenser"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
 "lqj" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -5904,6 +5894,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"lzB" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "o2_sensor"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine/o2,
+/area/shuttle/ftl/atmos)
 "lzS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -5978,6 +5980,15 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
+"lKe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
 "lLV" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/storage)
@@ -6128,21 +6139,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"mdN" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 38
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
 "meI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
@@ -6202,14 +6198,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"mja" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
 "mjh" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -6237,6 +6225,23 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/cargo/office)
+"mlW" = (
+/obj/machinery/suit_storage_unit/rd,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/hor)
 "mmp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -6384,11 +6389,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"msu" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai)
 "msE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6398,14 +6398,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
-"mtt" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/main)
 "mtE" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -6430,18 +6422,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"mBl" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side{
-	tag = "icon-green (SOUTHWEST)";
-	icon_state = "green";
-	dir = 10
-	},
-/area/shuttle/ftl/hydroponics)
 "mCq" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/structure/disposalpipe/segment{
@@ -6470,17 +6450,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"mDB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/secure_construction)
 "mFr" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6534,6 +6503,23 @@
 	},
 /turf/open/floor/engine/o2,
 /area/shuttle/ftl/atmos)
+"mJg" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "mJy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6724,23 +6710,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"nbp" = (
-/obj/machinery/iv_drip,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/surgery)
 "nbO" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
@@ -6797,6 +6766,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"ngT" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "munitions";
+	tag = "munitions east"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
 "nhp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6971,14 +6960,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"nwF" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/gravity_generator)
 "nwO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7067,6 +7048,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
+"nNs" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
 "nOc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -7150,14 +7141,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"ogb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "ohL" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
@@ -7181,14 +7164,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"okq" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/chiefs_office)
 "olz" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -7337,41 +7312,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"oCo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+"oyO" = (
+/obj/structure/closet/secure_closet/captains,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
+/obj/machinery/light/small,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = -32
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "oCV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"oCX" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/weapon/electronics/airlock,
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
 "oDt" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel{
@@ -7472,6 +7428,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"oUm" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/machinery/airalarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
 "oWI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -7534,6 +7509,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"pbo" = (
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 36
+	},
+/obj/machinery/button/door{
+	id = "munitions";
+	name = "Munitions Lockdown";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "43"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/office)
 "pel" = (
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
@@ -7553,19 +7553,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"pgm" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay)
 "pgp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -7727,17 +7714,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/sleeper)
+"pvs" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 8;
+	filter_type = "plasma";
+	on = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering North";
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (SOUTHWEST)";
+	icon_state = "darkblue";
+	dir = 10
+	},
+/area/shuttle/ftl/engine/engine_smes)
 "pwo" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/cargo)
-"pwu" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai_upload)
 "pwP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7939,6 +7936,13 @@
 	},
 /turf/open/floor/engine/air,
 /area/shuttle/ftl/atmos)
+"pMW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "pNg" = (
 /obj/machinery/conveyor{
 	id = "QMLoad";
@@ -7950,21 +7954,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
-"pPF" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"pRM" = (
+/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
 /turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
+/area/shuttle/ftl/bridge/meeting_room)
 "pSv" = (
 /obj/structure/shuttle/engine/propulsion/burst/right,
 /obj/structure/window/reinforced{
@@ -8021,15 +8016,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"qaZ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side{
-	tag = "icon-green (WEST)";
-	icon_state = "green";
-	dir = 8
-	},
-/area/shuttle/ftl/hydroponics)
 "qbb" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -8050,17 +8036,6 @@
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"qcQ" = (
-/obj/machinery/camera{
-	c_tag = "Research Division South";
-	dir = 8;
-	name = "security camera";
-	network = list("SS13","RD")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "qfA" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -8079,11 +8054,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"qiS" = (
-/obj/machinery/light,
+"qjb" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
+/obj/machinery/light,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/assembly/robotics)
 "qjU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -8107,22 +8089,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"qlV" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
 "qnP" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32;
@@ -8145,6 +8111,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/fore)
+"qoh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "qrp" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -8184,22 +8164,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"qsB" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_x = 30;
-	pixel_y = 4
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "qsP" = (
 /obj/structure/rack{
 	dir = 8;
@@ -8234,14 +8198,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
-"qyx" = (
-/obj/structure/tank_dispenser,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
 "qyU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen";
@@ -8313,18 +8269,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"qFT" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/central)
-"qIo" = (
-/obj/machinery/pdapainter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "qIA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -8347,18 +8291,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"qJi" = (
-/obj/structure/table/reinforced,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
 "qKP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
@@ -8564,6 +8496,19 @@
 "qVj" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/bridge)
+"qVk" = (
+/obj/structure/cryofeed/right,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/ftl/medical/sleeper)
 "qVR" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -8621,6 +8566,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
+"qZl" = (
+/obj/structure/disposaloutlet{
+	dir = 4;
+	name = "Corpse dispenser"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
 "rai" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
@@ -8831,11 +8793,17 @@
 	dir = 5
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"rts" = (
-/obj/machinery/vending/cola,
-/obj/effect/decal/cleanable/dirt,
+"rtr" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
+/area/shuttle/ftl/crew_quarters/captain)
 "rvu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -9288,16 +9256,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue/side,
 /area/shuttle/ftl/hallway/primary/fore)
-"siE" = (
-/obj/machinery/porta_turret_cover,
-/obj/machinery/porta_turret/ai{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai)
 "siL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
@@ -9337,6 +9295,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"skt" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/partyalarm{
+	desc = "Cuban Pete is in the house! (Mapper note: If you are prone to seizures and you press this, you might be in for a gnarly ride.)";
+	name = "\improper bridge party button";
+	pixel_y = 24
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "skF" = (
 /obj/structure/sink{
 	dir = 4;
@@ -9572,21 +9551,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/detectives_office)
-"sxZ" = (
-/obj/structure/table,
-/obj/item/weapon/wrench,
-/obj/item/weapon/crowbar,
-/obj/item/device/multitool,
-/obj/item/weapon/book/manual/ftl_wiki/munitions_manual,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Munitions East"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/loading)
 "sBd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -9621,6 +9585,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"sCY" = (
+/obj/structure/table/glass,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/stock_parts/scanning_module,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
 "sDC" = (
 /obj/machinery/blackbox_recorder,
 /obj/effect/decal/cleanable/dirt,
@@ -9633,20 +9615,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"sEO" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/shuttle/ftl/telecomms/server)
 "sFn" = (
 /obj/machinery/autolathe,
 /obj/machinery/light{
@@ -9665,6 +9633,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
+"sKa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "sKE" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/storage)
@@ -9829,27 +9809,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/starboard)
-"sXd" = (
-/obj/structure/table/wood,
-/obj/item/weapon/storage/box/matches,
-/obj/item/clothing/mask/cigarette/cigar,
-/obj/item/weapon/reagent_containers/food/drinks/flask/gold,
-/obj/item/device/radio/intercom{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
-"sYE" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/assembly/robotics)
 "sYO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
@@ -9871,6 +9830,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"sZx" = (
+/obj/structure/sign/directions/engineering{
+	dir = 1
+	},
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"sZP" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "tai" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -9892,6 +9871,28 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"tbh" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/monkeycubes{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/reagent_dispensers/virusfood{
+	density = 0;
+	pixel_x = -1;
+	pixel_y = -30
+	},
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/pen/red,
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "tbp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9923,6 +9924,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"tdv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
 "tfm" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white{
@@ -10028,6 +10040,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"tnm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/circuit/rcircuit/animated,
+/area/shuttle/ftl/turret_protected/ai)
 "tpz" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/crew_quarters/captain)
@@ -10416,14 +10433,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/central)
-"ujD" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/cargo/mining)
 "uko" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -10437,6 +10446,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"uln" = (
+/obj/machinery/vending/cola,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "umz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -10536,6 +10553,18 @@
 	},
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/cargo/office)
+"uAB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bridge)
 "uAC" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel{
@@ -10576,6 +10605,13 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"uIa" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge/meeting_room)
 "uKb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10586,6 +10622,32 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"uKx" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"uKG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHEAST)";
+	icon_state = "whiteblue";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/medbay)
 "uKJ" = (
 /obj/structure/spacepoddoor{
 	dir = 8
@@ -10600,15 +10662,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"uSh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/munitions/loading)
 "uSW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10700,6 +10753,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"vdT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "veG" = (
 /obj/effect/decal/cleanable/oil,
 /mob/living/simple_animal/bot/floorbot,
@@ -10824,6 +10889,16 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"vuE" = (
+/obj/structure/sign/directions/evac{
+	dir = 8
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/primary/port)
 "vuS" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
@@ -10878,6 +10953,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"vxp" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "vxM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10930,21 +11016,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"vAb" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
 "vAq" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -11036,16 +11107,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"vLD" = (
-/obj/machinery/computer/med_data,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
 "vMb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11177,21 +11238,6 @@
 "wcS" = (
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"wdJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
-"wez" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/genetics)
 "wfh" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/fire,
@@ -11247,6 +11293,17 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"wim" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "medbay_l";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/whiteblue,
+/area/shuttle/ftl/medical/medbay_lobby)
 "wiF" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/decal/cleanable/dirt,
@@ -11418,6 +11475,15 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"wtz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "wuq" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -11460,16 +11526,15 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"wxl" = (
-/obj/structure/window/reinforced{
+"wwU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	busy = 0;
+	c_tag = "Robotics";
 	dir = 8
 	},
-/obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_3)
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/assembly/robotics)
 "wyj" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11488,6 +11553,26 @@
 "wyM" = (
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
+"wzz" = (
+/obj/machinery/processor{
+	desc = "A machine used to process slimes and retrieve their extract.";
+	name = "Slime Processor"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab west";
+	dir = 10;
+	name = "security camera";
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "wAg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -11504,6 +11589,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"wBc" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "wCn" = (
 /obj/machinery/door/window/brigdoor{
 	id = "Cell 2";
@@ -11525,6 +11621,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"wGa" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/medical,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
 "wGH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -11626,18 +11735,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"wSd" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (NORTH)";
-	icon_state = "whiteblue";
-	dir = 1
-	},
-/area/shuttle/ftl/medical/medbay)
 "wSr" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
@@ -11741,21 +11838,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"xaW" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/partyalarm{
-	desc = "Cuban Pete is in the house! (Mapper note: If you are prone to seizures and you press this, you might be in for a gnarly ride.)";
-	name = "\improper bridge party button";
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
 "xcF" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel{
@@ -11951,6 +12033,12 @@
 	dir = 5
 	},
 /area/shuttle/ftl/security/nuke_storage)
+"xwR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "xxg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12000,14 +12088,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
-"xDk" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/hallway/primary/fore)
 "xDF" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintanence Hatch";
@@ -12020,16 +12100,21 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"xEx" = (
-/obj/machinery/light{
-	dir = 1
+"xFP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "xFU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12137,18 +12222,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"xMF" = (
-/obj/machinery/vending/cart,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "HoP Office";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "xOD" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -12203,6 +12276,17 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"xRO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/main)
 "xRQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12240,6 +12324,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"xWI" = (
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/weapon/storage/fancy/cigarettes,
+/obj/item/weapon/storage/box/evidence,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "xXk" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -12261,6 +12353,23 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"yaW" = (
+/obj/machinery/vending/cart,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "HoP Office";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "ybQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
@@ -12279,15 +12388,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"ybV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/munitions/office)
 "ydL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -12302,6 +12402,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
+"yhp" = (
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	pixel_y = -32
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
 "yhF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12326,15 +12441,36 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"ynn" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
+"ymg" = (
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side{
+/obj/structure/chair,
+/obj/machinery/light{
 	dir = 1
 	},
-/area/shuttle/ftl/hydroponics)
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/shuttle/white,
+/area/shuttle/ftl/subshuttle/pod_3)
+"ymE" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "medbay_r";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/whiteblue,
+/area/shuttle/ftl/medical/medbay_lobby)
 "ynt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12378,20 +12514,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"ysD" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
 "yuQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12437,17 +12559,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"yxr" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/shuttle{
-	icon_state = "swall12";
-	dir = 2
-	},
-/area/shuttle/ftl/subshuttle/pod_3)
 "yys" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch{
@@ -12542,6 +12653,16 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
+"yDw" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "yDB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12552,6 +12673,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
+"yEE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "yFF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -12619,23 +12747,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"yQT" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
-/area/shuttle/ftl/crew_quarters/kitchen)
-"ySS" = (
-/obj/machinery/light,
-/obj/structure/table/glass,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
 "yTo" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/door/firedoor,
@@ -12956,14 +13067,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"zBL" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/security/main)
 "zCr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch{
@@ -12978,22 +13081,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"zCW" = (
-/obj/structure/cryofeed/right,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/medical/sleeper)
-"zDo" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = -31
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "zFg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology{
@@ -13030,14 +13117,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"zNu" = (
+"zLt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
+	pixel_x = 32;
 	pixel_y = 0
 	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/munitions)
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "zNV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -13180,6 +13277,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
+"zXV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/telecomms/computer)
 "zYk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -13283,33 +13393,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
-"AhO" = (
-/obj/machinery/status_display,
-/obj/structure/disposalpipe/segment{
+"Akr" = (
+/obj/structure/sign/directions/engineering{
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall/rust,
+/area/shuttle/ftl/security/armory)
+"AlM" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/shuttle/ftl/crew_quarters/bar)
-"Aie" = (
-/obj/machinery/processor{
-	desc = "A machine used to process slimes and retrieve their extract.";
-	name = "Slime Processor"
-	},
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab west";
-	dir = 10;
-	name = "security camera";
-	network = list("SS13","RD")
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "AmI" = (
 /obj/structure/window/reinforced,
 /mob/living/carbon/monkey,
@@ -13388,6 +13488,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"AtA" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "AtZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13531,6 +13637,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"AER" = (
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay doors.";
+	id = "medbay_r";
+	name = "Medbay Exit Button";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = 24;
+	req_access_txt = "1"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/virology)
 "AFc" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -13596,20 +13714,28 @@
 "AKO" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
+"AMa" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/box/matches,
+/obj/item/clothing/mask/cigarette/cigar,
+/obj/item/weapon/reagent_containers/food/drinks/flask/gold,
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "AMA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hydroponics)
-"AML" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/weapon/shovel/spade,
-/obj/item/weapon/wrench,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side,
 /area/shuttle/ftl/hydroponics)
 "AOf" = (
 /turf/open/floor/engine,
@@ -13653,6 +13779,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/heads)
+"AVp" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "AWa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13719,6 +13852,14 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"AYj" = (
+/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
 "AZq" = (
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/telecomms/computer)
@@ -13796,16 +13937,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"BeD" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
 "BeI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13817,12 +13948,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
-"Bjc" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/gravity_generator)
 "Bjp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -13846,14 +13971,6 @@
 "Bjq" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/maintenance/bridge)
-"Bjw" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/armory)
 "Bkr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13862,14 +13979,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"BkF" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/atmos/equipment)
 "BkZ" = (
 /obj/spacepod{
 	dir = 1
@@ -13905,6 +14014,18 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
+"BuZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "Bxj" = (
 /obj/machinery/computer/card/minor/ce,
 /obj/effect/decal/cleanable/dirt,
@@ -13941,6 +14062,14 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/security/nuke_storage)
+"BCf" = (
+/obj/machinery/pdapainter,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "BCO" = (
 /obj/structure/closet/wardrobe/robotics_black,
 /obj/item/device/radio/headset/headset_sci{
@@ -13963,33 +14092,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"BFC" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/cloning{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/weapon/circuitboard/computer/med_data{
-	pixel_x = 3;
-	pixel_y = -3;
-	pixel_z = 0
-	},
-/obj/item/weapon/circuitboard/machine/clonescanner{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/machine/clonepod,
-/obj/item/weapon/circuitboard/computer/scan_consolenew{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
 "BHm" = (
 /obj/structure/table,
 /obj/item/weapon/grenade/chem_grenade/cleaner,
@@ -14023,15 +14125,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/meeting_room)
-"BOL" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "BRp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14052,6 +14145,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
+"BTy" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
 "BUb" = (
 /obj/structure/disposalpipe/junction,
 /obj/structure/cable{
@@ -14173,6 +14272,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
+"Cmy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	name = "RnD Desk";
+	req_access_txt = "0"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/obj/machinery/door/window/eastright{
+	name = "RnD Desk";
+	req_access_txt = "26"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/lab)
 "CnE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14204,6 +14320,17 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"Cpd" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "CpP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/rdconsole/core,
@@ -14212,6 +14339,13 @@
 "Cqj" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/disposal)
+"Crk" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "CtK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
@@ -14221,6 +14355,13 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"CtT" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "CuE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel/black,
@@ -14271,18 +14412,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
-"Czf" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp/green,
-/obj/item/weapon/hand_labeler{
-	pixel_x = 5
+"CAe" = (
+/obj/machinery/camera{
+	c_tag = "Research Division South";
+	dir = 8;
+	name = "security camera";
+	network = list("SS13","RD")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "CAh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14293,6 +14439,19 @@
 "CAA" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/cmo)
+"CAB" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "tox_sensor"
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/engine/plasma,
+/area/shuttle/ftl/atmos)
 "CBo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -14305,6 +14464,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"CBB" = (
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/assembly/robotics)
 "CCT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -14477,6 +14642,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
+"COt" = (
+/obj/structure/toilet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "CRK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -14501,32 +14677,6 @@
 "CUe" = (
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"CXt" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
-"CXL" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/telecomms/computer)
 "CYK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14547,17 +14697,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"Dak" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle/red,
-/area/shuttle/ftl/subshuttle/pod_3)
 "Ddv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14678,13 +14817,6 @@
 "DjS" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/chemistry)
-"DlE" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai)
 "DmU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14765,17 +14897,22 @@
 "DtP" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/chemistry)
-"Duz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"DxI" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp/green,
+/obj/item/weapon/hand_labeler{
+	pixel_x = 5
 	},
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "DzC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15028,16 +15165,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"DPp" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/hor)
 "DQS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
@@ -15070,6 +15197,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"DWK" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/green/side{
+	tag = "icon-green (WEST)";
+	icon_state = "green";
+	dir = 8
+	},
+/area/shuttle/ftl/hydroponics)
 "DYz" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15135,16 +15274,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/secure_construction)
-"Edk" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+"Edh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/mob/living/simple_animal/pet/cat/Runtime,
+/turf/open/floor/wood,
+/area/shuttle/ftl/medical/cmo)
 "Edt" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -15261,14 +15402,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkyellow,
 /area/shuttle/ftl/engine/tool_storage)
-"Ehr" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/shuttle/ftl/assembly/robotics)
 "EhF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15283,19 +15416,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"EkR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai_upload)
 "Elk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -15313,6 +15433,18 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"Enm" = (
+/obj/structure/fireaxecabinet{
+	pixel_x = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Atmospherics West";
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "Eoe" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -15322,23 +15454,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Eog" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
 "Eop" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/projectile/automatic/pistol/usp{
@@ -15370,14 +15485,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"EoC" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/munitions/office)
 "EpW" = (
 /obj/structure/table/glass,
 /obj/item/weapon/wrench/medical,
@@ -15421,6 +15528,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/locker)
+"Etw" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "EtS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15512,16 +15633,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/starboard)
+"EBG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai)
 "ECr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"EDK" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
 "EFx" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular,
@@ -15579,28 +15699,20 @@
 "ELr" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/engine/chiefs_office)
-"EMc" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
-"EOy" = (
-/obj/machinery/light{
-	dir = 1
+"ELU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai_upload)
 "EOz" = (
 /obj/structure/displaycase/labcage,
 /obj/structure/cable,
@@ -15751,6 +15863,21 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"EZG" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/weapon/electronics/airlock,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "Fat" = (
 /obj/effect/landmark/start{
 	name = "Bartender";
@@ -15844,17 +15971,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"FgA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/whiteblue,
-/area/shuttle/ftl/medical/medbay_lobby)
 "Fhm" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -15865,16 +15981,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"Fii" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/engine/chiefs_office)
 "Fjg" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -15887,6 +15993,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"FjQ" = (
+/obj/machinery/dna_scannernew{
+	tag = ""
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
 "Fkm" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -15917,6 +16041,21 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
+"FlM" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1
+	},
+/area/shuttle/ftl/medical/medbay)
 "FmO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15956,6 +16095,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/turret_protected/ai)
+"Fqq" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_x = 30;
+	pixel_y = 4
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "FqK" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs,
@@ -16030,6 +16182,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"FvQ" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "Fzl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16099,6 +16266,22 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos/equipment)
+"FBV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/telecomms/computer)
 "FCj" = (
 /obj/machinery/door/poddoor{
 	id = "Supermatter Entry"
@@ -16338,19 +16521,6 @@
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"Ggb" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	busy = 0;
-	c_tag = "Robotics";
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/assembly/robotics)
 "Ggh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16451,23 +16621,6 @@
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"GpF" = (
-/obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/research/server)
 "Gqx" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -16651,15 +16804,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/research/division)
-"GIL" = (
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/weapon/storage/fancy/cigarettes,
-/obj/item/weapon/storage/box/evidence,
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "GJB" = (
 /obj/machinery/button/door{
 	dir = 2;
@@ -16671,6 +16815,26 @@
 	},
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/assembly/robotics)
+"GKJ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay doors.";
+	id = "get_outta_the_gene_pool";
+	name = "Genetics Exit Button";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -24;
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
 "GLC" = (
 /obj/vehicle/atv,
 /turf/open/floor/plasteel/delivery,
@@ -16750,6 +16914,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"GUt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "GUI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16842,6 +17013,21 @@
 	dir = 5
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"GYW" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "GZC" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -16907,6 +17093,14 @@
 "HfS" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
+"HjM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "Hkk" = (
 /obj/machinery/cryopod/right,
 /obj/effect/decal/cleanable/dirt,
@@ -16956,19 +17150,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"HrN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
 "Hsb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -16976,34 +17157,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"Hst" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/main)
-"HsD" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/masks{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay)
 "HsM" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -17126,27 +17279,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/secure_construction)
-"HQk" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
 "HRu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -17214,6 +17346,37 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/chemistry)
+"HVH" = (
+/obj/structure/rack,
+/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "HVL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -17221,6 +17384,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
+"HVR" = (
+/obj/machinery/computer/med_data,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "Iao" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17497,11 +17671,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"ItV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
 "Iux" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -17534,17 +17703,23 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"IxC" = (
-/obj/machinery/light{
-	dir = 4
+"Ixj" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	tag = "icon-manifold (WEST)";
+	icon_state = "manifold";
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
 "ICv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -17572,6 +17747,21 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
+"IDq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_construct{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "IEk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -17587,6 +17777,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
+"IEr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
 "IES" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -17623,13 +17826,17 @@
 "IHS" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/heads)
-"IIl" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side{
-	dir = 1
+"IJa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
 	},
-/area/shuttle/ftl/hydroponics)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/telecomms/computer)
 "IJs" = (
 /turf/closed/wall,
 /area/shuttle/ftl/bridge/eva)
@@ -17835,15 +18042,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"Jcn" = (
-/obj/machinery/camera{
-	c_tag = "Tool Storage";
-	dir = 1
-	},
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow,
-/area/shuttle/ftl/engine/tool_storage)
 "Jde" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -17902,17 +18100,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"Jgd" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/secure_construction)
 "Jge" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -17940,6 +18127,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
+"JkA" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 1
+	},
+/area/shuttle/ftl/hydroponics)
 "JkJ" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel/black,
@@ -17994,6 +18193,11 @@
 	dir = 4
 	},
 /area/shuttle/ftl/munitions)
+"JpK" = (
+/obj/structure/closet/secure_closet/hop,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "Jqu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18024,19 +18228,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"JtN" = (
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "o2_sensor"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light,
-/turf/open/floor/engine/o2,
-/area/shuttle/ftl/atmos)
 "Juf" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -18089,6 +18280,37 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"Jwx" = (
+/obj/structure/table/glass,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Chemistry";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_construct{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 10
+	},
+/area/shuttle/ftl/medical/chemistry)
 "JxA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18140,22 +18362,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"JBw" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "JCe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18194,15 +18400,6 @@
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"JKl" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	tag = "icon-pump_map (EAST)";
-	icon_state = "pump_map";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
 "JKJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -18238,6 +18435,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
+"JOO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/hos,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
 "JOU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18253,6 +18458,16 @@
 	dir = 10
 	},
 /area/shuttle/ftl/hallway/primary/central)
+"JRS" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "JSu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
@@ -18275,15 +18490,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"JWw" = (
-/obj/structure/table/wood,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
 "JXK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -18376,15 +18582,24 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Kik" = (
-/obj/structure/dresser,
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
+"Kgp" = (
+/obj/machinery/nuclearbomb/selfdestruct,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "Kko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18506,40 +18721,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"Ksl" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9
-	},
-/obj/item/clothing/glasses/science{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/item/weapon/storage/box/pillbottles,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/chemistry)
 "KtO" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 8;
@@ -18548,17 +18729,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/cargo/office)
-"KtY" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/clothing/head/welding,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/assembly/robotics)
 "KuI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18675,14 +18845,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"KEB" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
+"KEQ" = (
+/obj/structure/table,
+/obj/item/weapon/wrench,
+/obj/item/weapon/crowbar,
+/obj/item/device/multitool,
+/obj/item/weapon/book/manual/ftl_wiki/munitions_manual,
+/obj/machinery/camera{
+	c_tag = "Munitions East"
 	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/research/division)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/loading)
 "KFi" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/central)
@@ -18925,16 +19099,6 @@
 "KWF" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/office)
-"KXe" = (
-/obj/machinery/biogenerator,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side{
-	dir = 5
-	},
-/area/shuttle/ftl/hydroponics)
 "KXj" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/belt/champion,
@@ -18953,13 +19117,18 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/nuke_storage)
-"KYK" = (
-/obj/machinery/light{
-	dir = 8
+"KYs" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
 "Lab" = (
 /obj/machinery/computer/upload/ai,
 /obj/effect/decal/cleanable/dirt,
@@ -19008,14 +19177,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"Lgk" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway 3";
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai)
 "LiV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -19103,10 +19264,6 @@
 "LtU" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge)
-"LuH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/engine/chiefs_office)
 "LuZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -19141,18 +19298,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"LxG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "LyT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -19173,6 +19318,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"LCI" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
 "LCO" = (
 /obj/item/device/radio/off{
 	pixel_x = -4;
@@ -19224,17 +19381,24 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/turret_protected/ai)
-"LFk" = (
-/obj/structure/disposalpipe/segment{
+"LGe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
+/turf/open/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/closed/wall,
-/area/shuttle/ftl/research/xenobiology)
+/area/shuttle/ftl/research/division)
 "LGG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -19349,11 +19513,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"LQY" = (
-/obj/structure/closet/secure_closet/captains,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "LRC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -19395,6 +19554,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/janitor)
+"LWa" = (
+/obj/structure/sign/directions/evac{
+	dir = 1
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall/rust,
+/area/shuttle/ftl/hallway/primary/fore)
 "LWn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -19505,6 +19674,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"Mdx" = (
+/obj/machinery/biogenerator,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/green/side{
+	dir = 5
+	},
+/area/shuttle/ftl/hydroponics)
 "MfW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19535,35 +19711,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/central)
-"MkW" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
-"Mls" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/priority{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "Mmb" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8;
@@ -19575,10 +19722,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
-"Mom" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
+"MmL" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "Mpd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -19641,35 +19796,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos/equipment)
-"MBX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/light{
-	dir = 8
+"MAQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/secure_construction)
 "MCW" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"MGS" = (
-/obj/structure/table/glass,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/weapon/stock_parts/scanning_module,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
 "MHn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19678,16 +19816,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"MLB" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics East";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/suit_storage_unit/atmos,
+"MLR" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plasteel/green/side{
+	tag = "icon-green (SOUTHWEST)";
+	icon_state = "green";
+	dir = 10
+	},
+/area/shuttle/ftl/hydroponics)
 "MME" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19728,10 +19865,23 @@
 "MNU" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/mining)
+"MOW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/crew_quarters/locker)
 "MPe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"MPt" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "MRf" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -19799,6 +19949,17 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/xenobiology)
+"MUU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "medbay_r";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/whiteblue,
+/area/shuttle/ftl/medical/medbay_lobby)
 "MVg" = (
 /obj/machinery/button/door{
 	dir = 2;
@@ -19835,21 +19996,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/hos)
-"NbI" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering South";
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (NORTHWEST)";
-	icon_state = "darkblue";
-	dir = 9
-	},
-/area/shuttle/ftl/engine/engine_smes)
 "Ncc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19877,6 +20023,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"NcE" = (
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bridge)
 "NcR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -20067,17 +20229,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"Nua" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/hos,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
 "NvR" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hydroponics)
@@ -20122,16 +20273,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/fore)
-"NEy" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "NEB" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -20187,27 +20328,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/whiteblue,
 /area/shuttle/ftl/medical/medbay)
-"NJm" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/bridge/eva)
 "NJs" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/detectives_office)
-"NJK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "NKk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20281,6 +20404,18 @@
 "NMe" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/brig)
+"NNM" = (
+/obj/structure/table/glass,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
 "NPh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -20294,15 +20429,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"NPt" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (NORTHWEST)";
-	icon_state = "whiteblue";
-	dir = 9
-	},
-/area/shuttle/ftl/medical/medbay)
 "NPO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20342,31 +20468,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_3)
-"NRi" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/research/server)
-"NRB" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 4
-	},
-/area/shuttle/ftl/medical/medbay)
 "NSu" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/disposal)
@@ -20425,19 +20526,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"Obg" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/fancy/donut_box,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
 "ObJ" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -20473,17 +20561,32 @@
 	dir = 6
 	},
 /area/shuttle/ftl/hydroponics)
-"Odg" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+"Oef" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/cloning{
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/obj/machinery/firealarm{
-	pixel_y = -24
+/obj/item/weapon/circuitboard/computer/med_data{
+	pixel_x = 3;
+	pixel_y = -3;
+	pixel_z = 0
+	},
+/obj/item/weapon/circuitboard/machine/clonescanner{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/clonepod,
+/obj/item/weapon/circuitboard/computer/scan_consolenew{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
 "OeJ" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
@@ -20494,6 +20597,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/security/armory)
+"Ofl" = (
+/obj/machinery/iv_drip,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
 "Ofo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20510,15 +20627,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"Ogq" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
 "OiJ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/airalarm{
@@ -20528,21 +20636,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
-"Okq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whiteblue/corner{
-	tag = "icon-whitebluecorner (EAST)";
-	icon_state = "whitebluecorner";
-	dir = 4
-	},
-/area/shuttle/ftl/medical/medbay)
 "OkI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20644,6 +20737,17 @@
 "OtG" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/port)
+"Owq" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "OwL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -20668,35 +20772,11 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"Oyl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "OzD" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/hydroponics)
-"OAw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
 "OBz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20707,6 +20787,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"ODD" = (
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway 3";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/circuit/rcircuit/animated,
+/area/shuttle/ftl/turret_protected/ai)
 "OEf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20753,6 +20844,23 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/locker)
+"OIP" = (
+/obj/structure/sign/directions/evac{
+	dir = 4
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
+"OJH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/circuit/rcircuit/animated,
+/area/shuttle/ftl/turret_protected/ai)
 "OJW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20780,6 +20888,11 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
+"OLO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
@@ -20976,11 +21089,6 @@
 	dir = 5
 	},
 /area/shuttle/ftl/security/nuke_storage)
-"PdO" = (
-/obj/machinery/vending/dinnerware,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cafeteria,
-/area/shuttle/ftl/crew_quarters/kitchen)
 "Pej" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -21023,13 +21131,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/office)
-"PgY" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
 "PiF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /obj/effect/decal/cleanable/dirt,
@@ -21147,12 +21248,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Puj" = (
-/obj/structure/table/wood,
-/obj/item/weapon/book/manual/wiki/security_space_law,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
 "PwC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21330,32 +21425,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"PFZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/telecomms/computer)
 "PHD" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"PJw" = (
-/obj/machinery/vending/snack,
+"PIa" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
 "PKI" = (
@@ -21376,6 +21458,32 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/engine/tool_storage)
+"PNB" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"PNI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay)
 "POB" = (
 /obj/machinery/button/door{
 	id = "QMLoaddoor";
@@ -21413,10 +21521,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"PUu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/gravity_generator)
+"PQT" = (
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
 "PUH" = (
 /obj/machinery/computer/station_alert,
 /obj/effect/decal/cleanable/dirt,
@@ -21442,6 +21556,24 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
+"PYX" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering South";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTHWEST)";
+	icon_state = "darkblue";
+	dir = 9
+	},
+/area/shuttle/ftl/engine/engine_smes)
 "PZO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -21486,6 +21618,18 @@
 	dir = 5
 	},
 /area/shuttle/ftl/cargo/mining)
+"Qfe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "Qhl" = (
 /obj/machinery/chem_dispenser/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -21503,19 +21647,23 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
+"Qiu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "QmH" = (
 /obj/machinery/vending/clothing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"QoK" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/hallway/primary/port)
 "Qpa" = (
 /obj/structure/rack{
 	dir = 8;
@@ -21682,6 +21830,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"QJU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "QKb" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c";
@@ -21696,22 +21849,6 @@
 	dir = 6
 	},
 /area/shuttle/ftl/hallway/primary/central)
-"QKd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	name = "RnD Desk";
-	req_access_txt = "0"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "research lab shutters"
-	},
-/obj/machinery/door/window/eastright{
-	name = "RnD Desk";
-	req_access_txt = "26"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/research/lab)
 "QMh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -21851,6 +21988,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
+"QZt" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (EAST)";
+	icon_state = "whiteblue";
+	dir = 4
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "RaZ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -21899,31 +22058,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Rii" = (
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 36
-	},
-/obj/machinery/button/door{
-	id = "munitions";
-	name = "Munitions Lockdown";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "43"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/office)
 "RkK" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/decal/cleanable/dirt,
@@ -21946,6 +22080,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"Rtb" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "Rtg" = (
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
@@ -22008,16 +22149,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"RCn" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge/meeting_room)
 "RCX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22050,20 +22181,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos/equipment)
-"RHc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/whiteblue,
-/area/shuttle/ftl/medical/medbay_lobby)
 "RIh" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -22138,42 +22255,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Sbq" = (
-/obj/structure/table,
-/obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
-	},
-/obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
+"RWG" = (
+/turf/closed/wall/rust,
+/area/shuttle/ftl/crew_quarters/locker)
 "Sbz" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/storage)
-"ScR" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "Sff" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j1";
@@ -22186,6 +22276,18 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos/equipment)
+"SfI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "Sgv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22226,14 +22328,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"SoG" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
 "Spu" = (
 /obj/machinery/vending/hydronutrients,
 /obj/structure/cable{
@@ -22361,6 +22455,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"SBn" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
+"SBQ" = (
+/turf/closed/wall/rust,
+/area/shuttle/ftl/hallway/primary/fore)
 "SCc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -22474,22 +22576,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"SIo" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
 "SIy" = (
 /obj/structure/table,
 /obj/item/weapon/weldingtool,
@@ -22501,31 +22587,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"SIz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/airalarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (NORTH)";
-	icon_state = "whiteblue";
-	dir = 1
-	},
-/area/shuttle/ftl/medical/medbay)
 "SIA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
+"SIY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
 "SJV" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
@@ -22601,23 +22676,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"SOd" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
 "SOT" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/chef_recipes,
@@ -22638,6 +22696,19 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/shuttle/ftl/security/nuke_storage)
+"SSB" = (
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "STa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -22729,6 +22800,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/munitions/cannon)
+"SZv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "SZz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -22847,34 +22925,12 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"TeP" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/medical,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (NORTH)";
-	icon_state = "whiteblue";
-	dir = 1
-	},
-/area/shuttle/ftl/medical/medbay)
 "TgB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"TgO" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
 "TgS" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -22962,29 +23018,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"Trd" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow,
-/area/shuttle/ftl/engine/tool_storage)
 "TrL" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -23035,22 +23068,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Tvx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
 "Twv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
@@ -23083,20 +23100,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
-"Tyk" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
 "Tzq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/r_n_d/destructive_analyzer,
@@ -23196,12 +23199,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"TGM" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
 "TIq" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer"
@@ -23303,23 +23300,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"TRw" = (
-/obj/machinery/dna_scannernew{
-	tag = ""
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+"TRG" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/genetics)
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "TSw" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/beakers{
@@ -23406,16 +23394,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"TYr" = (
-/obj/machinery/vending/boozeomat,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
 "TYL" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -23523,13 +23501,6 @@
 "UfQ" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/atmos)
-"UfX" = (
-/obj/machinery/computer/telecomms/server{
-	network = "tcommsat"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/telecomms/computer)
 "Uhb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23610,14 +23581,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"Umj" = (
+"UkB" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_y = 0
+	pixel_y = -32
 	},
-/turf/closed/wall,
-/area/shuttle/ftl/crew_quarters/kitchen)
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
 "UmG" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor";
@@ -23635,6 +23606,11 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
+"UnH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/research/division)
 "UnK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -23699,6 +23675,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/central)
+"Uso" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/bluegrid{
+	icon_state = "dark";
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/shuttle/ftl/telecomms/server)
 "Utb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23875,21 +23864,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"UID" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/whiteblue,
-/area/shuttle/ftl/medical/medbay_lobby)
 "UJG" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -23927,15 +23901,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/shuttle/ftl/atmos)
-"UKN" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/shuttle/ftl/telecomms/server)
 "UMr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24024,6 +23989,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"UUq" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
 "UVI" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/toilet)
@@ -24065,13 +24042,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"UZN" = (
-/obj/structure/table/wood,
-/obj/item/device/taperecorder,
-/obj/item/weapon/storage/briefcase,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
+"VaB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "medbay_l";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/whiteblue,
+/area/shuttle/ftl/medical/medbay_lobby)
 "VbC" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -24087,6 +24071,39 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/heads)
+"Vea" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
+"VeA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay doors.";
+	id = "medbay_l";
+	name = "Medbay Exit Button";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay)
 "Vft" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "virology_airlock_exterior";
@@ -24108,6 +24125,14 @@
 "VfT" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/mining)
+"VhT" = (
+/obj/structure/dresser,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "VhW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24209,14 +24234,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"VnV" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/crew_quarters/bar)
 "VoP" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -24228,22 +24245,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/gravity_generator)
-"VsO" = (
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "tox_sensor"
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
-/area/shuttle/ftl/atmos)
 "VvS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -24288,14 +24289,24 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"VyK" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+"VyT" = (
+/obj/machinery/camera{
+	c_tag = "R&D Server Room";
+	name = "security camera";
+	network = list("SS13","RD")
 	},
-/mob/living/simple_animal/slime,
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/xenobiology)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 2;
+	on = 1;
+	target_temperature = 80
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
 "VCL" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
@@ -24361,21 +24372,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"VIM" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "munitions";
-	tag = "munitions east"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
 "VIU" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -24616,6 +24612,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/medical/cmo)
+"Wnf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "WnF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24666,6 +24677,17 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
+"WsW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHWEST)";
+	icon_state = "whiteblue";
+	dir = 10
+	},
+/area/shuttle/ftl/medical/medbay)
 "WtB" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -24974,11 +24996,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/telecomms/server)
-"WQa" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "WQl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24998,19 +25015,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
-"WQR" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/telecomms/computer)
 "WRR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25035,14 +25039,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
-"WTa" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering)
 "WUn" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -25160,21 +25156,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/shuttle/ftl/crew_quarters/bar)
-"XdL" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
 "XfL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -25488,6 +25469,15 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
+"XOQ" = (
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
 "XPf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25543,17 +25533,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"XZb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/whiteblue,
-/area/shuttle/ftl/medical/medbay_lobby)
 "YcX" = (
 /obj/structure/rack,
 /obj/item/weapon/wrench,
@@ -25638,25 +25617,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"Ykq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Research and Development";
-	dir = 8;
-	name = "security camera";
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
 "YlR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -25740,6 +25700,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge/meeting_room)
+"Ysm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "Ytm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25793,13 +25762,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"YyP" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/xenobiology)
 "YyZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -25869,18 +25831,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"YEL" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
 "YGp" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -25963,6 +25913,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/green/side,
 /area/shuttle/ftl/hydroponics)
+"YNs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bridge)
 "YNL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -25987,6 +25952,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
+"YRU" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/loading)
 "YSk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -26025,6 +26000,32 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"YUf" = (
+/obj/structure/table,
+/obj/item/weapon/tank/internals/emergency_oxygen{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/weapon/tank/internals/emergency_oxygen{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Atmospherics East";
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "YWa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -26048,22 +26049,6 @@
 	},
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/cargo/office)
-"YYD" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "YYQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -26088,6 +26073,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/heads)
+"ZbN" = (
+/obj/structure/sign/directions/evac{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/medical{
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/engineering,
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/engineering)
 "Zdg" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/glasses/meson,
@@ -26138,6 +26134,14 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/secure_construction)
+"ZmN" = (
+/obj/structure/sign/directions/engineering,
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Zny" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms";
@@ -26219,6 +26223,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"Zvs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
 "ZCx" = (
 /obj/machinery/computer/crew,
 /obj/structure/cable{
@@ -26229,6 +26242,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/medical/cmo)
+"ZCP" = (
+/obj/structure/sign/pods,
+/turf/closed/wall/r_wall/rust,
+/area/shuttle/ftl/hallway/primary/port)
 "ZCR" = (
 /obj/structure/table/wood,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -26336,22 +26353,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"ZMw" = (
-/obj/structure/toilet,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/ftl/crew_quarters/toilet)
 "ZMy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32031,7 +32032,7 @@ Fkm
 Fkm
 Fkm
 Fkm
-etk
+Fkm
 Tpw
 sme
 sme
@@ -32248,7 +32249,7 @@ sme
 sme
 sme
 Tpw
-EMc
+rUW
 rUW
 rUW
 rUW
@@ -33279,17 +33280,17 @@ Tpw
 rUW
 rUW
 rUW
+HjM
 rUW
-PgY
 IvE
 IvE
 IvE
 IvE
 IvE
-BeD
+GUt
 VHM
 xpr
-rUW
+HjM
 XYU
 VHM
 rUW
@@ -33302,21 +33303,21 @@ Tpw
 Tpw
 rUW
 JhN
-IxC
 VPN
+Qfe
 VPN
 DmU
 VPN
-mDB
 XkS
 XkS
 XkS
-Jgd
+XkS
+MAQ
 HfS
-HfS
+Rtb
 fCh
 TEp
-aea
+Cpd
 Tpw
 sme
 sme
@@ -34056,7 +34057,7 @@ CUe
 CUe
 xaH
 pSv
-bvC
+ZCP
 LQq
 yMw
 GzL
@@ -34303,8 +34304,8 @@ sme
 sme
 sme
 sme
-yxr
-Dak
+wmx
+cju
 TNY
 FRb
 zSN
@@ -34578,13 +34579,13 @@ qgP
 IaL
 Jqu
 prr
-Odg
+sZP
 OPU
 FCj
 VQG
 FCj
 OPU
-oCo
+AVp
 RaZ
 zox
 GhC
@@ -34827,8 +34828,8 @@ CUe
 CUe
 MAk
 AWO
-QoK
-NJK
+OtG
+IDq
 dvG
 GzL
 qgP
@@ -35089,16 +35090,16 @@ bce
 yMw
 GzL
 qgP
-ItV
+iyj
 prH
 VNw
-hrH
+pvs
 OPU
 FCj
 VQG
 FCj
 OPU
-NbI
+PYX
 RaZ
 Jqu
 EZu
@@ -35331,8 +35332,8 @@ sme
 sme
 sme
 sme
-yxr
-wxl
+wmx
+ymg
 HfB
 FzL
 wjt
@@ -35346,7 +35347,7 @@ LQq
 yMw
 plh
 OPU
-MkW
+SBn
 ybQ
 Uph
 hIY
@@ -35358,7 +35359,7 @@ lqk
 mjh
 Brz
 CcN
-JKl
+gCb
 rPy
 rPy
 UfQ
@@ -35598,7 +35599,7 @@ CUe
 CUe
 xaH
 ToY
-bvC
+ZCP
 LQq
 swy
 ZPF
@@ -35618,13 +35619,13 @@ CuE
 gQY
 POZ
 Pdv
-ogb
+QJU
 Twv
 TZC
-kBK
-zDo
+SSB
+Enm
 dtl
-MBX
+OLO
 dcI
 ptk
 NTj
@@ -35860,7 +35861,7 @@ qTu
 swy
 ZPF
 OPU
-HrN
+FvQ
 ITG
 KHe
 xOD
@@ -36117,7 +36118,7 @@ hTJ
 SWD
 xih
 OPU
-Tvx
+gRr
 GWT
 VMr
 Jwf
@@ -36129,7 +36130,7 @@ ahA
 ahA
 axL
 TIq
-SoG
+AlM
 rPy
 tIY
 INw
@@ -36378,7 +36379,7 @@ Jmm
 QIt
 NlB
 AeB
-XdL
+MmL
 rxl
 LiV
 Jes
@@ -36641,7 +36642,7 @@ esx
 JfM
 OPU
 OPU
-kbH
+OPU
 iHq
 OPU
 rPy
@@ -36883,14 +36884,14 @@ eVx
 GLC
 ugm
 NLV
-NJm
+IJs
 qTu
 swy
 ZPF
 ptB
 YJV
 XSX
-oCX
+EZG
 WFw
 zcw
 SIy
@@ -37159,7 +37160,7 @@ Pmv
 AsQ
 kAj
 rPy
-VsO
+CAB
 FRu
 siL
 dLc
@@ -37167,7 +37168,7 @@ fgR
 PlM
 siL
 tRq
-JtN
+lzB
 rPy
 RhC
 sWN
@@ -37404,7 +37405,7 @@ ZPF
 ptB
 sPZ
 XSX
-Wah
+TRG
 wHI
 Wah
 Wah
@@ -37655,18 +37656,18 @@ IJs
 IJs
 IJs
 IJs
-qTu
+BuZ
 swy
 ZPF
 iXC
 sLN
 XSX
 EPk
-Ogq
+aRb
 Zdg
-qyx
+hin
 WNG
-YYX
+foI
 YYX
 XSX
 ukS
@@ -37912,7 +37913,7 @@ vrl
 JkJ
 JkJ
 IJs
-xEx
+qTu
 swy
 ZPF
 iXC
@@ -38176,7 +38177,7 @@ iXC
 sLN
 cAO
 JkU
-iKt
+kcn
 iKt
 snn
 fIA
@@ -38431,15 +38432,15 @@ nYR
 Tqn
 iXC
 sLN
-okq
+cAO
 EWe
 AKO
 JAo
 AKO
 AKO
 Bxj
-okq
-iUN
+cAO
+fCS
 xPL
 EwG
 lQA
@@ -38701,13 +38702,13 @@ XNO
 iQN
 mDa
 rPy
-Mls
-qsB
+Etw
+Fqq
 psx
-Sbq
-MLB
+YUf
+Ysm
 xte
-LxG
+iJj
 fFd
 vke
 ajU
@@ -38947,9 +38948,9 @@ iXC
 Oct
 cAO
 LnG
-LuH
+yEE
 Ksi
-Fii
+SZv
 lvi
 JtB
 ekz
@@ -38967,7 +38968,7 @@ rPy
 rPy
 rPy
 rPy
-rPy
+OIP
 YHL
 rvu
 gqx
@@ -39461,10 +39462,10 @@ iXC
 sLN
 wWi
 AOf
+AtA
 AOf
-AOf
-AOf
-PUu
+Crk
+pMW
 vAq
 WPx
 Snw
@@ -39481,7 +39482,7 @@ mjq
 bpC
 xPF
 Tbk
-WTa
+sZx
 RhC
 bYM
 mnz
@@ -39973,13 +39974,13 @@ swy
 vMb
 iXC
 sLN
-nwF
-Bjc
+wWi
+AOf
 AOf
 AOf
 aXz
 AOf
-hsY
+xwR
 VsD
 qIA
 qvR
@@ -40242,7 +40243,7 @@ CoB
 DzC
 EtS
 gvS
-BkF
+XDw
 VHj
 wrU
 mJy
@@ -40489,10 +40490,10 @@ iXC
 sLN
 wWi
 AOf
+axG
 AOf
 AOf
-AOf
-AOf
+axG
 AOf
 wWi
 ChO
@@ -40992,10 +40993,10 @@ nKu
 QHv
 PLQ
 mNZ
-mVQ
+uKx
 gNB
 jdd
-ujD
+mNZ
 qTu
 swy
 vMb
@@ -41253,7 +41254,7 @@ mVQ
 YSk
 pCs
 mNZ
-xEx
+qTu
 Bah
 QWv
 Uxs
@@ -41264,7 +41265,7 @@ wQt
 wQt
 wQt
 DBT
-Umj
+wQt
 wQt
 wQt
 wQt
@@ -41518,12 +41519,12 @@ YJV
 YJV
 wQt
 LPJ
-dIm
-lpp
+nNs
+qZl
 CHm
 SId
 KaO
-PdO
+AYj
 ISg
 wQt
 KcB
@@ -42020,7 +42021,7 @@ lLV
 jwe
 nyx
 lLV
-cVa
+tdv
 uyi
 yza
 ffs
@@ -42031,14 +42032,14 @@ iXC
 YJV
 YJV
 wQt
-TYr
+LCI
 Fat
 WQl
 pit
 Kmf
 gBd
 Fbl
-yQT
+nmE
 CKy
 CKy
 CKy
@@ -42299,16 +42300,16 @@ nmE
 OzD
 isB
 AdZ
-qaZ
+DWK
 Ipy
-mBl
+MLR
 CKy
 KcB
 HEH
 kZU
 gyq
 AEG
-eQs
+HEH
 KQV
 bYM
 mnz
@@ -42566,7 +42567,7 @@ qQj
 zng
 chn
 HEH
-KQV
+Vea
 bYM
 mnz
 dRD
@@ -42795,7 +42796,7 @@ nxy
 YXz
 Wio
 ffs
-qTu
+BuZ
 AWQ
 iXX
 iXC
@@ -43068,7 +43069,7 @@ zlq
 uGV
 gZm
 CKy
-huV
+kIB
 Idw
 dQJ
 lWe
@@ -43314,8 +43315,8 @@ AWQ
 ZPF
 iXC
 YJV
-VnV
-WQa
+xaf
+krd
 bzq
 bzq
 bgt
@@ -43324,8 +43325,8 @@ rhj
 XvX
 Lsf
 PEU
-jgg
-IIl
+CKy
+hJQ
 Idw
 dQJ
 lWe
@@ -44096,13 +44097,13 @@ xaf
 nQi
 nGy
 NvR
-ynn
+JkA
 Idw
 TLW
 lWe
-AML
-jgg
-zCW
+hhr
+CKy
+qVk
 puf
 uCW
 uCW
@@ -44610,7 +44611,7 @@ nQi
 sme
 sme
 NvR
-KXe
+Mdx
 gvb
 jQk
 RvQ
@@ -44843,7 +44844,7 @@ sme
 OtG
 OtG
 OtG
-BOL
+wtz
 Pmj
 cfg
 hcv
@@ -44854,14 +44855,14 @@ IES
 qTu
 swy
 ZPF
-iXC
+ZbN
 qTY
 iXC
 hPn
 hPn
 xaf
 yhF
-AhO
+bVB
 MTu
 xaf
 FQs
@@ -45129,7 +45130,7 @@ Ihn
 OZN
 eii
 lRJ
-jXK
+lRJ
 nwO
 lRJ
 LKP
@@ -45882,16 +45883,16 @@ scI
 scI
 scI
 scI
-QKd
+Cmy
 scI
 scI
 OtG
 OtG
-OtG
+vuE
 ESX
 Smf
 ejz
-hZG
+ZmN
 hZG
 hZG
 DtP
@@ -46127,7 +46128,7 @@ sme
 sme
 nKI
 hAl
-YyP
+iPh
 DAF
 Tus
 VZz
@@ -46135,12 +46136,12 @@ tai
 vIW
 cVx
 Pqq
-SIo
+Pqq
 Tpn
 zGT
 MVg
 QXe
-SOd
+fMG
 scI
 sme
 sme
@@ -46153,11 +46154,11 @@ sme
 sme
 Gkh
 TCs
-Ksl
-cWh
+ecS
+Jwx
 vTG
-NPt
-pgm
+cGF
+UUq
 hvy
 Qrx
 mqV
@@ -46165,7 +46166,7 @@ ceC
 SCh
 Rom
 Lfs
-abC
+qoh
 vsK
 ZJO
 rai
@@ -46397,7 +46398,7 @@ PzY
 uZg
 uZg
 QXe
-MGS
+sCY
 scI
 sme
 sme
@@ -46644,7 +46645,7 @@ XAS
 XAS
 XAS
 XAS
-zwh
+cba
 OkI
 DoE
 XKi
@@ -46676,11 +46677,11 @@ Kqy
 gHo
 mqV
 mqV
-TZr
+mqV
 mqV
 tNi
 DeI
-dkv
+tbh
 mqV
 BVh
 sme
@@ -46898,12 +46899,12 @@ sme
 sme
 MTy
 hAl
-VyK
+gPT
 DAF
 Tus
 AeD
 uKb
-Aie
+wzz
 YwV
 yaB
 Rgf
@@ -46911,7 +46912,7 @@ msE
 sYO
 kkO
 wrD
-ySS
+NNM
 Gxn
 sme
 sme
@@ -47191,7 +47192,7 @@ NJb
 TZr
 WiA
 vds
-NEy
+sKa
 aVN
 ynt
 ziM
@@ -47418,12 +47419,12 @@ Gqx
 zwh
 uKb
 rFQ
-LFk
+YwV
 bmd
 VxD
 wgZ
-Ykq
-Eog
+ijL
+PNB
 LOT
 zYk
 Gxn
@@ -47441,11 +47442,11 @@ HsM
 xRQ
 OwL
 KFR
-FgA
-ifP
+wim
+VeA
 heg
 iuy
-mqV
+AER
 mqV
 mqV
 mqV
@@ -47669,7 +47670,7 @@ sme
 sme
 MTy
 hAl
-VyK
+gPT
 DAF
 JbN
 AeD
@@ -47698,12 +47699,12 @@ eOQ
 hBM
 zUK
 jXL
-RHc
+VaB
 SMk
 kuc
 zov
 bgn
-HsD
+ftj
 ewD
 mqV
 Vft
@@ -47949,14 +47950,14 @@ hea
 dCD
 iMG
 WNK
-FJq
+WNK
 iMG
-dKd
+eOQ
 AEK
 XMa
 Fhm
 WNK
-SIz
+oUm
 qzO
 ekQ
 juy
@@ -48205,13 +48206,13 @@ OBz
 CwD
 tNP
 ZNn
-oOj
+GYW
 oOj
 Uvr
 stV
 rFT
 NYv
-vLD
+HVR
 WNK
 LoQ
 wXP
@@ -48222,7 +48223,7 @@ zlx
 jme
 dlR
 lsM
-bRz
+WsW
 SWo
 sme
 sme
@@ -48440,7 +48441,7 @@ sme
 sme
 MTy
 hAl
-YyP
+iPh
 DAF
 JbN
 AeD
@@ -48451,9 +48452,9 @@ LGN
 tyy
 TZf
 xrT
-DPp
+gos
 tCW
-eKR
+mlW
 FdQ
 sme
 sme
@@ -48462,7 +48463,7 @@ YSr
 KEc
 sCC
 AJC
-AJC
+QZt
 AJC
 dDH
 ihL
@@ -48479,7 +48480,7 @@ XOg
 TdB
 lVS
 UzS
-aGe
+uKG
 SWo
 sme
 sme
@@ -48720,16 +48721,16 @@ RUf
 ejz
 iMG
 WNK
-FJq
+WNK
 iMG
-dKd
+eOQ
 TYc
 XMa
 pgp
 FJq
-wSd
+FlM
 Dfq
-NRB
+PNI
 CKU
 WxK
 mrt
@@ -48957,7 +48958,7 @@ cOv
 cOv
 cOv
 cOv
-aSC
+cOv
 QVR
 gJO
 PDc
@@ -48983,7 +48984,7 @@ eOQ
 ena
 FtM
 HHd
-UID
+ymE
 eLN
 nll
 CAA
@@ -49214,12 +49215,12 @@ gJO
 gJO
 gJO
 CGi
-GpF
+Ixj
 Nke
 Qhy
 til
-NRi
-gEm
+gJO
+LGe
 cjN
 wvs
 tKh
@@ -49240,8 +49241,8 @@ rth
 cfz
 gLz
 bcD
-XZb
-Okq
+MUU
+dcH
 KnJ
 lmF
 eeE
@@ -49249,7 +49250,7 @@ DjF
 Xnm
 SIk
 ONU
-nbp
+Ofl
 mrt
 mrt
 sme
@@ -49470,7 +49471,7 @@ sme
 gJO
 gJO
 gJO
-hVz
+VyT
 ZEa
 YHX
 UjD
@@ -49482,9 +49483,9 @@ kfJ
 xGP
 AmT
 xJp
-gHe
+SfI
 YTQ
-glp
+UnH
 Ytm
 GWq
 pFy
@@ -49743,7 +49744,7 @@ cdr
 cdr
 cdr
 KFi
-fSA
+YSr
 hea
 PAZ
 mGq
@@ -49759,7 +49760,7 @@ EFx
 ivW
 wGH
 ISy
-dpM
+Edh
 CAA
 CAA
 mrt
@@ -50269,7 +50270,7 @@ wfq
 QyX
 bzN
 EfT
-TeP
+wGa
 Ywm
 wKh
 urG
@@ -50524,7 +50525,7 @@ ICv
 gKa
 pzc
 VFu
-wez
+GKJ
 Gad
 pLs
 PAR
@@ -50758,16 +50759,16 @@ sme
 sme
 sme
 cdr
-KEB
+cdr
 jji
 Yel
 MHn
 Fjg
-qcQ
+CAe
 imj
 oqo
 Hvd
-KEB
+cdr
 sme
 sme
 KFi
@@ -50778,7 +50779,7 @@ EWl
 EWl
 EWl
 EfT
-TRw
+FjQ
 GGT
 tfm
 Edt
@@ -51796,8 +51797,8 @@ NMe
 Whx
 vwY
 jfI
-Czf
-GIL
+DxI
+xWI
 ZWw
 YSr
 hea
@@ -52054,8 +52055,8 @@ cog
 WIs
 wcS
 omC
-UZN
-jMN
+iek
+ZWw
 YSr
 hea
 WGP
@@ -52308,7 +52309,7 @@ Elk
 vuu
 NMe
 yuQ
-JBw
+zLt
 hrJ
 FPY
 iaz
@@ -52575,7 +52576,7 @@ CwD
 btK
 rXD
 NLL
-Trd
+iOj
 NLI
 hXz
 NSu
@@ -52819,7 +52820,7 @@ hDU
 fUQ
 kTG
 tPH
-ysD
+PQT
 QOI
 etS
 wCn
@@ -52834,7 +52835,7 @@ IvT
 hDm
 inJ
 vvc
-Jcn
+aZY
 NSu
 OID
 HUk
@@ -53076,7 +53077,7 @@ xPT
 NMe
 GWR
 gxJ
-qlV
+KYs
 kth
 WIP
 Hrz
@@ -53335,7 +53336,7 @@ Sqk
 ZOU
 NMe
 WHl
-bEs
+yhp
 NMe
 NMe
 NMe
@@ -53602,8 +53603,8 @@ sPR
 RCX
 MbK
 mmp
-PFZ
-WQR
+FBV
+zXV
 VNF
 SEB
 euL
@@ -53848,7 +53849,7 @@ Eet
 OUN
 fNe
 Sqk
-wdJ
+SIY
 Elv
 Hrz
 tdd
@@ -53867,7 +53868,7 @@ pBd
 uVz
 uVz
 uVz
-sEO
+Uso
 hCA
 slH
 Nyn
@@ -54124,7 +54125,7 @@ Spz
 Iqb
 hQR
 DZJ
-Spz
+lKe
 hCA
 kZc
 Nyn
@@ -54381,7 +54382,7 @@ Spz
 iss
 ciM
 WPN
-UKN
+Spz
 hCA
 slH
 mWl
@@ -54630,12 +54631,12 @@ WGD
 pFy
 JuQ
 RSY
-UfX
-CXL
+inK
+IJa
 LCO
 RFB
 Spz
-fZy
+Spz
 Spz
 Spz
 Spz
@@ -54873,7 +54874,7 @@ sme
 ksn
 Egt
 WOT
-Hst
+xRO
 XKk
 nnW
 qAo
@@ -54882,10 +54883,10 @@ nox
 WOT
 cpq
 sTk
-mtt
-YSr
+WOT
+aDL
 hea
-dCD
+PAZ
 zgu
 zgu
 zgu
@@ -55644,24 +55645,24 @@ sme
 cJy
 lMN
 Wfb
-zBL
+Wfb
 Wfb
 Wfb
 WOT
-EOy
+Qiu
 eAF
-mtt
+WOT
 IiO
 Glt
 WOT
-YSr
+eIo
 hea
 PAZ
 NcR
 HnJ
 GJB
 lck
-Ehr
+bvB
 mrK
 goT
 tPe
@@ -55923,7 +55924,7 @@ oOn
 CGk
 mzx
 mzx
-dyf
+XOQ
 Rwn
 slH
 mWl
@@ -56420,8 +56421,8 @@ vsn
 DVI
 ada
 XMd
-OAw
-mdN
+xFP
+mJg
 vRt
 DYz
 Wfb
@@ -56437,7 +56438,7 @@ cYW
 QFG
 cCg
 aBV
-KtY
+qjb
 Rwn
 slH
 Nyn
@@ -56688,13 +56689,13 @@ PAZ
 mVd
 TaE
 Tbl
-Ggb
+wwU
 JSu
 hqO
 OHL
 CGZ
 aly
-sYE
+CBB
 Rwn
 slH
 mWl
@@ -56935,7 +56936,7 @@ LHX
 hRD
 dzn
 Avd
-CXt
+yDw
 gcK
 rqK
 SDE
@@ -57446,13 +57447,13 @@ hDv
 Ggi
 sxj
 rxG
-Bjw
-gcd
+hRD
+HVH
 xzQ
 SIA
 rqh
 NLX
-SDE
+cfG
 YSr
 hea
 vWh
@@ -57698,18 +57699,18 @@ sme
 sme
 sme
 bhJ
-Nua
-sxj
+JOO
+BTy
 grC
-Mom
+IEr
 mFr
 hRD
 OeJ
 GMP
-dOA
+emP
 wmF
 ZdY
-SDE
+Akr
 OBz
 CwD
 TdR
@@ -57722,7 +57723,7 @@ vyJ
 wFi
 mhg
 MrC
-qFT
+IkS
 IkS
 zbA
 biz
@@ -58217,7 +58218,7 @@ IiQ
 CyX
 Bpj
 fJZ
-KYK
+OJH
 fJZ
 CyX
 IiQ
@@ -58230,7 +58231,7 @@ fnq
 lCJ
 CYK
 SZZ
-fjV
+CYK
 Ytm
 LWn
 ptj
@@ -58728,12 +58729,12 @@ sme
 VGU
 XPf
 IiQ
-DlE
+fJZ
 fJZ
 IiQ
 xKM
 IiQ
-msu
+fJZ
 IiQ
 sme
 sme
@@ -58985,12 +58986,12 @@ sme
 VGU
 XPf
 IiQ
-Lgk
+ODD
 fJZ
 ABg
 CZN
 IpF
-fJZ
+tnm
 IiQ
 sme
 sme
@@ -59513,16 +59514,16 @@ DdT
 OQG
 Jwv
 Hvt
-ZMw
+COt
 kWO
 bSM
 jaU
 TGK
-BFC
+Oef
 MNi
 Fbx
 bSM
-Edk
+Zvs
 lMr
 jPM
 sme
@@ -59757,9 +59758,9 @@ VGU
 Utb
 IiQ
 Lab
-eyv
+EBG
 FEm
-siE
+bbQ
 Fqa
 bez
 IiQ
@@ -60282,7 +60283,7 @@ QmH
 HzW
 DdT
 Ghn
-Oyl
+rik
 uko
 sme
 sme
@@ -60522,21 +60523,21 @@ sme
 sme
 sme
 sme
-zNu
+VGU
 XwV
 QtE
 IOp
 Dgd
 Dft
 lqj
-EkR
+ELU
 ESQ
 OqJ
 alv
 ohV
 Lav
 rTI
-HzW
+SBQ
 DdT
 Ghn
 rik
@@ -60783,7 +60784,7 @@ VGU
 QqQ
 KFv
 NKk
-QtE
+UkB
 Dft
 Nry
 rkv
@@ -60793,7 +60794,7 @@ WXW
 TTW
 ajl
 NzI
-HzW
+SBQ
 hOS
 VkF
 rik
@@ -61050,8 +61051,8 @@ hDM
 SGc
 Lav
 NzI
-HzW
-DdT
+SBQ
+Wnf
 Ghn
 rik
 mrr
@@ -61059,7 +61060,7 @@ sme
 sme
 lvv
 wlS
-aKg
+Kgp
 Ilu
 jOa
 wlS
@@ -61307,7 +61308,7 @@ alv
 WZz
 Lav
 NzI
-HzW
+SBQ
 haL
 Ghn
 rik
@@ -61556,15 +61557,15 @@ CCT
 zgm
 QtE
 Dft
-pwu
-rkv
+Nry
+fln
 Etg
 Lvq
 alv
 oyE
 Lav
 NzI
-HzW
+SBQ
 sZa
 Ghn
 rik
@@ -61824,7 +61825,7 @@ vdu
 HzW
 qMx
 Ghn
-Duz
+rik
 TEw
 sme
 sme
@@ -62068,21 +62069,21 @@ CCT
 erg
 CCT
 zgm
-Dgd
+QtE
 Dft
 Dft
 ntv
 Etg
-aDP
+MOW
 BRp
-eyy
+few
 KaH
-eyy
-SlH
-YYD
+RWG
+LWa
+aqk
 nUa
 PwC
-TEw
+hDn
 TEw
 uko
 uko
@@ -62596,8 +62597,8 @@ SlH
 xFU
 Ghn
 tOf
-xDk
-fOL
+SlH
+WyM
 WyM
 WyM
 WyM
@@ -63103,7 +63104,7 @@ LrQ
 KWF
 KWF
 KWF
-jwi
+KWF
 ydL
 kIQ
 XVI
@@ -63358,13 +63359,13 @@ rFl
 qrp
 YjV
 sNm
-Rii
+pbo
 wuq
-ybV
+bBb
 sme
 sme
 czQ
-RCn
+uIa
 WDj
 hkR
 czQ
@@ -63609,7 +63610,7 @@ cCa
 VGU
 Jnl
 VGU
-VIM
+ngT
 QtE
 rSJ
 QtE
@@ -63617,7 +63618,7 @@ Fub
 RIh
 Fzq
 PfL
-EoC
+kIk
 sme
 sme
 PkY
@@ -63632,9 +63633,9 @@ ATF
 YSB
 IHS
 IHS
-doi
+vdT
 BqZ
-ORo
+YNs
 Nzx
 Bjq
 sme
@@ -63874,7 +63875,7 @@ bnP
 VIU
 jzQ
 fXH
-EoC
+kIk
 sme
 sme
 PkY
@@ -63889,9 +63890,9 @@ IHS
 Gfx
 IHS
 IHS
-xMF
+yaW
 BqZ
-HQk
+NcE
 cmc
 Bjq
 sme
@@ -64131,7 +64132,7 @@ ObJ
 kMN
 nfS
 nfS
-uSh
+YRU
 sme
 sme
 czQ
@@ -64142,11 +64143,11 @@ BNE
 sme
 sme
 Vdi
-qIo
+BCf
 ZaG
-hqF
+JpK
 tDX
-ScR
+wBc
 BqZ
 XiI
 WQA
@@ -64399,9 +64400,9 @@ XVI
 czQ
 PkY
 jxC
-klM
 jxC
-klM
+jxC
+jxC
 jxC
 jxC
 jxC
@@ -64649,7 +64650,7 @@ Uec
 SYl
 ctY
 XFA
-Tyk
+hCn
 cgo
 rvv
 umz
@@ -64660,9 +64661,9 @@ slK
 WHB
 aOD
 yzo
-ixz
+csS
 jxC
-cyk
+uAB
 iIV
 Bjq
 sme
@@ -64903,7 +64904,7 @@ XDt
 PyM
 jDO
 Uec
-rts
+uln
 EsB
 EsB
 Rhp
@@ -64911,13 +64912,13 @@ wsW
 exq
 EsB
 EsB
-TGM
+CtT
 jxC
-sXd
+AMa
 fjt
 QYU
 ZOh
-JWw
+JRS
 jxC
 cyk
 iIV
@@ -65154,13 +65155,13 @@ sme
 sme
 Uec
 iim
-sxZ
+KEQ
 HJO
 XDt
 FKg
 AFc
 Uec
-PJw
+iFd
 EsB
 EsB
 Ngj
@@ -65174,7 +65175,7 @@ jsE
 UMt
 LDA
 Xji
-YEL
+rtr
 jxC
 TrL
 dPR
@@ -65425,7 +65426,7 @@ DKV
 Idc
 EsB
 EsB
-Puj
+kjJ
 tpz
 XIn
 FEK
@@ -65674,7 +65675,7 @@ XDt
 dJp
 aro
 Uec
-TgO
+PIa
 MCW
 MCW
 SNF
@@ -65682,11 +65683,11 @@ SEZ
 sQy
 EsB
 EsB
-EDK
+pRM
 tpz
 bDX
 kfr
-Kik
+VhT
 jxC
 jxC
 oZg
@@ -65931,7 +65932,7 @@ Uec
 Uec
 Uec
 Uec
-mja
+MPt
 ctY
 PiF
 lHv
@@ -65939,10 +65940,10 @@ Juj
 NqL
 Ogh
 ctY
-qiS
+ctY
 tpz
 WzA
-LQY
+oyO
 jxC
 jxC
 oZg
@@ -66958,7 +66959,7 @@ sme
 sme
 sme
 oYr
-vAb
+Owq
 Bkr
 gDU
 vwA
@@ -66968,7 +66969,7 @@ wXZ
 bXX
 JKW
 eWL
-pPF
+vxp
 nhp
 PBI
 SYG
@@ -67476,7 +67477,7 @@ pXe
 sjL
 evU
 evU
-qJi
+XBD
 Lwj
 wOv
 evU
@@ -68244,7 +68245,7 @@ sme
 sme
 qVj
 qVj
-xaW
+skt
 xMp
 AoY
 JFf
@@ -68252,7 +68253,7 @@ Ggh
 Xsc
 AoY
 xMp
-Obg
+jvr
 LtU
 LtU
 sme

--- a/_maps/map_files/Trailblazer/Trailblazer.dmm
+++ b/_maps/map_files/Trailblazer/Trailblazer.dmm
@@ -92,12 +92,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"ajl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/locker)
 "ajC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -132,12 +126,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"apd" = (
-/obj/item/weapon/storage/book/bible,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "apY" = (
 /obj/machinery/conveyor{
 	id = "QMLoad";
@@ -145,24 +133,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
-"aqc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "aqk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -244,10 +214,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"auY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai_upload)
 "auZ" = (
 /obj/machinery/computer/telecomms/monitor{
 	network = "tcommsat"
@@ -330,6 +296,15 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"aDM" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/fore)
 "aGg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -345,6 +320,14 @@
 	dir = 8
 	},
 /area/shuttle/ftl/cargo/mining)
+"aKq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
 "aLZ" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -364,18 +347,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"aOD" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
 "aQT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -410,11 +381,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"aTk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai)
 "aVw" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -450,27 +416,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"aWI" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "aXz" = (
 /obj/machinery/gravity_generator/main/station,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/gravity_generator)
-"aXH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engineering)
 "aXX" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -498,15 +447,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/yellow,
 /area/shuttle/ftl/engine/tool_storage)
-"baI" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "0"
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "bbQ" = (
 /obj/machinery/porta_turret_cover,
 /obj/machinery/porta_turret/ai{
@@ -520,17 +460,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
-"bbS" = (
-/obj/effect/landmark/start{
-	name = "Botanist";
-	shuttle_abstract_movable = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hydroponics)
 "bce" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -588,6 +517,15 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"bgx" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
 "bhJ" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/hos)
@@ -623,6 +561,11 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"bmw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "bnP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -639,16 +582,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engineering)
-"bqb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/assembly/robotics)
 "bqk" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer"
@@ -750,10 +683,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/cmo)
-"bvB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/shuttle/ftl/assembly/robotics)
 "bvC" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/hallway/primary/port)
@@ -766,36 +695,6 @@
 "bzq" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"bzN" = (
-/obj/machinery/disposal/bin{
-	name = "corpse disposal unit"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Genetics";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/genetics)
-"bAC" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Hallway North"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering)
 "bAS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -830,13 +729,6 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/mining)
-"bDX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "bJs" = (
 /obj/machinery/meter,
 /obj/structure/window/reinforced,
@@ -1032,18 +924,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"cba" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "cbF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -1065,31 +945,10 @@
 "cdr" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/division)
-"ceC" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/machinery/camera{
-	c_tag = "Virology Isolation"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "cfg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"cfi" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
 "cfz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/side{
@@ -1134,6 +993,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/janitor)
+"ciF" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "munitions";
+	tag = "munitions east"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/loading)
 "ciM" = (
 /obj/machinery/telecomms/bus/preset_one/birdstation,
 /obj/effect/decal/cleanable/dirt,
@@ -1191,18 +1061,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
-"cog" = (
-/obj/structure/table/wood,
-/obj/machinery/airalarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "cok" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -1338,6 +1196,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"cxL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
 "cyk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1347,6 +1210,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
+"cyU" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
 "czQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1462,28 +1333,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"cNH" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/mecha_control{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/robotics,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"cOf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "cOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -1630,6 +1479,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
+"dhT" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "dld" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /obj/effect/decal/cleanable/dirt,
@@ -1668,14 +1531,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"dlV" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "dmt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1733,19 +1588,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"doq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "doQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct{
@@ -1812,6 +1654,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"dtt" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "munitions";
+	tag = "munitions east"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
+"dtC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/central)
 "duP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/shower{
@@ -1828,18 +1688,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"dvG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "dwM" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -1879,6 +1727,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"dyF" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	tag = "icon-intact (NORTH)";
+	icon_state = "intact";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "dzn" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/energy/ionrifle,
@@ -1903,6 +1760,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
+"dBQ" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "dCD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1914,6 +1789,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"dDg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "dDH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -1934,6 +1822,12 @@
 "dDX" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
+"dFE" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/mining)
 "dHH" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -1969,6 +1863,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"dLj" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"dNB" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/medical/sleeper)
 "dPR" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/bridge)
@@ -1992,12 +1907,34 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"dTR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
+"dSS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "dUA" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
@@ -2022,61 +1959,28 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"ebN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai)
-"ecS" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	layer = 2.9
-	},
-/obj/item/clothing/glasses/science{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/item/weapon/storage/box/pillbottles,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/chemistry)
 "eeE" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/medical/cmo)
-"efw" = (
-/obj/item/weapon/mop,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct/small{
+"efT" = (
+/obj/structure/dresser,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
+"egJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "eii" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2141,6 +2045,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
+"emN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
 "emP" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/chemimp{
@@ -2158,12 +2069,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"emY" = (
-/obj/machinery/conveyor_switch{
-	id = "CargoMunitions"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/storage)
 "ena" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -2181,6 +2086,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"enB" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
 "erg" = (
 /turf/open/floor/plating/warnplate/side{
 	tag = "icon-plating_warn_side (EAST)";
@@ -2326,6 +2239,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
+"eBI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "eDT" = (
 /obj/machinery/requests_console{
 	department = "AI";
@@ -2384,6 +2308,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"eJf" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "eJj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenence Hatch";
@@ -2483,19 +2420,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"eOE" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/loading)
 "eOQ" = (
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -2538,16 +2462,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"eRa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "eRb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2560,6 +2474,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/locker)
+"eVb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "eVx" = (
 /turf/open/floor/plasteel/loadingarea{
 	dir = 1
@@ -2585,6 +2510,11 @@
 /obj/machinery/telecomms/relay/portable/preset,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/cargo/mining)
+"eXq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "eZD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -2598,6 +2528,21 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"fag" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/pet/cat/Runtime,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/wood,
+/area/shuttle/ftl/medical/cmo)
 "fcr" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -2616,6 +2561,20 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/eva)
+"feh" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "few" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/locker)
@@ -2669,21 +2628,32 @@
 /obj/structure/chair,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"fln" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai_upload)
-"fmR" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/bo/weapons,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
-"fmV" = (
+"flI" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
+/obj/machinery/camera{
+	c_tag = "Virology Isolation"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"fmE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "fnq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -2698,42 +2668,26 @@
 	dir = 9
 	},
 /area/shuttle/ftl/hallway/primary/central)
-"fnY" = (
-/obj/structure/sink{
-	icon_state = "sink";
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+"foK" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
+"fpo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
-/area/shuttle/ftl/medical/surgery)
-"foI" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
+/area/shuttle/ftl/research/xenobiology)
 "frF" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/medbay)
-"frS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/division)
 "fsX" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -2785,14 +2739,6 @@
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/engine/engine_smes)
-"fxq" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
 "fzJ" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -2815,12 +2761,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"fCh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
+"fCf" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "fCx" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -2842,6 +2786,18 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
+"fCG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
 "fCS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display{
@@ -2857,6 +2813,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"fDE" = (
+/obj/effect/landmark/start{
+	name = "Botanist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
 "fEi" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -2995,12 +2963,19 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"fNe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"fNg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "fNG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -3187,24 +3162,6 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/meeting_room)
-"gaM" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (NORTHWEST)";
-	icon_state = "darkblue";
-	dir = 9
-	},
-/area/shuttle/ftl/atmos)
 "gbt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3225,20 +3182,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"gdR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos/equipment)
 "get" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -3259,15 +3202,45 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/hydroponics)
-"gjO" = (
-/obj/structure/disposalpipe/segment{
+"gjg" = (
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/item/weapon/storage/box/pillbottles,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/chemistry)
+"gkR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "glv" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -3295,6 +3268,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
+"gnf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/loading)
 "gop" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -3340,12 +3321,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"gpi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel/warning{
-	dir = 1
-	},
-/area/shuttle/ftl/cargo/mining)
 "gqx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3365,29 +3340,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"gtC" = (
-/obj/machinery/cryopod/right,
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/warnwhite{
-	tag = "icon-white_warn (SOUTHEAST)";
-	icon_state = "white_warn";
-	dir = 6
-	},
-/area/shuttle/ftl/medical/sleeper)
-"gum" = (
-/obj/structure/table/reinforced,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/engine/chiefs_office)
 "gvb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3405,15 +3357,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"gvS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/engineering)
 "gxJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -3427,15 +3370,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/genetics)
-"gyq" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "gBd" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme{
@@ -3628,21 +3562,20 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"gNB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "gOq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"gOt" = (
+/obj/structure/window,
+/obj/machinery/vending/cigarette{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "gPT" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3650,14 +3583,20 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"gQY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+"gQb" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "gRr" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -3711,6 +3650,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"gWl" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
 "gZm" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -3743,17 +3686,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"hbF" = (
-/obj/machinery/button/door{
-	id = "miningpodbay";
-	layer = 4;
-	name = "Mining Podbay Doors";
-	pixel_x = 8;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "hcv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3832,11 +3764,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/green/side,
 /area/shuttle/ftl/hydroponics)
-"hhR" = (
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/chemistry)
 "hhV" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/machinery/airalarm{
@@ -3871,18 +3798,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"hkR" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge Airlock";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge/meeting_room)
 "hnj" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -3934,6 +3849,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"hrN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/circuit/rcircuit/animated,
+/area/shuttle/ftl/turret_protected/ai)
+"hrP" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/security/vacantoffice)
 "hse" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -3979,6 +3912,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"hue" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "hvy" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/decal/cleanable/dirt,
@@ -4013,6 +3957,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
+"hBd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "hBM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4080,41 +4031,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/hallway/primary/fore)
-"hDv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
-"hDF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "virology_airlock_interior";
-	locked = 1;
-	name = "Virology Interior Airlock";
-	req_access_txt = "23"
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = 8;
-	pixel_y = -28;
-	req_access_txt = "23"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "hDM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 2
@@ -4159,6 +4075,13 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hydroponics)
+"hLV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
 "hOS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4169,10 +4092,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"hPn" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/hallway/primary/port)
 "hPo" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -4210,18 +4129,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"hXz" = (
+"hWB" = (
 /obj/structure/table,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow,
-/area/shuttle/ftl/engine/tool_storage)
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "hYu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -4256,6 +4173,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/atmos/equipment)
+"ics" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
 "icv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -4305,21 +4228,14 @@
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"igx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"ieQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/ftl/security/nuke_storage)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "ihL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4494,6 +4410,15 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/medbay)
+"iuU" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
 "ivW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4516,6 +4441,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"ixV" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "iyj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -4546,6 +4484,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
+"iBo" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/hallway/primary/port)
 "iBY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -4660,25 +4603,6 @@
 	},
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/turret_protected/ai_upload)
-"iOj" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow,
-/area/shuttle/ftl/engine/tool_storage)
 "iPh" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4706,17 +4630,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
-"iQN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engineering)
 "iRn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/black,
@@ -4730,6 +4643,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"iSS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/central)
 "iUc" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/hor)
@@ -4767,33 +4686,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"iZi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/side,
-/area/shuttle/ftl/medical/chemistry)
 "jaU" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"jdd" = (
-/obj/structure/ore_box,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/ftl/cargo/mining)
 "jel" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4950,6 +4848,40 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"jpC" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"jqa" = (
+/obj/structure/table/reinforced,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "jsE" = (
 /obj/structure/displaycase/captain,
 /obj/machinery/airalarm{
@@ -4978,6 +4910,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
+"jvl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/machinery/camera{
+	busy = 0;
+	c_tag = "Munitions North";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
 "jvr" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/fancy/donut_box,
@@ -5018,6 +4962,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"jyE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "jzw" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/decal/cleanable/dirt,
@@ -5025,6 +4979,10 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"jzE" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/locker)
 "jzQ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -5042,6 +5000,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/office)
+"jAh" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/gloves/color/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos/equipment)
 "jAS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5052,6 +5021,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"jBb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "jDO" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -5081,13 +5056,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"jHl" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "jJj" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5105,31 +5073,39 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
+"jMd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/fore)
+"jNx" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "jNA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"jOa" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
+"jPC" = (
+/obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/weapon/nullrod,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/nuke_storage)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/security/vacantoffice)
 "jPM" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/storage/tech)
@@ -5146,16 +5122,15 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"jQN" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"jSc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel/circuit/rcircuit/animated,
+/area/shuttle/ftl/turret_protected/ai)
 "jUu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating,
@@ -5301,13 +5276,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
-"kfr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "kfJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -5321,6 +5289,17 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"kiX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "kjJ" = (
 /obj/structure/table/wood,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -5347,11 +5326,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"kkO" = (
-/turf/open/floor/plasteel/warnwhite{
-	dir = 8
+"kpy" = (
+/obj/effect/landmark{
+	name = "blobstart"
 	},
-/area/shuttle/ftl/research/lab)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/wood,
+/area/shuttle/ftl/security/vacantoffice)
 "kqs" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -5403,10 +5389,27 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
+"kuf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "kwc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/research/xenobiology)
+"kza" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
 "kzg" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen";
@@ -5421,6 +5424,24 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"kzi" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/chemistry)
+"kzy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 1";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "kAj" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -5440,14 +5461,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
-"kCK" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "0"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
 "kFr" = (
 /obj/machinery/door/poddoor/preopen{
@@ -5515,16 +5528,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hydroponics)
-"kIQ" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/fore)
 "kJQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -5652,6 +5655,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"lda" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "ldb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -5667,6 +5678,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
+"leX" = (
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = 22
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "lfg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -5683,13 +5710,22 @@
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
 /area/shuttle/ftl/medical/medbay)
-"lgQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
+"lgR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "lis" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -5713,10 +5749,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/munitions)
-"ljy" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "ljR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5850,20 +5882,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"lvv" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
 "lwg" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -5960,10 +5978,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"lHv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
 "lJT" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -6117,6 +6131,26 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"lXj" = (
+/obj/item/weapon/electronics/airlock{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/electronics/apc,
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/cable_coil,
+/obj/item/device/multitool{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
 "mbn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6145,6 +6179,20 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/mining)
+"meX" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "mgh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -6188,15 +6236,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"mhg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/central)
 "mib" = (
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
+"miW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
 /area/shuttle/ftl/research/division)
 "mjh" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -6214,6 +6268,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engineering)
+"mjC" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/loading)
 "mlz" = (
 /obj/structure/table,
 /obj/structure/disposalpipe/segment{
@@ -6321,25 +6381,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"mql" = (
-/obj/item/weapon/electronics/airlock{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/electronics/apc,
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stack/cable_coil,
-/obj/item/device/multitool{
-	pixel_x = -4;
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
 "mqu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
@@ -6389,15 +6430,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"msE" = (
+"mrO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/warnwhite/corner{
-	dir = 1
-	},
-/area/shuttle/ftl/research/lab)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "mtE" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -6422,27 +6466,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"mCq" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
-"mCA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
 "mDa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6450,6 +6473,44 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"mFi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai_upload)
+"mFl" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/device/multitool{
+	pixel_x = 4
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/weapon/melee/classic_baton/telescopic{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	moving_diagonally = 0;
+	name = "munitions office fire alarm";
+	pixel_x = -24;
+	pixel_y = -12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/office)
 "mFr" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6457,25 +6518,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"mFv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Equipment";
-	req_access_txt = "15"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos/equipment)
 "mGq" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -6646,6 +6688,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"mVn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "mVQ" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6710,13 +6763,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"nbO" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "nbT" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
@@ -6850,6 +6896,22 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
+"nlE" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/bo/weapons,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
+"nlV" = (
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/locker)
 "nmc" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid,
@@ -6949,6 +7011,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"nuV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel/darkyellow,
+/area/shuttle/ftl/engine/tool_storage)
 "nwq" = (
 /obj/structure/table/wood,
 /obj/structure/disposalpipe/segment{
@@ -6989,6 +7062,13 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/storage)
+"nDT" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/genetics)
 "nGy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -7004,6 +7084,13 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"nJi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
 "nKu" = (
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel{
@@ -7104,6 +7191,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
+"nZt" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/secure_construction)
 "occ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7113,18 +7204,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"ocC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/atmos)
 "oes" = (
 /obj/structure/chair{
 	dir = 4
@@ -7277,20 +7356,21 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/xenobiology)
-"osD" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
 "otX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"ouh" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "ovd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7312,17 +7392,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"oyO" = (
-/obj/structure/closet/secure_closet/captains,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = -32
+"ozE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/computer/security,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
+/area/shuttle/ftl/security/hos)
 "oCV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -7394,6 +7472,21 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
+"oLo" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
 "oOj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7403,11 +7496,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"oOn" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/assembly/robotics)
 "oQa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7428,6 +7516,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"oQk" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"oRx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engineering)
 "oUm" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/airalarm{
@@ -7509,31 +7616,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"pbo" = (
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 36
-	},
-/obj/machinery/button/door{
-	id = "munitions";
-	name = "Munitions Lockdown";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "43"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+"pdW" = (
+/obj/spacepod{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/office)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/engine,
+/area/shuttle/ftl/cargo/mining)
 "pel" = (
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
@@ -7541,6 +7630,16 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hydroponics)
+"peQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/locker)
 "pfo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7582,12 +7681,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"pku" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/engineering)
 "plh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7732,6 +7825,20 @@
 	dir = 10
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"pvx" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/loading)
 "pwo" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/cargo)
@@ -7828,6 +7935,15 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"pCJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/camera_advanced/xenobio,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "pDD" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -7866,6 +7982,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"pHH" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "pJo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -7954,6 +8078,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
+"pNO" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_x = 30;
+	pixel_y = 4
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "pRM" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -7980,6 +8118,20 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
+"pSP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "pTN" = (
 /obj/machinery/button/door{
 	id = "EvaGarage";
@@ -8036,6 +8188,36 @@
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
+"qcY" = (
+/obj/machinery/cryopod/right,
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (SOUTHEAST)";
+	icon_state = "white_warn";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/sleeper)
+"qdP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "0"
+	},
+/obj/docking_port/stationary{
+	dheight = 8;
+	dir = 2;
+	dwidth = 95;
+	height = 59;
+	id = "ftl_start";
+	name = "Starting Area";
+	width = 153
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile/ftl,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "qfA" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -8066,29 +8248,23 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"qjU" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "atmos blast door"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"qlS" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Equipment";
-	req_access_txt = "15"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "qnP" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32;
@@ -8198,6 +8374,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
+"qyM" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "7;9"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bridge)
 "qyU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen";
@@ -8291,6 +8483,24 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"qKd" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
+"qKp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "qKP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
@@ -8340,16 +8550,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"qMY" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/atmos)
 "qNk" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -8729,14 +8929,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"rpv" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/security/vacantoffice)
 "rqh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8824,11 +9016,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"rvU" = (
-/turf/open/floor/plasteel/darkwarning{
-	dir = 1
-	},
-/area/shuttle/ftl/security/armory)
 "rwb" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -8924,6 +9111,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
+"rDN" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "rEB" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/sortjunction{
@@ -9135,18 +9326,21 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/engine/tool_storage)
-"scs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
+"rYP" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/security/vacantoffice)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "scI" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/lab)
@@ -9256,6 +9450,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue/side,
 /area/shuttle/ftl/hallway/primary/fore)
+"shl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"shU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/central)
 "siL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
@@ -9332,13 +9545,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/ftl/bridge/eva)
-"slr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/assembly/robotics)
 "slH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9422,13 +9628,15 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"spz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
+"snV" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "0"
 	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/eva)
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "sqY" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel/twenty,
@@ -9551,6 +9759,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/detectives_office)
+"szh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "sBd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -9585,6 +9801,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"sCI" = (
+/obj/effect/landmark/start{
+	name = "Chief Engineer"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "sCY" = (
 /obj/structure/table/glass,
 /obj/item/weapon/stock_parts/console_screen,
@@ -9645,6 +9868,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"sKA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engineering)
 "sKE" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/storage)
@@ -9674,32 +9907,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"sNm" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+"sNx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/closet/bombcloset,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Munitions Office";
-	dir = 5
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (SOUTHEAST)";
+	icon_state = "darkblue";
+	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/office)
-"sOq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
+/area/shuttle/ftl/engine/engineering)
 "sPR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9727,6 +9945,22 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"sSb" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_construct{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "sTk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -9746,6 +9980,39 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
+"sUG" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
+"sUM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/telecomms/computer)
 "sVD" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/beakers{
@@ -9782,6 +10049,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
+"sWK" = (
+/obj/structure/disposalpipe/junction,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
 "sWL" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -9809,14 +10089,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/starboard)
-"sYO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
+"sWX" = (
+/obj/structure/table,
+/obj/item/weapon/circular_saw,
+/obj/item/weapon/scalpel{
+	pixel_y = 12
 	},
-/turf/open/floor/plasteel/warnwhite{
-	dir = 8
+/obj/item/weapon/hemostat,
+/obj/item/weapon/cautery{
+	pixel_x = 4
 	},
-/area/shuttle/ftl/research/lab)
+/obj/item/weapon/surgicaldrill,
+/obj/item/weapon/retractor,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
 "sZa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9871,6 +10165,25 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"taK" = (
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1;
+	desc = "It's a secure locker for personnel.";
+	name = "Kazaaak-Aerwhisp's closet";
+	registered_name = "Kazaaak-Aerwhisp"
+	},
+/obj/item/clothing/suit/jacket/leather/overcoat,
+/obj/item/weapon/reagent_containers/food/drinks/flask/det{
+	desc = "Friend of the detective. This one, like the detective, seems to have spent too much time in the kitchen, however.";
+	name = "Over-Boiled detective's flask"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/locker)
 "tbh" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/monkeycubes{
@@ -9920,10 +10233,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"tdd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "tdv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9981,17 +10290,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"tga" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkyellow,
+/area/shuttle/ftl/engine/tool_storage)
 "tgG" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"tha" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/loading)
 "til" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10057,6 +10369,15 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/chemistry)
+"twQ" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "typ" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 2
@@ -10100,6 +10421,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
+"tAA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/central)
 "tCy" = (
 /obj/structure/disposalpipe/segment,
@@ -10256,6 +10585,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"tNJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "tNP" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -10412,20 +10747,6 @@
 "ugm" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"uhS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/medical/genetics)
-"uiH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering)
 "ujm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -10439,13 +10760,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
-"ukS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering)
 "uln" = (
 /obj/machinery/vending/cola,
 /obj/effect/decal/cleanable/dirt,
@@ -10454,6 +10768,21 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"ulp" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"ulv" = (
+/obj/machinery/computer/upload/borg,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/circuit/rcircuit/animated,
+/area/shuttle/ftl/turret_protected/ai)
 "umz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -10477,14 +10806,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"uqd" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
+"uqe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engine_smes)
 "uqI" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (SOUTHEAST)";
@@ -10517,6 +10843,11 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/secure_construction)
+"utr" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge/eva)
 "uvK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -10571,6 +10902,19 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
+"uAG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "uBh" = (
 /obj/machinery/door/airlock/vault{
 	icon_state = "closed";
@@ -10598,20 +10942,6 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"uGV" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
-"uIa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge/meeting_room)
 "uKb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10622,18 +10952,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"uKx" = (
-/obj/machinery/suit_storage_unit/mining/eva,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "uKG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -10736,16 +11054,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"vds" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "vdu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10770,13 +11078,6 @@
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"veP" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
 "vfg" = (
 /obj/structure/window{
 	icon_state = "window";
@@ -10786,6 +11087,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"vfj" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
 "vgB" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/extinguisher_cabinet{
@@ -10835,6 +11146,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"vpn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
 "vpL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/heavy,
@@ -10880,6 +11196,21 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"vuf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "vuu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10907,13 +11238,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"vvc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel/darkyellow,
-/area/shuttle/ftl/engine/tool_storage)
 "vvi" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 1
@@ -10940,19 +11264,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"vwY" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "vxp" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
@@ -11016,20 +11327,15 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"vAq" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/power/apc/priority{
-	auto_name = 1;
+"vAU" = (
+/obj/structure/disposalpipe/segment{
 	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+	icon_state = "pipe-c"
 	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/gravity_generator)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
 "vBj" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/weapon/storage/toolbox/mechanical{
@@ -11059,6 +11365,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
+"vCF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_exterior";
+	locked = 1;
+	name = "Virology Exterior Airlock";
+	req_access_txt = "23"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "vCU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11078,6 +11404,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"vHI" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/grille/broken,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/crew_quarters/bar)
 "vIW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -11197,6 +11529,16 @@
 	},
 /turf/open/floor/engine/o2,
 /area/shuttle/ftl/atmos)
+"vUx" = (
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_construct/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
 "vVh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11235,9 +11577,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/bridge/eva)
-"wcS" = (
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "wfh" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/fire,
@@ -11256,12 +11595,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"wfq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/genetics)
 "wft" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical{
@@ -11274,6 +11607,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"wfF" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "wgZ" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c (EAST)";
@@ -11322,16 +11666,10 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"wkq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
+"wjv" = (
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
+/area/shuttle/ftl/medical/sleeper)
 "wlu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11360,6 +11698,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"wmb" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/medbay)
 "wmx" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall12";
@@ -11484,38 +11828,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"wuq" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/device/multitool{
-	pixel_x = 4
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/weapon/melee/classic_baton/telescopic{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc/priority{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	moving_diagonally = 0;
-	name = "munitions office fire alarm";
-	pixel_x = -24;
-	pixel_y = -12
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/office)
 "wvs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11526,6 +11838,10 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"wvH" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/main)
 "wwU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -11573,22 +11889,11 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"wAg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
+"wAk" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/hallway/primary/starboard)
 "wBc" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -11615,6 +11920,16 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"wDi" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "wFi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -11634,21 +11949,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
-"wGH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/medical/cmo)
 "wHI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11662,6 +11962,24 @@
 	dir = 4
 	},
 /area/shuttle/ftl/cargo/mining)
+"wIo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
+"wIr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/hallway/primary/starboard)
 "wID" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11707,6 +12025,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"wNr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
+"wNM" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/closet/bombcloset,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Munitions Office";
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/office)
 "wOv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/requests_console{
@@ -11721,6 +12068,38 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"wPU" = (
+/obj/structure/rack,
+/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "wQt" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/kitchen)
@@ -11761,6 +12140,19 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
+"wUK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "wWi" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/gravity_generator)
@@ -11773,6 +12165,12 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"wXg" = (
+/obj/machinery/chem_dispenser/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
 "wXP" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -11885,28 +12283,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"xmL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sink{
-	icon_state = "sink";
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Research Airlock";
-	dir = 6;
-	name = "security camera";
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "xpr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11926,6 +12302,20 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"xrE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/telecomms/computer)
 "xrT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -12033,12 +12423,6 @@
 	dir = 5
 	},
 /area/shuttle/ftl/security/nuke_storage)
-"xwR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/gravity_generator)
 "xxg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12050,29 +12434,10 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"xzQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 1
-	},
-/area/shuttle/ftl/security/armory)
-"xAW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/telecomms/computer)
-"xBh" = (
-/obj/effect/landmark{
-	name = "blobstart"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/effect/decal/cleanable/dirt,
+"xAY" = (
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood,
-/area/shuttle/ftl/security/vacantoffice)
+/area/shuttle/ftl/engine/chiefs_office)
 "xCx" = (
 /obj/machinery/door/airlock/glass_external{
 	name = "Escape Shuttle"
@@ -12088,6 +12453,18 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
+"xCV" = (
+/obj/machinery/flasher/portable,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/security/armory)
 "xDF" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintanence Hatch";
@@ -12100,21 +12477,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"xFP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
 "xFU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12149,6 +12511,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"xHb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos/equipment)
 "xHE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -12157,15 +12531,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
-"xJp" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet/firecloset,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
@@ -12236,16 +12601,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engineering)
-"xPL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (SOUTHEAST)";
-	icon_state = "darkblue";
-	dir = 6
-	},
-/area/shuttle/ftl/engine/engineering)
 "xPT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12287,22 +12642,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
-"xRQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+"xSM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
+/area/shuttle/ftl/medical/genetics)
 "xTr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -12388,16 +12736,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"ydL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/fore)
 "ygW" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkblue,
@@ -12437,10 +12775,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
-"ylu" = (
+"ykS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/cargo/mining)
 "ymg" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12514,6 +12855,33 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"yun" = (
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 36
+	},
+/obj/machinery/button/door{
+	id = "munitions";
+	name = "Munitions Lockdown";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "43"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/office)
 "yuQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12559,6 +12927,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"yxK" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
 "yys" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch{
@@ -12592,18 +12970,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
-"yzo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
 "yzL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -12747,6 +13113,29 @@
 	},
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
+"ySk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Bar Entry";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/partyalarm{
+	desc = "Cuban Pete is in the house! (Mapper note: If you are prone to seizures and you press this, you might be in for a gnarly ride.)";
+	dir = 8;
+	name = "\improper PARTY BUTTON";
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "yTo" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/door/firedoor,
@@ -12843,6 +13232,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"zdM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "zeA" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -12879,19 +13276,6 @@
 "zgu" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/computer)
-"zhy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/surgery)
 "ziM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -12929,21 +13313,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"zlY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "zng" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13012,14 +13381,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
-"zsO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "zua" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13034,16 +13395,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"zve" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
+"zvH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/circuit/rcircuit/animated,
+/area/shuttle/ftl/turret_protected/ai)
 "zwh" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/decal/cleanable/dirt,
@@ -13081,27 +13437,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"zFg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "virology_airlock_exterior";
-	locked = 1;
-	name = "Virology Exterior Airlock";
-	req_access_txt = "23"
+"zFo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
+"zGB" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai_upload)
 "zGT" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /turf/open/floor/engine,
@@ -13117,56 +13467,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"zLt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+"zNY" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
-"zNV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"zOi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engine_smes)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "zOB" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"zQA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
 "zRv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13207,27 +13520,21 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"zUm" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
-"zUK" = (
+"zVr" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/area/shuttle/ftl/medical/medbay_lobby)
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "zWP" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal{
@@ -13277,19 +13584,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
-"zXV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/telecomms/computer)
 "zYk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -13311,13 +13605,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"AbZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
+"Abo" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "atmos blast door"
 	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/eva)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Equipment";
+	req_access_txt = "15"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "AdZ" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -13393,6 +13703,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
+"Ajp" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start{
+	name = "Head of Security"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
 "Akr" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8
@@ -13429,12 +13750,60 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"Aoz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"AoM" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 8;
+	pixel_y = -28;
+	req_access_txt = "23"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_interior";
+	locked = 1;
+	name = "Virology Interior Airlock";
+	req_access_txt = "23"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "AoY" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/book/manual/ftl_wiki/bo_guide,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"Aqc" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "Arj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall/rust,
@@ -13443,21 +13812,6 @@
 /obj/structure/sign/biohazard,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/virology)
-"Asd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
 "AsQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13593,6 +13947,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"ABr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "ADa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -13659,6 +14023,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"AFi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
 "AFy" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -13695,6 +14074,21 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
+"AIo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "AJC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -13711,6 +14105,16 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"AJR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
 "AKO" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
@@ -13731,12 +14135,17 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"AMA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+"AMs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hydroponics)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "AOf" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/gravity_generator)
@@ -13775,10 +14184,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"ATF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "AVp" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -13894,6 +14299,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
+"Bav" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
 "BbH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13979,12 +14396,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"BkZ" = (
-/obj/spacepod{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/cargo/mining)
 "Bpj" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber";
@@ -13993,6 +14404,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/turret_protected/ai)
+"Bpm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/loading)
+"Bpq" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/telecomms/computer)
 "Bpx" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14014,6 +14440,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
+"BsU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "BuZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14026,22 +14462,27 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"Bwg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
 "Bxj" = (
 /obj/machinery/computer/card/minor/ce,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"BxJ" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
 "BzH" = (
 /obj/machinery/door/window/southleft{
 	name = "Medbay";
@@ -14049,19 +14490,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"BzW" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
 "BCf" = (
 /obj/machinery/pdapainter,
 /obj/effect/decal/cleanable/dirt,
@@ -14084,14 +14512,21 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
-"BEi" = (
-/obj/machinery/light/small{
-	dir = 1
+"BEk" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
 	},
-/area/shuttle/ftl/medical/virology)
+/obj/machinery/door/firedoor,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/cmo)
 "BHm" = (
 /obj/structure/table,
 /obj/item/weapon/grenade/chem_grenade/cleaner,
@@ -14116,6 +14551,11 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
+"BKS" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "BNE" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/sign/securearea{
@@ -14125,6 +14565,18 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/meeting_room)
+"BQf" = (
+/obj/machinery/button/door{
+	id = "miningpodbay";
+	layer = 4;
+	name = "Mining Podbay Doors";
+	pixel_x = 8;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "BRp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14134,6 +14586,10 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"BSg" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "BSM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14145,24 +14601,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
-"BTy" = (
-/obj/machinery/light/small{
-	dir = 4
+"BUJ" = (
+/obj/machinery/conveyor_switch{
+	id = "CargoMunitions"
 	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
-"BUb" = (
-/obj/structure/disposalpipe/junction,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
+/area/shuttle/ftl/cargo/storage)
 "BVh" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -14198,6 +14643,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"BYb" = (
+/obj/structure/table/wood,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/device/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
 "Cbf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -14220,23 +14680,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions)
-"CcN" = (
+"Cei" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "7;9"
+	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engine_smes)
-"Cgk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
+/area/shuttle/ftl/maintenance/bridge)
 "ChO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14346,6 +14803,16 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/gravity_generator)
+"Ctt" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/storage)
 "CtK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
@@ -14362,10 +14829,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"CuE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engine_smes)
 "Cvm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -14412,6 +14875,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
+"CzC" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/shuttle/ftl/telecomms/computer)
 "CAe" = (
 /obj/machinery/camera{
 	c_tag = "Research Division South";
@@ -14635,13 +15105,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"CMO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
 "COt" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
@@ -14677,6 +15140,19 @@
 "CUe" = (
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
+"CUB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/atmos)
 "CYK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14697,6 +15173,25 @@
 	dir = 8
 	},
 /area/shuttle/ftl/turret_protected/ai)
+"DaK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "Ddv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14781,14 +15276,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
-"Diu" = (
-/obj/structure/window/reinforced{
-	dir = 4
+"Djt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/medical/sleeper)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "DjF" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/structure/cable{
@@ -14863,14 +15359,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"DoE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/camera_advanced/xenobio,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "Dpy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/darkblue/side{
@@ -14879,6 +15367,31 @@
 	dir = 9
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"Dro" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
+"DrI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "DrP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14948,19 +15461,6 @@
 "DAF" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"DBm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
 "DBO" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/toolbox/electrical{
@@ -15026,6 +15526,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"DDP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/meeting_room)
 "DER" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15044,6 +15560,14 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
+"DGy" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "DGT" = (
 /obj/machinery/door/window/brigdoor{
 	id = "Cell 1";
@@ -15274,18 +15798,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/secure_construction)
-"Edh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/mob/living/simple_animal/pet/cat/Runtime,
-/turf/open/floor/wood,
-/area/shuttle/ftl/medical/cmo)
 "Edt" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -15416,6 +15928,18 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"Ele" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
 "Elk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -15433,6 +15957,15 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"EmB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/security/armory)
 "Enm" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = -31
@@ -15542,13 +16075,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"EtS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/engineering)
 "EvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -15587,6 +16113,22 @@
 	dir = 5
 	},
 /area/shuttle/ftl/engine/engineering)
+"EwK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "EzV" = (
 /obj/structure/rack,
 /obj/item/pod_parts/armor/mining,
@@ -15633,15 +16175,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/starboard)
-"EBG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai)
 "ECr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"EDo" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	tag = "icon-dvalve_map (EAST)";
+	icon_state = "dvalve_map";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "EFx" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular,
@@ -15666,6 +16213,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
+"EHr" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
 "EJd" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/structure/cable{
@@ -15696,6 +16249,13 @@
 "EKA" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/office)
+"ELm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engine_smes)
 "ELr" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/engine/chiefs_office)
@@ -15781,6 +16341,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"ESg" = (
+/obj/structure/closet/secure_closet/captains,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "ESQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15822,6 +16394,14 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
+"EUR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "EVL" = (
 /turf/open/floor/plasteel/warning{
 	dir = 8
@@ -15845,15 +16425,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"EYY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"EXi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/medical/cmo)
 "EZu" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -15887,14 +16467,6 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Fbk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/genetics)
 "Fbl" = (
 /obj/machinery/gibber,
 /obj/effect/decal/cleanable/dirt,
@@ -15951,16 +16523,11 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/secure_construction)
-"FfG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
+"Fez" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
 /area/shuttle/ftl/medical/chemistry)
 "Fgf" = (
 /obj/structure/cable{
@@ -15971,6 +16538,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"Fgg" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "Fhm" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -15981,18 +16556,34 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"FhS" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/atmos_alert{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/stationalert,
+/obj/item/weapon/circuitboard/computer/powermonitor{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/machine/thermomachine/freezer{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
 "Fjg" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"FjG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/loading)
 "FjQ" = (
 /obj/machinery/dna_scannernew{
 	tag = ""
@@ -16033,6 +16624,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"Flp" = (
+/obj/structure/ore_box,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/mining)
 "Flq" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -16056,17 +16657,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
-"FmO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
 "Fpb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16095,19 +16685,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/turret_protected/ai)
-"Fqq" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_x = 30;
-	pixel_y = 4
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "FqK" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs,
@@ -16125,29 +16702,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
-"FqS" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/button/flasher{
-	id = "hopflash";
-	pixel_x = 10;
-	pixel_y = 40;
-	req_access_txt = "30"
-	},
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "30"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = 34
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "FtM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -16209,19 +16763,6 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"Fzq" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/office)
 "FzL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16294,6 +16835,13 @@
 	},
 /turf/open/floor/noslip,
 /area/shuttle/ftl/engine/engine_smes)
+"FDm" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
 "FDJ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -16395,17 +16943,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
-"FNK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 1";
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
+"FMv" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "FOc" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -16444,11 +16985,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"FQs" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/hallway/primary/starboard)
 "FRb" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -16472,6 +17008,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"FUe" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/storage)
 "FXz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -16511,16 +17065,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"Gda" = (
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
 "Gfx" = (
 /mob/living/simple_animal/pet/dog/corgi/Ian{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/heads)
-"GfO" = (
-/mob/living/simple_animal/bot/floorbot,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/assembly/robotics)
 "Ggh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16531,20 +17090,16 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"Ggi" = (
-/obj/structure/table/wood,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/device/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -3;
-	pixel_y = 8
+"Ghk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "Ghn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16560,6 +17115,18 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"GiM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
 "Gkh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -16575,6 +17142,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
+"GlP" = (
+/obj/machinery/door/window/southleft{
+	name = "Longsleep Cryopods"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/medical/sleeper)
 "GmN" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -16629,17 +17204,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
-"GrD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/eva)
 "GsF" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16664,15 +17228,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"Gtu" = (
+"Gue" = (
+/obj/structure/table/optable,
 /obj/structure/cable{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Surgery";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
 "GvT" = (
 /obj/machinery/recycler,
 /turf/open/floor/plating,
@@ -16780,6 +17357,24 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"GCW" = (
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/weapon/stamp/cmo,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/medical/cmo)
 "GEk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -16804,6 +17399,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/research/division)
+"GHM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "GJB" = (
 /obj/machinery/button/door{
 	dir = 2;
@@ -16839,17 +17442,6 @@
 /obj/vehicle/atv,
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/bridge/eva)
-"GMP" = (
-/obj/machinery/flasher/portable,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkwarning{
-	dir = 1
-	},
-/area/shuttle/ftl/security/armory)
 "GOA" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
@@ -16914,13 +17506,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"GUt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
 "GUI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17028,19 +17613,14 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"GZC" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"HaA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/fore)
 "HaX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17063,6 +17643,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"Hdk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "Hdw" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -17093,6 +17685,32 @@
 "HfS" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
+"HhG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
+"HjJ" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "HjM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -17108,11 +17726,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/sleeper)
-"HkS" = (
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
 "HlR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -17197,14 +17810,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/central)
-"HwH" = (
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "Hyv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17235,6 +17840,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"HGC" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "HHd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -17266,13 +17882,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
-"HKs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+"HNz" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
+/area/shuttle/ftl/hallway/primary/central)
 "HOx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -17299,29 +17914,12 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"HSq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "HSV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"HTH" = (
-/obj/machinery/computer/upload/borg,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai)
 "HUk" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -17346,44 +17944,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/chemistry)
-"HVH" = (
-/obj/structure/rack,
-/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
-	pixel_x = 2;
-	pixel_y = 9
-	},
-/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/weapon/grenade/syndieminibomb/concussion/frag{
-	pixel_x = 0;
-	pixel_y = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
-"HVL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/fore)
 "HVR" = (
 /obj/machinery/computer/med_data,
 /obj/structure/disposalpipe/segment{
@@ -17395,6 +17955,17 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"HYs" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/mecha_control{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/robotics,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
 "Iao" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17408,13 +17979,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
-"IbX" = (
-/obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,
-/obj/item/weapon/nullrod,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/shuttle/ftl/security/vacantoffice)
 "Icp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -17479,15 +18043,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
-"Ihg" = (
-/obj/structure/table,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
+"IgN" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/assembly/robotics)
 "Ihn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -17496,15 +18057,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"IhI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "IiO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
@@ -17539,30 +18091,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/central)
-"Ilu" = (
+"Imu" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/ftl/security/nuke_storage)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/fore)
 "ImK" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
@@ -17667,6 +18208,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"Itk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "Itx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
@@ -17697,6 +18247,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/tool_storage)
+"Iws" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "Ixb" = (
 /obj/structure/chair{
 	dir = 1
@@ -17726,42 +18281,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/genetics)
-"ICD" = (
-/obj/structure/table,
-/obj/item/weapon/circular_saw,
-/obj/item/weapon/scalpel{
-	pixel_y = 12
-	},
-/obj/item/weapon/hemostat,
-/obj/item/weapon/cautery{
-	pixel_x = 4
-	},
-/obj/item/weapon/surgicaldrill,
-/obj/item/weapon/retractor,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/surgery)
-"IDq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "IEk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -17909,23 +18428,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"ISy" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/weapon/stamp/cmo,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/medical/cmo)
 "ITh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -17982,14 +18484,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"IWW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/telecomms/computer)
 "IXy" = (
 /obj/effect/landmark/start{
 	name = "Atmospheric Technician";
@@ -18057,22 +18551,10 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/eva)
-"Jep" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "7;9"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/maintenance/bridge)
+"Jeo" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "Jes" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18094,6 +18576,29 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
+"JfD" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Research Airlock";
+	dir = 6;
+	name = "security camera";
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "JfM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -18127,6 +18632,28 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
+"Jkx" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "JkA" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -18149,18 +18676,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
-"JkX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/eva)
-"JlK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
 "Jmm" = (
 /obj/machinery/power/smes/engineering{
 	color = ""
@@ -18182,6 +18697,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"Jmt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "Jnl" = (
 /obj/machinery/door/poddoor{
 	id = "weapon_k_1";
@@ -18395,11 +18918,40 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"JIh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
 "JJy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"JJP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "JKJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -18435,6 +18987,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
+"JMZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos/equipment)
 "JOO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18484,12 +19051,23 @@
 	dir = 9
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"JUD" = (
-/obj/effect/landmark/start{
-	name = "Chief Engineer"
+"JUv" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"JWt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/engine/chiefs_office)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
 "JXK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -18506,30 +19084,24 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"JZK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
-"Kae" = (
-/obj/machinery/computer/pandemic,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+"JYS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
+"JZa" = (
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
+"JZE" = (
+/obj/machinery/camera/motion{
+	
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/circuit/rcircuit/animated,
+/area/shuttle/ftl/turret_protected/ai_upload)
 "Kar" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -18554,6 +19126,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"KbZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/ftl/assembly/robotics)
 "KcB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18582,24 +19159,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Kgp" = (
-/obj/machinery/nuclearbomb/selfdestruct,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 1
-	},
-/area/shuttle/ftl/security/nuke_storage)
 "Kko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18681,14 +19240,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/starboard)
-"KpT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
 "Kqy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18721,6 +19272,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
+"KtD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "KtO" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 8;
@@ -18779,6 +19340,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/research/server)
+"KxV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai)
 "Kzj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18825,6 +19398,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
+"KDS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "KEc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18887,33 +19470,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"KFR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
-"KGM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai_upload)
 "KHe" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -18974,15 +19530,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"KPa" = (
-/obj/structure/window,
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
+"KOT" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
+/area/shuttle/ftl/research/lab)
 "KPf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -19010,6 +19563,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
+"KRb" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions/office)
 "KSr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -19157,6 +19724,17 @@
 "LdK" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/nuke_storage)
+"Lek" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/assembly/robotics)
 "Lfs" = (
 /obj/structure/table/glass,
 /obj/structure/cable{
@@ -19177,6 +19755,15 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"LfY" = (
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
 "LiV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -19228,13 +19815,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"LqQ" = (
-/obj/machinery/camera/motion{
-	
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/circuit/rcircuit/animated,
-/area/shuttle/ftl/turret_protected/ai_upload)
 "LrQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19264,13 +19844,6 @@
 "LtU" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge)
-"LuZ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/fore)
 "Lvq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19298,6 +19871,23 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"Lwp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
+"LyA" = (
+/obj/machinery/computer/pandemic,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "LyT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -19416,6 +20006,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
+"LHl" = (
+/obj/structure/closet/crate/engineering,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
 "LHX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -19431,6 +20028,17 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
+"LIz" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "LKb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -19440,13 +20048,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"LKP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "LNy" = (
 /obj/machinery/door/poddoor/multi_tile/four_tile_hor{
 	id = "miningpodbay";
@@ -19513,16 +20114,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"LRC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
+"LQA" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
+/area/shuttle/ftl/security/nuke_storage)
 "LSy" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -19654,10 +20253,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/engine/engine_smes)
-"MaP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
 "MbK" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -19739,13 +20334,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"MrC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/central)
 "Mtv" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
@@ -19774,16 +20362,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/fore)
-"MzR" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start{
-	name = "Head of Security"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
 "MAk" = (
 /obj/structure/chair{
 	dir = 1
@@ -19808,6 +20386,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"MGN" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Quartermaster";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
 "MHn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19830,6 +20425,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/division)
+"MMN" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engine_smes)
 "MNi" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/machine/telecomms/broadcaster{
@@ -20232,6 +20834,13 @@
 "NvR" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hydroponics)
+"NwZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
 "Nyn" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/bar)
@@ -20342,27 +20951,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"NLh" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Gravity Generator";
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/gravity_generator)
-"NLI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkyellow,
-/area/shuttle/ftl/engine/tool_storage)
 "NLL" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/emergency,
@@ -20404,6 +20992,16 @@
 "NMe" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/brig)
+"NNm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/warnwhite/corner{
+	dir = 1
+	},
+/area/shuttle/ftl/research/lab)
 "NNM" = (
 /obj/structure/table/glass,
 /obj/item/stack/cable_coil{
@@ -20487,15 +21085,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"NVW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"NVG" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/eva)
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
 "NXI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -20526,6 +21134,10 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"NYC" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "ObJ" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -20541,6 +21153,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"ObV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Oct" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -20561,6 +21184,19 @@
 	dir = 6
 	},
 /area/shuttle/ftl/hydroponics)
+"Ods" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "Oef" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/computer/cloning{
@@ -20636,17 +21272,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
-"OkI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Oki" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/camera{
+	c_tag = "Bridge Airlock";
+	dir = 4
 	},
-/area/shuttle/ftl/research/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge/meeting_room)
 "OlA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -20729,6 +21367,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
+"OsF" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "Otm" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/decal/cleanable/dirt,
@@ -20748,30 +21395,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"OwL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
-"OxM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+"Ozg" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/engine/chiefs_office)
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "OzD" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
@@ -20811,6 +21448,32 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
+"OFv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai_upload)
+"OGs" = (
+/obj/machinery/nuclearbomb/selfdestruct,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "OGx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_mining{
@@ -20891,6 +21554,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"OLE" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "OLO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -20903,21 +21581,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"ONU" = (
-/obj/effect/landmark/start{
-	name = "Medical Doctor";
-	shuttle_abstract_movable = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/surgery)
 "ONW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20968,16 +21631,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/cargo/office)
-"OUN" = (
-/obj/machinery/light/small{
+"OWB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "OWZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -21035,36 +21699,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/medical/sleeper)
-"PaU" = (
-/obj/structure/disposalpipe/segment{
+"PbP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/eva)
-"Pda" = (
-/obj/structure/table/optable,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Surgery";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/surgery)
+/area/shuttle/ftl/engine/engineering)
 "Pdv" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -21074,21 +21720,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"PdM" = (
-/obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = 22
-	},
+"Ped" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/shuttle/ftl/security/nuke_storage)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "Pej" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -21131,15 +21776,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/office)
-"PiF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+"Pjt" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm{
+	dir = 2;
+	pixel_y = 24
 	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "PkY" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -21162,18 +21811,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/storage)
-"PlJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/meeting_room)
 "PlM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
@@ -21236,6 +21873,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"Pqn" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/atmos/equipment)
 "Pqq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -21257,6 +21903,22 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"PwK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "PyM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -21333,17 +21995,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"PBt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering)
 "PBI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -21373,6 +22024,17 @@
 "PDj" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/space)
+"PDJ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/atmos)
 "PEU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21414,17 +22076,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"PFR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/division)
 "PHD" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21447,6 +22098,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"PLf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engine_smes)
+"PLN" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge/eva)
 "PLQ" = (
 /turf/open/floor/plasteel{
 	icon_state = "bot"
@@ -21582,6 +22255,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/chemistry)
+"Qad" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/meeting_room)
 "QaO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply{
 	dir = 1
@@ -21630,11 +22316,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
-"Qhl" = (
-/obj/machinery/chem_dispenser/constructable,
+"Qga" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/division)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/atmos)
 "Qhy" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /obj/structure/window/reinforced{
@@ -21659,6 +22351,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
+"Qmm" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge/meeting_room)
 "QmH" = (
 /obj/machinery/vending/clothing,
 /obj/effect/decal/cleanable/dirt,
@@ -21760,18 +22460,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"QyX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
+"QCq" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/genetics)
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge/meeting_room)
 "QFG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"QGb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "QGi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21877,11 +22586,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"QNp" = (
-/turf/open/floor/plasteel/warning{
-	dir = 1
-	},
-/area/shuttle/ftl/cargo/mining)
 "QNF" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21938,26 +22642,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"QTd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
-"QUa" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
 "QVR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -21983,11 +22667,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
-"QYU" = (
-/obj/machinery/computer/card,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
 "QZt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -22058,6 +22737,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
+"RhH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/r_n_d/destructive_analyzer,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/lab)
 "RkK" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/decal/cleanable/dirt,
@@ -22074,6 +22759,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
+"RqT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/mining)
 "Rrt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel{
@@ -22166,6 +22863,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
+"RDQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/shuttle/ftl/medical/chemistry)
 "RFB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -22203,6 +22913,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"RMn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "RQo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -22232,19 +22960,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/telecomms/computer)
-"RUf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "RUi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22258,24 +22973,68 @@
 "RWG" = (
 /turf/closed/wall/rust,
 /area/shuttle/ftl/crew_quarters/locker)
+"RZG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "Sbz" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/storage)
-"Sff" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+"Scd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
+"Sdj" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos/equipment)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTHWEST)";
+	icon_state = "darkblue";
+	dir = 9
+	},
+/area/shuttle/ftl/atmos)
+"SeQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "SfI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/emcloset,
@@ -22288,6 +23047,28 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"Sgu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "Sgv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22409,6 +23190,41 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/munitions/cannon)
+"Ssl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Holding Pen";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"Sso" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/button/flasher{
+	id = "hopflash";
+	pixel_x = 10;
+	pixel_y = 40;
+	req_access_txt = "30"
+	},
+/obj/machinery/button/door{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "30"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = 34
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "SuE" = (
 /obj/machinery/conveyor{
 	id = "QMLoad";
@@ -22429,6 +23245,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"Swd" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
 "Swy" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -22444,6 +23266,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"SAI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "SBh" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8;
@@ -22468,14 +23300,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
-"SCh" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "SDb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22534,16 +23358,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"SHl" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "munitions";
-	tag = "munitions east"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/loading)
 "SId" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -22587,12 +23401,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"SIA" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
 "SIY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -22604,6 +23412,11 @@
 "SJV" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
+"SKA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/turret_protected/ai)
 "SKN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -22648,6 +23461,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/cargo/office)
+"SMX" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos/equipment)
 "SNo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22691,6 +23517,23 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/security/brig)
+"SPN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 8
+	},
+/area/shuttle/ftl/research/lab)
+"SRx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/security/vacantoffice)
 "SRI" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -22709,21 +23552,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"STa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "STc" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -22751,17 +23579,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
-"SXY" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
 "SYl" = (
 /obj/machinery/airalarm{
 	dir = 2;
@@ -22800,13 +23617,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/munitions/cannon)
-"SZv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+"SZm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/engine/chiefs_office)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "SZz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -22857,14 +23675,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
-"Tbj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/computer/security,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
 "Tbk" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -22876,10 +23686,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"TbN" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/hallway/primary/starboard)
 "Tde" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22951,21 +23757,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"TlC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
-"ToN" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
 "ToY" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
 /obj/structure/window/reinforced{
@@ -23018,19 +23809,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"TrL" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "7;9"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
 "Tus" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -23079,6 +23857,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"Txe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/security/vacantoffice)
 "TxJ" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4;
@@ -23100,17 +23891,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
-"Tzq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/lab)
 "TBn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
+"TBE" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
 "TCs" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -23154,6 +23960,16 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/security/detectives_office)
+"TEd" = (
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/assembly/robotics)
 "TEp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -23163,6 +23979,14 @@
 "TEw" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/hallway/primary/fore)
+"TEy" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "TFC" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -23177,28 +24001,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"TGK" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/atmos_alert{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/stationalert,
-/obj/item/weapon/circuitboard/computer/powermonitor{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/weapon/circuitboard/machine/thermomachine/freezer{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
 "TIq" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer"
@@ -23219,6 +24021,17 @@
 "TJP" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
+"TJQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
 "TLR" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -23236,15 +24049,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"TMU" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
+"TMM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"TNO" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "TNX" = (
 /obj/effect/landmark/start{
 	name = "Security Officer";
@@ -23332,24 +24157,6 @@
 	dir = 6
 	},
 /area/shuttle/ftl/medical/chemistry)
-"TTW" = (
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1;
-	desc = "It's a secure locker for personnel.";
-	name = "Kazaaak-Aerwhisp's closet";
-	registered_name = "Kazaaak-Aerwhisp"
-	},
-/obj/item/clothing/suit/jacket/leather/overcoat,
-/obj/item/weapon/reagent_containers/food/drinks/flask/det{
-	desc = "Friend of the detective. This one, like the detective, seems to have spent too much time in the kitchen, however.";
-	name = "Over-Boiled detective's flask"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/locker)
 "TWL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -23357,27 +24164,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"TXg" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/gloves/color/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos/equipment)
-"TXT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/obj/machinery/camera{
-	busy = 0;
-	c_tag = "Munitions North";
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
 "TYc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23425,6 +24211,28 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"TZi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/medical/cmo)
 "TZr" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -23512,20 +24320,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"UhD" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"Uhz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "Uic" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -23550,20 +24352,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"Ujk" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
 "UjD" = (
 /obj/machinery/door/window/northright{
 	name = "Server Room";
@@ -23901,6 +24689,14 @@
 	},
 /turf/open/floor/engine/n2,
 /area/shuttle/ftl/atmos)
+"UMf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
 "UMr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23976,19 +24772,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"UUk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "UUq" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/decal/cleanable/dirt,
@@ -24001,6 +24784,27 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
+"UUA" = (
+/obj/machinery/disposal/bin{
+	name = "corpse disposal unit"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Genetics";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
 "UVI" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/toilet)
@@ -24125,14 +24929,21 @@
 "VfT" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/mining)
-"VhT" = (
-/obj/structure/dresser,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
+"VgH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
+/area/shuttle/ftl/security/detectives_office)
 "VhW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24227,13 +25038,12 @@
 /obj/structure/sink/kitchen,
 /turf/closed/wall,
 /area/shuttle/ftl/hydroponics)
-"VnI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+"VnH" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkwarning{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
+/area/shuttle/ftl/security/armory)
 "VoP" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -24270,25 +25080,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Vyh" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "0"
-	},
-/obj/docking_port/stationary{
-	dheight = 8;
-	dir = 2;
-	dwidth = 95;
-	height = 59;
-	id = "ftl_start";
-	name = "Starting Area";
-	width = 153
-	},
-/obj/structure/fans/tiny,
-/obj/docking_port/mobile/ftl,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "VyT" = (
 /obj/machinery/camera{
 	c_tag = "R&D Server Room";
@@ -24312,15 +25103,6 @@
 /obj/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/ftl/subshuttle/pod_3)
-"VFu" = (
-/obj/effect/landmark/start{
-	name = "Geneticist";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/genetics)
 "VFP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24331,6 +25113,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
+"VGo" = (
+/obj/item/weapon/storage/book/bible,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
 "VGU" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions)
@@ -24431,25 +25220,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"VNF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/telecomms/computer)
 "VPN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24467,6 +25237,16 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/engine/engine_smes)
+"VQK" = (
+/obj/effect/landmark/start{
+	name = "Geneticist";
+	shuttle_abstract_movable = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
 "VRE" = (
 /obj/structure/sink{
 	icon_state = "sink";
@@ -24485,10 +25265,29 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/munitions)
+"VUc" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "VUj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
+"VUW" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
 "VVD" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -24496,13 +25295,23 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"VWT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+"VXo" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/security/vacantoffice)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
 "VYg" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -24594,12 +25403,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
-"WiA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "WmS" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -24665,6 +25468,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
+"WoY" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "Wqi" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24688,10 +25501,6 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/medbay)
-"WtB" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
 "WvC" = (
 /obj/machinery/light{
 	dir = 8
@@ -24714,6 +25523,13 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
+"Wxx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/secure_construction)
 "WxK" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/structure/cable{
@@ -24765,6 +25581,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"WCi" = (
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/bot/floorbot,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/assembly/robotics)
 "WCw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24788,21 +25609,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"WDj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/meeting_room)
 "WFe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24865,30 +25671,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"WHB" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
-"WIs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "WIP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -24904,18 +25686,13 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"WKY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions/loading)
-"WMB" = (
-/obj/machinery/door/window/southleft{
-	name = "Longsleep Cryopods"
+"WKn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/medical/sleeper)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "WMT" = (
 /obj/effect/landmark/start{
 	name = "Research Director"
@@ -24956,23 +25733,6 @@
 "WNK" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/medbay_lobby)
-"WOk" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/storage)
 "WOT" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/main)
@@ -24996,6 +25756,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/telecomms/server)
+"WPZ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/chemistry)
 "WQl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25015,22 +25788,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
-"WRR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Holding Pen";
-	dir = 1
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
-"WSz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/secure_construction)
 "WSX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -25056,28 +25813,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"WVZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+"WUB" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Bar Entry";
-	dir = 4
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/assembly/robotics)
+"WVG" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/partyalarm{
-	desc = "Cuban Pete is in the house! (Mapper note: If you are prone to seizures and you press this, you might be in for a gnarly ride.)";
-	dir = 8;
-	name = "\improper PARTY BUTTON";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/nuke_storage)
 "WWV" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -25156,6 +25910,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/shuttle/ftl/crew_quarters/bar)
+"XdH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "XfL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -25182,6 +25949,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"Xih" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/yellow,
+/area/shuttle/ftl/engine/tool_storage)
 "XiI" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -25259,6 +26039,16 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/secure_construction)
+"Xld" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_construct,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "Xnm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -25283,6 +26073,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"Xsv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "XvQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -25344,6 +26147,21 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"XCl" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
 "XDt" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -25370,21 +26188,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"XGf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
-"XHs" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
+"XHN" = (
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/atmos/equipment)
+/area/shuttle/ftl/bridge/eva)
 "XIn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25446,15 +26253,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/shuttle/ftl/atmos)
-"XNO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engineering)
 "XOg" = (
 /obj/structure/sink{
 	dir = 4;
@@ -25469,15 +26267,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"XOQ" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/assembly/robotics)
 "XPf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25518,14 +26307,34 @@
 "XVI" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge/meeting_room)
-"XXw" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
+"XWy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel{
+	icon_state = "bar"
 	},
+/area/shuttle/ftl/crew_quarters/kitchen)
+"XXe" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
+"XYy" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
+/area/shuttle/ftl/engine/engineering)
 "XYU" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -25563,18 +26372,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"Yfo" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge/eva)
 "Yhk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25586,12 +26383,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"YiQ" = (
-/obj/structure/closet/crate/engineering,
-/turf/open/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/ftl/cargo/storage)
+"Yhr" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "YjG" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -25652,6 +26450,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"Ypz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "YqI" = (
 /obj/machinery/smartfridge/chemistry/virology,
 /obj/effect/decal/cleanable/dirt,
@@ -25709,6 +26515,13 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"YsU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "Ytm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25770,16 +26583,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/computer)
+"Yzn" = (
+/obj/machinery/computer/card,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "Yzz" = (
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"YzG" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/storage)
 "YAo" = (
 /obj/structure/chair{
 	dir = 1
@@ -25831,24 +26643,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"YGp" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+"YDd" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/latejoin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"YFd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Equipment";
+	req_access_txt = "15"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos/equipment)
 "YHL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25879,6 +26704,13 @@
 "YJV" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
+"YLo" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "YLu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -25908,6 +26740,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"YLZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
 "YMH" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -25962,17 +26801,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/loading)
-"YSk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/plasteel/warning{
-	dir = 4
-	},
-/area/shuttle/ftl/cargo/mining)
 "YSr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25983,12 +26811,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"YSB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "YTQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/firecloset,
@@ -26026,14 +26848,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"YWa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/medical/cmo)
 "YXz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -26164,22 +26978,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"ZoR" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Quartermaster";
-	shuttle_abstract_movable = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
 "ZrB" = (
 /obj/machinery/button/door{
 	id = "Supermatter port";
@@ -26213,6 +27011,11 @@
 	dir = 10
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"ZuL" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
 "Zvn" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
@@ -26232,6 +27035,25 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"ZAO" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Hallway North"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/lizard{
+	desc = "A cute tiny lizard.";
+	name = "Faster-Than-Lizard\(13\)"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
+"ZAW" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "ZCx" = (
 /obj/machinery/computer/crew,
 /obj/structure/cable{
@@ -26268,40 +27090,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"ZDF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/medical/cmo)
-"ZDO" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/space,
-/area/shuttle/ftl/security/nuke_storage)
 "ZEa" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
@@ -26460,9 +27248,25 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"ZVt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "ZWw" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/security/detectives_office)
+"ZWF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "ZXO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32773,7 +33577,7 @@ IvE
 IvE
 ZlR
 pDD
-cfi
+WoY
 dwM
 jUu
 jUu
@@ -32801,7 +33605,7 @@ Fel
 quT
 iyk
 iyk
-iyk
+dyF
 vzF
 Hsb
 Tpw
@@ -33029,9 +33833,9 @@ IvE
 IvE
 IvE
 IvE
-IvE
-HKs
-DBm
+nZt
+eBI
+Ped
 ZMy
 VPN
 VPN
@@ -33057,9 +33861,9 @@ IvE
 IvE
 fJv
 HfS
-HfS
-WSz
-cpp
+BSg
+KDS
+EDo
 yGV
 Tpw
 sme
@@ -33287,7 +34091,7 @@ IvE
 IvE
 IvE
 IvE
-GUt
+gkR
 VHM
 xpr
 HjM
@@ -33315,7 +34119,7 @@ XkS
 MAQ
 HfS
 Rtb
-fCh
+Wxx
 TEp
 Cpd
 Tpw
@@ -34573,7 +35377,7 @@ Ixb
 ToY
 bvC
 LQq
-yMw
+Ghk
 GzL
 qgP
 IaL
@@ -34829,9 +35633,9 @@ CUe
 MAk
 AWO
 OtG
-IDq
-dvG
-GzL
+sSb
+wUK
+YDd
 qgP
 IaL
 Jqu
@@ -35087,7 +35891,7 @@ Ixb
 pSv
 bvC
 bce
-yMw
+Ghk
 GzL
 qgP
 iyj
@@ -35115,7 +35919,7 @@ UCn
 oKO
 OPU
 PeA
-ADa
+eXq
 VvS
 dRD
 sme
@@ -35358,7 +36162,7 @@ rJj
 lqk
 mjh
 Brz
-CcN
+PLf
 gCb
 rPy
 rPy
@@ -35371,9 +36175,9 @@ UfQ
 UfQ
 rPy
 rPy
-FNK
-VnI
-VvS
+kzy
+lda
+zdM
 dRD
 sme
 sme
@@ -35614,9 +36418,9 @@ SCc
 Dpy
 Jci
 HSV
-RaZ
-CuE
-gQY
+MMN
+uqe
+ouh
 POZ
 Pdv
 QJU
@@ -35629,7 +36433,7 @@ OLO
 dcI
 ptk
 NTj
-ADa
+eXq
 VvS
 awP
 sme
@@ -35872,7 +36676,7 @@ typ
 rkV
 vvi
 pKx
-zOi
+ELm
 SqE
 rPy
 jxD
@@ -37153,7 +37957,7 @@ xaa
 dnq
 qFw
 jZv
-Cgk
+Scd
 ovd
 yow
 Pmv
@@ -37409,11 +38213,11 @@ TRG
 wHI
 Wah
 Wah
-Wah
-MaP
-TlC
+NYC
+JYS
+SZm
 jYm
-uiH
+enB
 ZJK
 MTo
 rPy
@@ -37648,7 +38452,7 @@ sme
 Ppy
 OoX
 gCF
-JkX
+hBd
 ace
 IJs
 IJs
@@ -37667,11 +38471,11 @@ aRb
 Zdg
 hin
 WNG
-foI
+OsF
 YYX
 XSX
-ukS
-PBt
+aKq
+fCG
 mDa
 rPy
 CIn
@@ -37904,9 +38708,9 @@ sme
 sme
 fdE
 WWV
-gCF
-NVW
-Yfo
+XHN
+kuf
+PLN
 IJs
 JkJ
 vrl
@@ -38162,12 +38966,12 @@ sme
 Jde
 nmc
 gCF
-PaU
+KtD
 qNk
 ZXO
 nRv
 nRv
-GrD
+Hdk
 nRv
 swf
 TxO
@@ -38189,7 +38993,7 @@ AsQ
 mDa
 rPy
 iKr
-tfy
+Qga
 Mmb
 TQY
 GoO
@@ -38423,9 +39227,9 @@ fCx
 aBu
 bSy
 bSy
-spz
-AbZ
-ygW
+DGy
+egJ
+Iws
 ygW
 eRb
 nYR
@@ -38436,18 +39240,18 @@ cAO
 EWe
 AKO
 JAo
-AKO
+xAY
 AKO
 Bxj
 cAO
 fCS
-xPL
+sNx
 EwG
 lQA
 ptk
-qMY
-ocC
-gaM
+PDJ
+CUB
+Sdj
 nOc
 gvk
 SuR
@@ -38681,7 +39485,7 @@ nmz
 IJs
 JkJ
 dUA
-JkJ
+utr
 JkJ
 IJs
 lkQ
@@ -38692,18 +39496,18 @@ sLN
 cAO
 agJ
 AKO
-gum
-OxM
-JUD
+jqa
+QGb
+sCI
 PUH
 RQo
-iUN
-XNO
-iQN
+Lwp
+sKA
+PbP
 mDa
 rPy
 Etw
-Fqq
+pNO
 psx
 YUf
 Ysm
@@ -38950,18 +39754,18 @@ cAO
 LnG
 yEE
 Ksi
-SZv
+ZWF
 lvi
 JtB
 ekz
 xLD
-aXH
+oRx
 bqk
 UVX
 rPy
 rPy
 rPy
-qjU
+Abo
 rPy
 rPy
 rPy
@@ -39211,7 +40015,7 @@ wWi
 wWi
 wWi
 wWi
-bAC
+ZAO
 NFK
 Sqb
 Aej
@@ -39466,7 +40270,7 @@ AtA
 AOf
 Crk
 pMW
-vAq
+rYP
 WPx
 Snw
 WnF
@@ -39484,7 +40288,7 @@ xPF
 Tbk
 sZx
 RhC
-bYM
+fmE
 mnz
 hZG
 sme
@@ -39704,7 +40508,7 @@ sme
 LNy
 Qes
 wIf
-Ihg
+hWB
 EzV
 mNZ
 oDt
@@ -39722,8 +40526,8 @@ AOf
 AOf
 AOf
 AOf
-AOf
-NLh
+Jeo
+OLE
 wWi
 Mvd
 Kzj
@@ -39732,7 +40536,7 @@ YYQ
 XDw
 XDw
 RGW
-mFv
+YFd
 XDw
 XDw
 Mvd
@@ -39740,9 +40544,9 @@ Mvd
 Mvd
 Mvd
 Mvd
-eRa
-cOf
-mnz
+ObV
+XdH
+Ypz
 hZG
 sme
 sme
@@ -39960,9 +40764,9 @@ sme
 sme
 uKJ
 MNU
-BkZ
-gpi
-hbF
+pdW
+ykS
+BQf
 ugi
 meI
 sjs
@@ -39980,12 +40784,12 @@ AOf
 AOf
 aXz
 AOf
-xwR
+WKn
 VsD
 qIA
 qvR
 rxF
-pku
+Yhr
 XDw
 nhU
 FBu
@@ -39998,7 +40802,7 @@ mol
 olz
 wXQ
 RhC
-jQN
+HGC
 mnz
 dRD
 sme
@@ -40218,7 +41022,7 @@ sme
 uKJ
 MNU
 MNU
-QNp
+dFE
 fAz
 OGx
 fAz
@@ -40241,8 +41045,8 @@ AOf
 wWi
 CoB
 DzC
-EtS
-gvS
+szh
+Xld
 XDw
 VHj
 wrU
@@ -40250,7 +41054,7 @@ mJy
 Cou
 XDw
 aqq
-scs
+Txe
 nuf
 mgh
 QRI
@@ -40484,7 +41288,7 @@ CBo
 hiO
 mNZ
 qTu
-swy
+zNY
 vMb
 iXC
 sLN
@@ -40499,16 +41303,16 @@ wWi
 ChO
 eLe
 qXu
-ChO
+XYy
 XDw
 MAG
 jJj
 vTA
 AQw
 XDw
-rpv
-xBh
-VWT
+hrP
+kpy
+SRx
 kXa
 wXQ
 KQV
@@ -40737,12 +41541,12 @@ mNZ
 mNZ
 mNZ
 yac
-Gtu
+ABr
 jkp
 mNZ
-jHl
-HSq
-UUk
+Uhz
+HhG
+Ozg
 iXC
 sLN
 wWi
@@ -40760,11 +41564,11 @@ Mvd
 XDw
 ohL
 Xwd
-vTA
+xHb
 hhV
 XDw
 Wok
-IbX
+jPC
 lVd
 rwN
 wXQ
@@ -40993,12 +41797,12 @@ nKu
 QHv
 PLQ
 mNZ
-uKx
-gNB
-jdd
+jNx
+DrI
+Flp
 mNZ
 qTu
-swy
+zNY
 vMb
 iXC
 wqu
@@ -41016,9 +41820,9 @@ Efl
 FAc
 XDw
 ncx
-XHs
-gdR
-TXg
+Pqn
+JMZ
+jAh
 XDw
 sCe
 rGl
@@ -41248,10 +42052,10 @@ PeZ
 nKu
 Sbz
 xcF
-YiQ
+LHl
 mNZ
 mVQ
-YSk
+RqT
 pCs
 mNZ
 qTu
@@ -41274,7 +42078,7 @@ KcB
 XDw
 wiF
 wiF
-Sff
+SMX
 fcr
 XDw
 nqG
@@ -41504,8 +42308,8 @@ sKE
 POB
 lEa
 Jsa
-emY
-YzG
+BUJ
+Ctt
 mNZ
 bCs
 wlu
@@ -41762,7 +42566,7 @@ apY
 SuE
 IeK
 wSy
-WOk
+FUe
 UBh
 wMS
 agv
@@ -41793,7 +42597,7 @@ sMm
 Tvp
 HEH
 LVO
-efw
+vUx
 yFO
 HEH
 bUL
@@ -42049,9 +42853,9 @@ CKy
 CKy
 rEB
 GWB
-UhD
-zve
-mCq
+oLo
+wNr
+VUW
 nag
 wYM
 tbp
@@ -42290,7 +43094,7 @@ YJV
 Dgo
 wQt
 YLA
-HkS
+EHr
 WQl
 pit
 SOT
@@ -42307,7 +43111,7 @@ CKy
 KcB
 HEH
 kZU
-gyq
+yxK
 AEG
 HEH
 KQV
@@ -42546,9 +43350,9 @@ iXC
 YJV
 Dgo
 wQt
-fxq
-QTd
-FmO
+Gda
+XWy
+JWt
 vmD
 tbS
 fCZ
@@ -42557,7 +43361,7 @@ gEK
 dlA
 LjD
 cjZ
-dQJ
+Swd
 lWe
 YMH
 CKy
@@ -42804,7 +43608,7 @@ YJV
 xaf
 wQt
 wQt
-BxJ
+sUG
 ZOw
 kzg
 DNI
@@ -42813,9 +43617,9 @@ wQt
 rSC
 Vnu
 LjD
-AMA
-bbS
-lWe
+emN
+fDE
+GiM
 YMH
 CKy
 KcB
@@ -43048,7 +43852,7 @@ uVF
 uyc
 PKI
 gJC
-KpT
+vAU
 aOf
 bZn
 bOO
@@ -43066,12 +43870,12 @@ jVU
 nGX
 cWq
 zlq
-uGV
+VUc
 gZm
 CKy
 kIB
 Idw
-dQJ
+Swd
 lWe
 YMH
 CKy
@@ -43304,9 +44108,9 @@ hYu
 lwg
 hYu
 tOp
-BUb
-Asd
-mCA
+sWK
+Bwg
+Bav
 OJW
 BEf
 ffs
@@ -43318,7 +44122,7 @@ YJV
 xaf
 krd
 bzq
-bzq
+rDN
 bgt
 wWN
 rhj
@@ -43562,7 +44366,7 @@ Icp
 OSx
 zaE
 glv
-ZoR
+MGN
 Lce
 jlx
 tPF
@@ -43574,9 +44378,9 @@ iXC
 dWP
 xaf
 cIr
-bzq
-fmV
-XGf
+rDN
+ZVt
+ieQ
 TLR
 QNa
 Kvn
@@ -43832,7 +44636,7 @@ YJV
 xaf
 erp
 JJy
-KPa
+gOt
 bgt
 Xdc
 KuJ
@@ -44347,9 +45151,9 @@ iXC
 sme
 sme
 nQi
-IhI
-WVZ
-STa
+jyE
+ySk
+lgR
 nQi
 sme
 sme
@@ -44365,7 +45169,7 @@ Hkk
 Hkk
 Hkk
 Hkk
-gtC
+qcY
 RhC
 glA
 mnz
@@ -44603,9 +45407,9 @@ YJV
 iXC
 sme
 sme
-nGy
+vHI
 bgt
-zsO
+Itk
 vVh
 nQi
 sme
@@ -44621,8 +45425,8 @@ zbO
 UBq
 UBq
 UBq
-UBq
-WMB
+wjv
+GlP
 kJQ
 glA
 UKk
@@ -44858,15 +45662,15 @@ ZPF
 ZbN
 qTY
 iXC
-hPn
-hPn
+iBo
+iBo
 xaf
 yhF
 bVB
 MTu
 xaf
-FQs
-TbN
+wIr
+wAk
 NvR
 cYM
 OIp
@@ -44879,7 +45683,7 @@ PaH
 yoa
 PaH
 PaH
-Diu
+dNB
 RhC
 glA
 TCJ
@@ -45098,9 +45902,9 @@ sme
 sme
 sme
 sme
-Vyh
+qdP
 cfg
-kCK
+Jmt
 cfg
 Pmj
 cfg
@@ -45133,7 +45937,7 @@ lRJ
 lRJ
 nwO
 lRJ
-LKP
+pHH
 lRJ
 lRJ
 lRJ
@@ -45389,9 +46193,9 @@ EAf
 Cvm
 icv
 rml
-icv
-doq
-icv
+LIz
+feh
+LIz
 icv
 icv
 icv
@@ -45612,9 +46416,9 @@ sme
 sme
 sme
 sme
-baI
+snV
 cfg
-kCK
+Jmt
 cfg
 doQ
 ijO
@@ -45647,7 +46451,7 @@ bWI
 pVR
 wpV
 GRx
-GRx
+tNJ
 GRx
 GRx
 AaA
@@ -46154,7 +46958,7 @@ sme
 sme
 Gkh
 TCs
-ecS
+gjg
 Jwx
 vTG
 cGF
@@ -46162,8 +46966,8 @@ UUq
 hvy
 Qrx
 mqV
-ceC
-SCh
+flI
+twQ
 Rom
 Lfs
 qoh
@@ -46389,7 +47193,7 @@ AxL
 AxL
 FJv
 dHH
-zlY
+TMM
 INs
 LGN
 yaB
@@ -46409,17 +47213,17 @@ PAZ
 mGq
 sme
 sme
-Gkh
+Fez
 tpB
-FfG
-iZi
+WPZ
+RDQ
 GSo
 QGi
 UmG
 SDb
 OYB
 mqV
-BEi
+Aqc
 ERV
 yHC
 Kko
@@ -46645,14 +47449,14 @@ XAS
 XAS
 XAS
 XAS
-cba
-OkI
-DoE
+HjJ
+fpo
+pCJ
 XKi
 TgB
 TRj
 iBY
-Tzq
+RhH
 CpP
 FXz
 KFM
@@ -46668,7 +47472,7 @@ sme
 sme
 xXk
 xve
-hhR
+kzi
 PZO
 vTG
 eQe
@@ -46903,14 +47707,14 @@ gPT
 DAF
 Tus
 AeD
-uKb
+AMs
 wzz
 YwV
 yaB
 Rgf
-msE
-sYO
-kkO
+NNm
+SPN
+KOT
 wrD
 NNM
 Gxn
@@ -46933,7 +47737,7 @@ slQ
 KCi
 sVD
 mqV
-Kae
+LyA
 fOz
 DVX
 yxl
@@ -47166,7 +47970,7 @@ YwV
 qAL
 lWD
 MXK
-yaB
+ics
 yaB
 ADk
 AWa
@@ -47190,8 +47994,8 @@ bAS
 GWo
 NJb
 TZr
-WiA
-vds
+shl
+hue
 sKa
 aVN
 ynt
@@ -47439,9 +48243,9 @@ sme
 sme
 Juf
 HsM
-xRQ
-OwL
-KFR
+SeQ
+jpC
+Sgu
 wim
 VeA
 heg
@@ -47451,7 +48255,7 @@ mqV
 mqV
 mqV
 Arx
-hDF
+AoM
 Gtc
 mqV
 sme
@@ -47697,7 +48501,7 @@ sme
 Kar
 eOQ
 hBM
-zUK
+XXe
 jXL
 VaB
 SMk
@@ -47965,7 +48769,7 @@ BJw
 TBn
 mqV
 mqV
-zFg
+vCF
 hxy
 mqV
 sme
@@ -48224,7 +49028,7 @@ jme
 dlR
 lsM
 WsW
-SWo
+wmb
 sme
 sme
 sme
@@ -48460,7 +49264,7 @@ sme
 sme
 biz
 YSr
-KEc
+vuf
 sCC
 AJC
 QZt
@@ -48716,9 +49520,9 @@ iUc
 cdr
 cdr
 KFi
-eub
-RUf
-ejz
+wIo
+qKp
+mrO
 iMG
 WNK
 WNK
@@ -48968,13 +49772,13 @@ pUt
 UdH
 OZP
 MME
-xmL
+JfD
 duP
 zdL
 GHp
 KuI
 ikg
-hea
+RZG
 PAZ
 biz
 sme
@@ -48991,9 +49795,9 @@ CAA
 Jre
 OWZ
 yWF
-ICD
-zhy
-fnY
+sWX
+AFi
+VXo
 qXp
 mrt
 sme
@@ -49225,8 +50029,8 @@ cjN
 wvs
 tKh
 Ypi
-JZK
-wvs
+pSP
+miW
 pCH
 Ypi
 LKb
@@ -49249,7 +50053,7 @@ eeE
 DjF
 Xnm
 SIk
-ONU
+XCl
 Ofl
 mrt
 mrt
@@ -49482,7 +50286,7 @@ dnr
 kfJ
 xGP
 AmT
-xJp
+wDi
 SfI
 YTQ
 UnH
@@ -49503,10 +50307,10 @@ kcx
 erJ
 PAh
 Yrv
-ZDF
+TZi
 bua
 Iqd
-Pda
+Gue
 AeA
 mrt
 sme
@@ -49758,9 +50562,9 @@ kaE
 gya
 EFx
 ivW
-wGH
-ISy
-Edh
+BEk
+GCW
+fag
 CAA
 CAA
 mrt
@@ -49989,9 +50793,9 @@ cdr
 cdr
 KOd
 eld
-PFR
-frS
-aqc
+Ele
+JIh
+JJP
 Fjg
 HcR
 jzw
@@ -50010,14 +50814,14 @@ sme
 ICv
 GsF
 Jbv
-Fbk
+xSM
 kLq
-uhS
+nDT
 FPy
 ivW
 oIu
 ZCx
-YWa
+EXi
 WmS
 CAA
 mrt
@@ -50247,7 +51051,7 @@ cdr
 cRf
 jNA
 jji
-Qhl
+wXg
 cAD
 ZiB
 HcR
@@ -50266,9 +51070,9 @@ sme
 sme
 ICv
 IJZ
-wfq
-QyX
-bzN
+kza
+AJR
+UUA
 EfT
 wGa
 Ywm
@@ -50524,7 +51328,7 @@ sme
 ICv
 gKa
 pzc
-VFu
+VQK
 GKJ
 Gad
 pLs
@@ -51790,12 +52594,12 @@ sme
 ksn
 xPT
 Eet
-apd
-ylu
-aWI
+VGo
+cxL
+ulp
 NMe
 Whx
-vwY
+gQb
 jfI
 DxI
 xWI
@@ -51807,7 +52611,7 @@ WNj
 tlQ
 fBO
 wSr
-wSr
+gWl
 EAb
 XQA
 aWu
@@ -52048,12 +52852,12 @@ ksn
 xPT
 Eet
 fZS
-ljy
-WRR
+ZuL
+Ssl
 NMe
-cog
-WIs
-wcS
+Pjt
+VgH
+FMv
 omC
 iek
 ZWw
@@ -52309,7 +53113,7 @@ Elk
 vuu
 NMe
 yuQ
-zLt
+DaK
 hrJ
 FPY
 iaz
@@ -52576,9 +53380,9 @@ CwD
 btK
 rXD
 NLL
-iOj
-NLI
-hXz
+TBE
+nuV
+Xih
 NSu
 GvT
 HUk
@@ -52824,8 +53628,8 @@ PQT
 QOI
 etS
 wCn
-ylu
-dlV
+cxL
+bgx
 cOS
 ITj
 sPR
@@ -52834,7 +53638,7 @@ Swy
 IvT
 hDm
 inJ
-vvc
+tga
 aZY
 NSu
 OID
@@ -53081,9 +53885,9 @@ KYs
 kth
 WIP
 Hrz
-tdd
+vpn
 PoT
-nbO
+cyU
 lSC
 Yhk
 pFy
@@ -53589,14 +54393,14 @@ sme
 ksn
 xPT
 SOU
-CMO
+UMf
 Ccr
 ITj
 Mpd
 Fgf
 DGT
-ylu
-HwH
+cxL
+LfY
 ryK
 ITj
 sPR
@@ -53604,8 +54408,8 @@ RCX
 MbK
 mmp
 FBV
-zXV
-VNF
+xrE
+sUM
 SEB
 euL
 sDC
@@ -53846,15 +54650,15 @@ sme
 ksn
 xPT
 Eet
-OUN
-fNe
+TJQ
+nJi
 Sqk
 SIY
 Elv
 Hrz
-tdd
+vpn
 PoT
-nbO
+cyU
 lSC
 Yhk
 pFy
@@ -53862,7 +54666,7 @@ JuQ
 SEB
 YyZ
 AZq
-IWW
+Bpq
 ejB
 pBd
 uVz
@@ -54103,8 +54907,8 @@ sme
 cJy
 xPT
 NMe
-XXw
-TMU
+iuU
+vfj
 NMe
 NMe
 xRG
@@ -54373,7 +55177,7 @@ lis
 TFC
 vCU
 kZB
-xAW
+CzC
 auZ
 rHx
 iVK
@@ -54875,7 +55679,7 @@ ksn
 Egt
 WOT
 xRO
-XKk
+wvH
 nnW
 qAo
 rPo
@@ -55142,7 +55946,7 @@ EcH
 ClC
 tJs
 YSr
-uSW
+AIo
 MRf
 yys
 nqT
@@ -55398,9 +56202,9 @@ WOT
 LYM
 QQb
 iym
-OBz
-sOq
-PAZ
+mVn
+fNg
+kiX
 Rwn
 Rwn
 Rwn
@@ -55656,13 +56460,13 @@ IiO
 Glt
 WOT
 eIo
-hea
+RZG
 PAZ
 NcR
 HnJ
 GJB
 lck
-bvB
+KbZ
 mrK
 goT
 tPe
@@ -55907,7 +56711,7 @@ Otm
 DnX
 GAV
 rPo
-gjO
+BsU
 Yzz
 Yzz
 glX
@@ -55918,13 +56722,13 @@ PAZ
 NcR
 HnJ
 tCV
-bqb
-slr
-oOn
+Lek
+WUB
+IgN
 CGk
 mzx
 mzx
-XOQ
+TEd
 Rwn
 slH
 mWl
@@ -56163,9 +56967,9 @@ mTu
 mTu
 Iux
 TCO
-Ujk
-zQA
-EYY
+zVr
+RMn
+SAI
 lqq
 ldn
 Wfb
@@ -56176,7 +56980,7 @@ bBd
 dYh
 Yxv
 QSW
-GfO
+WCi
 OHL
 rBl
 jZV
@@ -56421,7 +57225,7 @@ vsn
 DVI
 ada
 XMd
-xFP
+PwK
 mJg
 vRt
 DYz
@@ -56955,7 +57759,7 @@ OHL
 BCO
 Rwn
 slH
-mWl
+BKS
 sme
 sme
 sme
@@ -57186,13 +57990,13 @@ sme
 sme
 IRY
 NeI
-MzR
+Ajp
 EFM
 YAo
 KnM
 hRD
 kMW
-rvU
+VnH
 csg
 gcK
 Eop
@@ -57442,15 +58246,15 @@ sme
 sme
 sme
 IRY
-Tbj
-hDv
-Ggi
+ozE
+hLV
+BYb
 sxj
 rxG
 hRD
-HVH
-xzQ
-SIA
+wPU
+EmB
+YLo
 rqh
 NLX
 cfG
@@ -57700,13 +58504,13 @@ sme
 sme
 bhJ
 JOO
-BTy
+FDm
 grC
 IEr
 mFr
 hRD
 OeJ
-GMP
+xCV
 emP
 wmF
 ZdY
@@ -57721,9 +58525,9 @@ cLC
 cLC
 vyJ
 wFi
-mhg
-MrC
-IkS
+iSS
+tAA
+dtC
 IkS
 zbA
 biz
@@ -57979,11 +58783,11 @@ zXn
 tGD
 KTU
 IEk
-XfL
+shU
 XfL
 sux
 Ura
-biz
+HNz
 sme
 sme
 sme
@@ -58472,7 +59276,7 @@ sme
 VGU
 XPf
 IiQ
-lgQ
+hrN
 fJZ
 LEa
 eDT
@@ -58752,8 +59556,8 @@ QwG
 PVQ
 rjR
 jPM
-veP
-cNH
+oQk
+HYs
 jPM
 sme
 sme
@@ -59004,12 +59808,12 @@ pLQ
 UEI
 bSM
 dyh
-SXY
+dLj
 occ
 ZDg
 fJh
 Fcs
-zNV
+NwZ
 blC
 jPM
 sme
@@ -59244,7 +60048,7 @@ VGU
 XPf
 IiQ
 CyX
-fJZ
+zvH
 FEm
 TJP
 fJZ
@@ -59260,9 +60064,9 @@ UVI
 UVI
 fje
 bSM
-mql
-LRC
-WtB
+lXj
+Aoz
+JUv
 cRY
 wCC
 vpL
@@ -59500,9 +60304,9 @@ VGU
 VGU
 XPf
 IiQ
-HTH
-aTk
-ebN
+ulv
+jSc
+KxV
 TPZ
 fJZ
 CIJ
@@ -59518,7 +60322,7 @@ COt
 kWO
 bSM
 jaU
-TGK
+FhS
 Oef
 MNi
 Fbx
@@ -59758,7 +60562,7 @@ VGU
 Utb
 IiQ
 Lab
-EBG
+SKA
 FEm
 bbQ
 Fqa
@@ -60288,11 +61092,11 @@ uko
 sme
 sme
 sme
-uqd
-BzW
-YGp
-zUm
-SRI
+LQA
+eJf
+dBQ
+Dro
+JZa
 sme
 sme
 sme
@@ -60535,7 +61339,7 @@ ESQ
 OqJ
 alv
 ohV
-Lav
+jzE
 rTI
 SBQ
 DdT
@@ -60544,13 +61348,13 @@ rik
 mrr
 sme
 sme
-osD
+WVG
 LdK
 LdK
 AhF
 LdK
 LdK
-osD
+WVG
 sme
 sme
 SlH
@@ -60791,9 +61595,9 @@ rkv
 OIE
 LOF
 WXW
-TTW
-ajl
-NzI
+taK
+peQ
+nlV
 SBQ
 hOS
 VkF
@@ -60801,13 +61605,13 @@ rik
 uko
 sme
 sme
-ZDO
+ixV
 LdK
 jut
-igx
+EwK
 KXj
 LdK
-ZDO
+ixV
 sme
 sme
 SlH
@@ -61044,12 +61848,12 @@ NSv
 TQx
 Dft
 iOf
-KGM
+OFv
 WbU
 vxM
 hDM
 SGc
-Lav
+jzE
 NzI
 SBQ
 Wnf
@@ -61058,13 +61862,13 @@ rik
 mrr
 sme
 sme
-lvv
+dhT
 wlS
-Kgp
-Ilu
-jOa
+OGs
+dSS
+Jkx
 wlS
-QUa
+meX
 sme
 sme
 SlH
@@ -61300,8 +62104,8 @@ VGU
 BXi
 vJo
 Dft
-LqQ
-auY
+JZE
+mFi
 eUE
 oQa
 alv
@@ -61315,13 +62119,13 @@ rik
 mrr
 sme
 sme
-GZC
+Ods
 LdK
 InD
-PdM
+leX
 awC
 LdK
-GZC
+Ods
 sme
 sme
 SlH
@@ -61558,7 +62362,7 @@ zgm
 QtE
 Dft
 Nry
-fln
+zGB
 Etg
 Lvq
 alv
@@ -61572,13 +62376,13 @@ rik
 uko
 sme
 sme
-ToN
+TEy
 LdK
 AFE
 uBh
 UQc
 LdK
-ToN
+TEy
 sme
 sme
 SlH
@@ -61830,7 +62634,7 @@ TEw
 sme
 sme
 sme
-uqd
+Fgg
 VhW
 xwH
 dck
@@ -62346,7 +63150,7 @@ otX
 otX
 otX
 yoh
-wkq
+wfF
 Hyv
 WSX
 MSb
@@ -62602,9 +63406,9 @@ WyM
 WyM
 WyM
 WyM
-LuZ
-VkF
-HVL
+HaA
+Imu
+jMd
 ykQ
 MSb
 MSb
@@ -62840,7 +63644,7 @@ CCT
 erg
 CCT
 zgm
-QtE
+qKd
 CCT
 sJh
 BWq
@@ -62860,7 +63664,7 @@ cok
 sgq
 cok
 mnO
-wAg
+qlS
 DJv
 GUI
 KPf
@@ -63096,8 +63900,8 @@ sme
 CCT
 UOf
 CCT
-zgm
-TXT
+dtt
+jvl
 VGU
 Ccz
 LrQ
@@ -63105,8 +63909,8 @@ KWF
 KWF
 KWF
 KWF
-ydL
-kIQ
+aDM
+aDM
 XVI
 YrI
 SNo
@@ -63121,7 +63925,7 @@ jny
 jny
 Gwd
 BqZ
-Jep
+qyM
 dPR
 dPR
 sme
@@ -63354,25 +64158,25 @@ CCT
 erg
 CCT
 zgm
-JlK
+YLZ
 rFl
 qrp
 YjV
-sNm
-pbo
-wuq
+wNM
+yun
+mFl
 bBb
 sme
 sme
 czQ
-uIa
-WDj
-hkR
+Qmm
+DDP
+Oki
 czQ
 sme
 sme
 BqZ
-FqS
+Sso
 Uzr
 pJs
 Vnr
@@ -63616,21 +64420,21 @@ rSJ
 QtE
 Fub
 RIh
-Fzq
+KRb
 PfL
 kIk
 sme
 sme
 PkY
 Njg
-PlJ
+Qad
 CAh
 PkY
 sme
 sme
 fzJ
-ATF
-YSB
+jBb
+YsU
 IHS
 IHS
 vdT
@@ -63886,7 +64690,7 @@ czQ
 sme
 sme
 fzJ
-IHS
+foK
 Gfx
 IHS
 IHS
@@ -64125,7 +64929,7 @@ cCa
 sng
 Uec
 WBa
-SHl
+ciF
 DJp
 hPo
 ObJ
@@ -64381,9 +65185,9 @@ sme
 sme
 sme
 Uec
-eOE
-WKY
-FjG
+pvx
+Bpm
+gnf
 qLr
 HJO
 TYL
@@ -64639,7 +65443,7 @@ sme
 sme
 Uec
 Uec
-tha
+mjC
 sfX
 wlW
 gVW
@@ -64658,9 +65462,9 @@ umz
 umz
 xtO
 slK
-WHB
-aOD
-yzo
+eVb
+uAG
+Xsv
 csS
 jxC
 uAB
@@ -64916,7 +65720,7 @@ CtT
 jxC
 AMa
 fjt
-QYU
+Yzn
 ZOh
 JRS
 jxC
@@ -65177,7 +65981,7 @@ LDA
 Xji
 rtr
 jxC
-TrL
+Cei
 dPR
 dPR
 sme
@@ -65677,7 +66481,7 @@ aro
 Uec
 PIa
 MCW
-MCW
+TNO
 SNF
 SEZ
 sQy
@@ -65685,9 +66489,9 @@ EsB
 EsB
 pRM
 tpz
-bDX
-kfr
-VhT
+EUR
+OWB
+efT
 jxC
 jxC
 oZg
@@ -65933,9 +66737,9 @@ Uec
 Uec
 Uec
 MPt
-ctY
-PiF
-lHv
+bmw
+dDg
+ZAW
 Juj
 NqL
 Ogh
@@ -65943,7 +66747,7 @@ ctY
 ctY
 tpz
 WzA
-oyO
+ESg
 jxC
 jxC
 oZg
@@ -66190,7 +66994,7 @@ Uec
 Uec
 Uec
 WYs
-WYs
+QCq
 IkR
 yzL
 JXK
@@ -67472,12 +68276,12 @@ sme
 sme
 sme
 sme
-NsX
+NVG
 pXe
 sjL
 evU
 evU
-XBD
+GHM
 Lwj
 wOv
 evU
@@ -67733,9 +68537,9 @@ DjK
 IUV
 evU
 evU
-evU
-dTR
-Qwl
+fCf
+zFo
+Djt
 itB
 evU
 cDN
@@ -67991,7 +68795,7 @@ wfo
 evU
 evU
 evU
-fmR
+nlE
 Qwl
 oes
 evU

--- a/_maps/map_files/Trailblazer/Trailblazer.dmm
+++ b/_maps/map_files/Trailblazer/Trailblazer.dmm
@@ -8168,6 +8168,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"pZM" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Hallway North"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/lizard{
+	desc = "A cute tiny lizard that eats cockroaches.";
+	name = "Faster-Than-Lizard(13)"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
 "qbb" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -27035,20 +27049,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"ZAO" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Hallway North"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/lizard{
-	desc = "A cute tiny lizard.";
-	name = "Faster-Than-Lizard\(13\)"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering)
 "ZAW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/decal/cleanable/greenglow,
@@ -40015,7 +40015,7 @@ wWi
 wWi
 wWi
 wWi
-ZAO
+pZM
 NFK
 Sqb
 Aej

--- a/_maps/map_files/Trailblazer/Trailblazer.dmm
+++ b/_maps/map_files/Trailblazer/Trailblazer.dmm
@@ -58,6 +58,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
+"afh" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
 "agv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -92,6 +98,22 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"ajA" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/medical/cmo)
 "ajC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -276,6 +298,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
+"aBK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/machinery/camera{
+	c_tag = "Mining Podbay";
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "aBV" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/effect/decal/cleanable/dirt,
@@ -353,18 +387,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
-"aRb" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
 "aRR" = (
 /obj/structure/table,
 /obj/item/weapon/crowbar,
@@ -945,6 +967,12 @@
 "cdr" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/division)
+"cdP" = (
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/main)
 "cfg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -1399,6 +1427,48 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"dam" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/paper/crumpled{
+	
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
+"dbV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1;
+	desc = "It's a secure locker for personnel.";
+	moving_diagonally = 0;
+	name = "Eats-The-Glue's closet";
+	registered_name = "Eats-The-Glue"
+	},
+/obj/item/clothing/tie/scarf/darkblue,
+/obj/item/weapon/gun/projectile/automatic/pistol,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/locker)
+"dbZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	tag = "icon-manifold (EAST)";
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "dck" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1875,6 +1945,17 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"dMN" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
 "dNB" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2032,19 +2113,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"eld" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/division)
 "emN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -2506,10 +2574,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"eWU" = (
-/obj/machinery/telecomms/relay/portable/preset,
-/turf/open/floor/plasteel/bot,
-/area/shuttle/ftl/cargo/mining)
 "eXq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
@@ -2807,6 +2871,22 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"fCT" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Janitor's Closet";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
 "fCZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -2922,17 +3002,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/turret_protected/ai)
-"fLU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/engine/chiefs_office)
 "fMr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
@@ -3566,16 +3635,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
-"gOt" = (
-/obj/structure/window,
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "gPT" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3821,6 +3880,23 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
+"hoP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "hqO" = (
 /obj/effect/landmark/start{
 	name = "Cyborg";
@@ -3867,19 +3943,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
-"hse" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
 "hsg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -4562,15 +4625,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
-"iJj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "iKr" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -4630,6 +4684,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
+"iRa" = (
+/obj/machinery/dna_scannernew{
+	tag = ""
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/genetics)
 "iRn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/black,
@@ -4698,18 +4773,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"jfI" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Detective's Office";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "jgM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4954,6 +5017,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
+"jwZ" = (
+/obj/machinery/vending/engivend,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "jxC" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/captain)
@@ -4979,6 +5051,34 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"jzy" = (
+/obj/structure/table,
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/weapon/crowbar,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/assembly/robotics)
 "jzE" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood,
@@ -5326,6 +5426,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"kkX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "kpy" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -5512,6 +5621,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
+"kGL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/cargo/storage)
 "kIk" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -5873,6 +5991,22 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
+"luG" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/division)
 "lvi" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -5953,31 +6087,6 @@
 "lEa" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"lFQ" = (
-/obj/structure/table,
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -10
-	},
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -10
-	},
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -10
-	},
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -10
-	},
-/obj/item/weapon/crowbar,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/weapon/stock_parts/cell/high/plus,
-/obj/item/weapon/stock_parts/cell/high/plus,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/assembly/robotics)
 "lJT" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -6576,6 +6685,24 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos/equipment)
+"mLF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/medical/chemistry)
+"mMU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "mNZ" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/mining)
@@ -6621,6 +6748,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"mPj" = (
+/obj/structure/closet/secure_closet/hop,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "mQz" = (
 /obj/machinery/door/poddoor{
 	id = "supermatter_eject"
@@ -6780,6 +6916,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos/equipment)
+"ndv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "ndH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6862,14 +7006,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_3)
-"nhU" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos/equipment)
 "nll" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -7062,6 +7198,14 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/storage)
+"nAE" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
 "nDT" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7135,16 +7279,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
-"nNs" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/shuttle/ftl/crew_quarters/kitchen)
 "nOc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -7271,6 +7405,30 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"ont" = (
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	dir = 8;
+	name = "security camera";
+	network = list("SS13","RD")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = 26;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/hor)
 "onF" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable{
@@ -7338,6 +7496,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"oqp" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "oqR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7436,6 +7606,28 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hydroponics)
+"oFx" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Kitchen";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
 "oGm" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
@@ -7661,6 +7853,24 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"phJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHEAST)";
+	icon_state = "whiteblue";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/medbay)
 "pit" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7977,11 +8187,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
-"pGK" = (
-/obj/machinery/vending/engivend,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
 "pHH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -8045,6 +8250,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
+"pLV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
 "pMk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
@@ -8232,6 +8446,16 @@
 /obj/docking_port/mobile/ftl,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
+"qfy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "qfA" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -8301,20 +8525,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/fore)
-"qoh" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "qrp" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -8388,6 +8598,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
+"qxW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/fore)
 "qyM" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -8481,6 +8711,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
+"qIT" = (
+/obj/structure/table/glass,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Chemistry";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_construct{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 10
+	},
+/area/shuttle/ftl/medical/chemistry)
 "qJe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8515,14 +8780,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
-"qKP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/obj/machinery/vending/tool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkyellow,
-/area/shuttle/ftl/engine/tool_storage)
 "qLr" = (
 /obj/machinery/conveyor_switch{
 	id = "munitions"
@@ -8743,35 +9000,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/sleeper)
-"qXp" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/blood/empty,
-/obj/item/weapon/reagent_containers/blood/empty{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/weapon/reagent_containers/blood/AMinus,
-/obj/item/weapon/reagent_containers/blood/BMinus{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/weapon/reagent_containers/blood/BPlus{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OPlus{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/weapon/reagent_containers/blood/random,
-/obj/item/weapon/reagent_containers/blood/random,
-/obj/item/weapon/reagent_containers/blood/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/surgery)
 "qXu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8806,6 +9034,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
+"raW" = (
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/research/lab)
 "rdo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9245,6 +9480,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"rLn" = (
+/obj/machinery/computer/monitor{
+	name = "primary power monitoring console"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "rOo" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -9355,6 +9610,16 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/gravity_generator)
+"sbQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "scI" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/lab)
@@ -9386,15 +9651,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
-"seF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 5";
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "seL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -9522,6 +9778,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"skn" = (
+/obj/structure/window,
+/obj/machinery/vending/cigarette{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "skt" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/emergency,
@@ -9573,22 +9842,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"slK" = (
-/obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
 "slQ" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine{
@@ -9712,6 +9965,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/central)
+"svo" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/atmos_alert{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/stationalert,
+/obj/item/weapon/circuitboard/computer/powermonitor{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/machine/thermomachine/freezer{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
 "svx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9791,6 +10070,26 @@
 	dir = 5
 	},
 /area/shuttle/ftl/medical/medbay)
+"sBE" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/box/rubbershot,
+/obj/item/weapon/storage/box/rubbershot,
+/obj/item/weapon/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/security/armory)
 "sCe" = (
 /obj/structure/chair/office/dark,
 /obj/structure/disposalpipe/segment{
@@ -9911,16 +10210,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"sMG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering)
 "sNx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10358,14 +10647,6 @@
 "tmg" = (
 /turf/closed/wall,
 /area/shuttle/ftl/research/division)
-"tng" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/machinery/camera{
-	c_tag = "Mining Podbay";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "tnm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -10383,6 +10664,25 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/chemistry)
+"twN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/locker)
 "twQ" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10436,14 +10736,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
-"tAA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/central)
 "tCy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -10457,26 +10749,6 @@
 "tCV" = (
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/assembly/robotics)
-"tCW" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 8;
-	name = "security camera";
-	network = list("SS13","RD")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/hor)
 "tDX" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -10774,6 +11046,21 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
+"ulf" = (
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "uln" = (
 /obj/machinery/vending/cola,
 /obj/effect/decal/cleanable/dirt,
@@ -10916,19 +11203,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"uAG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
 "uBh" = (
 /obj/machinery/door/airlock/vault{
 	icon_state = "closed";
@@ -10956,6 +11230,16 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
+"uJe" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "uKb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10966,20 +11250,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"uKG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (SOUTHEAST)";
-	icon_state = "whiteblue";
-	dir = 6
-	},
-/area/shuttle/ftl/medical/medbay)
 "uKJ" = (
 /obj/structure/spacepoddoor{
 	dir = 8
@@ -11092,15 +11362,6 @@
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"vfg" = (
-/obj/structure/window{
-	icon_state = "window";
-	dir = 1
-	},
-/obj/machinery/vending/coffee,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "vfj" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
@@ -11341,6 +11602,16 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/secure_construction)
+"vAL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "vAU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -11424,20 +11695,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/crew_quarters/bar)
-"vIW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "vJo" = (
 /obj/machinery/conveyor_switch{
 	id = "munitions"
@@ -11591,6 +11848,20 @@
 	dir = 1
 	},
 /area/shuttle/ftl/bridge/eva)
+"weW" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/engine/engine_smes)
 "wfh" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/fire,
@@ -11908,17 +12179,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/hallway/primary/starboard)
-"wBc" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "wCn" = (
 /obj/machinery/door/window/brigdoor{
 	id = "Cell 2";
@@ -11944,12 +12204,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"wFi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "wGa" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/medical,
@@ -12140,6 +12394,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
+"wSL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "wSV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -13053,13 +13325,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
-"yEE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/engine/chiefs_office)
 "yFF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -13120,6 +13385,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
+"yPS" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/heads)
 "yQS" = (
 /obj/machinery/door/window/southleft{
 	name = "Cockpit";
@@ -13388,6 +13668,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"zro" = (
+/obj/item/device/radio/off{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/device/multitool{
+	pixel_x = 7
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/machinery/camera{
+	c_tag = "Telecommunications";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/telecomms/computer)
 "zsg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13395,6 +13698,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
+"ztr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/engine/engineering)
 "zua" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13466,10 +13783,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai_upload)
-"zGT" = (
-/obj/machinery/r_n_d/circuit_imprinter,
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/lab)
 "zLe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13491,6 +13804,21 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
+"zOv" = (
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
 "zOB" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
@@ -13642,16 +13970,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"AdZ" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side{
-	tag = "icon-green (WEST)";
-	icon_state = "green";
-	dir = 8
-	},
-/area/shuttle/ftl/hydroponics)
 "Aej" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -13871,23 +14189,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Avd" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/box/rubbershot,
-/obj/item/weapon/storage/box/rubbershot,
-/obj/item/weapon/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkwarning{
-	dir = 1
-	},
-/area/shuttle/ftl/security/armory)
 "AvD" = (
 /obj/machinery/computer/aifixer,
 /obj/structure/cable{
@@ -13919,6 +14220,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
+"Ayz" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/research/server)
 "ABg" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -13987,18 +14307,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"AEG" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Janitor's Closet";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "AEK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14504,6 +14812,18 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
+"BzU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 5";
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "BCf" = (
 /obj/machinery/pdapainter,
 /obj/effect/decal/cleanable/dirt,
@@ -14551,6 +14871,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/janitor)
+"BIE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
 "BIM" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -14600,6 +14930,25 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"BRS" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "BSg" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
@@ -14672,6 +15021,34 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
+"Cbb" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/item/weapon/storage/bag/chemistry,
+/obj/item/weapon/storage/bag/chemistry,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (SOUTHEAST)";
+	icon_state = "whiteblue";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/chemistry)
 "Cbf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -14990,22 +15367,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"CGi" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/research/server)
 "CGk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -15421,6 +15782,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/eva)
+"DsJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "DtP" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/chemistry)
@@ -15894,13 +16266,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Efx" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "EfT" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/genetics)
@@ -16059,6 +16424,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
+"Eqy" = (
+/obj/structure/sign/securearea{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "Erm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -16338,12 +16722,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"ERV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
 "ERX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -16408,14 +16786,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"EUR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "EVL" = (
 /turf/open/floor/plasteel/warning{
 	dir = 8
@@ -16570,52 +16940,11 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"FhS" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/atmos_alert{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/stationalert,
-/obj/item/weapon/circuitboard/computer/powermonitor{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/weapon/circuitboard/machine/thermomachine/freezer{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
 "Fjg" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"FjQ" = (
-/obj/machinery/dna_scannernew{
-	tag = ""
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/genetics)
 "Fkm" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -16671,6 +17000,15 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
+"Fmw" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/atmos/equipment)
 "Fpb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16849,13 +17187,6 @@
 	},
 /turf/open/floor/noslip,
 /area/shuttle/ftl/engine/engine_smes)
-"FDm" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
 "FDJ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -16905,6 +17236,20 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
+"FHq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "FHU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small{
@@ -17649,6 +17994,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"Hbi" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
 "HcR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -17854,6 +18209,38 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"HFR" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/blood/AMinus,
+/obj/item/weapon/reagent_containers/blood/BMinus{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/blood/BPlus{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OPlus{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/surgery)
 "HGC" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -17958,17 +18345,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/chemistry)
-"HVR" = (
-/obj/machinery/computer/med_data,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
 "HYs" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/computer/mecha_control{
@@ -17993,17 +18369,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
-"Icp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo North";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
 "Idc" = (
 /obj/structure/table/wood,
 /obj/structure/disposalpipe/segment{
@@ -18383,13 +18748,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"INs" = (
-/obj/machinery/smartfridge/extract,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "INw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/window/reinforced{
@@ -18518,6 +18876,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/turret_protected/ai)
+"IZP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "Jbv" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -18730,11 +19098,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/munitions)
-"JpK" = (
-/obj/structure/closet/secure_closet/hop,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/heads)
 "Jqu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18817,37 +19180,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"Jwx" = (
-/obj/structure/table/glass,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/weapon/storage/box/syringes{
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct{
-	dir = 8
-	},
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 10
-	},
-/area/shuttle/ftl/medical/chemistry)
 "JxA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19039,6 +19371,21 @@
 	dir = 10
 	},
 /area/shuttle/ftl/hallway/primary/central)
+"JPU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "JRS" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -19505,6 +19852,14 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"KIZ" = (
+/obj/machinery/telecomms/relay/portable/preset,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/cargo/mining)
 "KNb" = (
 /obj/structure/table{
 	pixel_x = 2;
@@ -19769,6 +20124,19 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"LfM" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/shuttle/ftl/crew_quarters/kitchen)
 "LfY" = (
 /obj/machinery/flasher{
 	id = "Cell 1";
@@ -19778,6 +20146,19 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"LhR" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge/meeting_room)
 "LiV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -19858,24 +20239,13 @@
 "LtU" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge)
-"Lvq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1;
-	desc = "It's a secure locker for personnel.";
-	moving_diagonally = 0;
-	name = "Eats-The-Glue's closet";
-	registered_name = "Eats-The-Glue"
-	},
-/obj/item/clothing/tie/scarf/darkblue,
-/obj/item/weapon/gun/projectile/automatic/pistol,
+"LuP" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
 /turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/locker)
+/area/shuttle/ftl/bridge/meeting_room)
 "Lwj" = (
 /obj/machinery/computer/communications,
 /obj/structure/cable{
@@ -19934,26 +20304,6 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"LCO" = (
-/obj/item/device/radio/off{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/device/multitool{
-	pixel_x = 7
-	},
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/machinery/camera{
-	c_tag = "Telecommunications";
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/telecomms/computer)
 "LDA" = (
 /obj/structure/table/wood,
 /obj/item/weapon/card/id/captains_spare,
@@ -20290,6 +20640,19 @@
 	dir = 5
 	},
 /area/shuttle/ftl/hydroponics)
+"MfS" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/green/side{
+	tag = "icon-green (WEST)";
+	icon_state = "green";
+	dir = 8
+	},
+/area/shuttle/ftl/hydroponics)
 "MfW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20400,6 +20763,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"MEp" = (
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "MGN" = (
 /obj/structure/chair{
 	dir = 4
@@ -20425,15 +20794,16 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"MLR" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/green/side{
-	tag = "icon-green (SOUTHWEST)";
-	icon_state = "green";
-	dir = 10
+"MMb" = (
+/obj/item/weapon/banner,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
 	},
-/area/shuttle/ftl/hydroponics)
+/turf/open/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/shuttle/ftl/bridge/eva)
 "MME" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20691,15 +21061,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"NhV" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/medical/chemistry)
 "Njg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20871,6 +21232,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
+"Nzv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "Nzx" = (
 /obj/structure/rack{
 	dir = 8;
@@ -21152,6 +21522,17 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"Oab" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/machinery/vending/tool,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/darkyellow,
+/area/shuttle/ftl/engine/tool_storage)
 "ObJ" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -21398,17 +21779,6 @@
 "OtG" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/port)
-"Owq" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
 "Ozg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21607,6 +21977,22 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"OPh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos)
+"OPy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "OPU" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engine_smes)
@@ -21620,6 +22006,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/fore)
+"OQO" = (
+/obj/machinery/smartfridge/extract,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "ORo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21706,6 +22103,21 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"Pat" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo North";
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
 "PaH" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21725,6 +22137,17 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engineering)
+"PcU" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/atmos/equipment)
 "Pdv" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -21833,6 +22256,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"Pme" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
 "Pmj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21874,6 +22304,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"Ppk" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Detective's Office";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "Ppy" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge/eva)
@@ -22090,12 +22535,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"PHD" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge/meeting_room)
 "PIa" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -22134,11 +22573,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
-"PLQ" = (
-/turf/open/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/ftl/cargo/storage)
 "PMr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -22303,6 +22737,13 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
+"QdH" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/secure_construction)
 "QdY" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/extinguisher_cabinet{
@@ -22523,26 +22964,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"QIt" = (
-/obj/machinery/computer/monitor{
-	name = "primary power monitoring console"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 32
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/engine/engine_smes)
 "QJh" = (
 /obj/structure/table/wood,
 /obj/structure/cable{
@@ -22553,11 +22974,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"QJU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "QKb" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c";
@@ -22656,6 +23072,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"QVu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/gravity_generator)
 "QVR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -22840,6 +23266,22 @@
 "Rwn" = (
 /turf/closed/wall,
 /area/shuttle/ftl/assembly/robotics)
+"RyM" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "RyQ" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -22997,6 +23439,15 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
+"SaE" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
 "Sbz" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel{
@@ -23049,18 +23500,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"SfI" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "Sgu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -23148,6 +23587,18 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
+"SpP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 26
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
 "Sqb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -23372,24 +23823,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"SId" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cafeteria,
-/area/shuttle/ftl/crew_quarters/kitchen)
 "SIk" = (
 /obj/structure/table,
 /obj/item/weapon/surgical_drapes,
@@ -23553,19 +23986,6 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/shuttle/ftl/security/nuke_storage)
-"SSB" = (
-/obj/item/device/radio/intercom{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "STc" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -23771,6 +24191,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"TkI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/secure_construction)
 "ToY" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
 /obj/structure/window/reinforced{
@@ -24147,30 +24579,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"TSw" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/item/weapon/storage/bag/chemistry,
-/obj/item/weapon/storage/bag/chemistry,
+"TUB" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (SOUTHEAST)";
-	icon_state = "whiteblue";
-	dir = 6
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
 	},
-/area/shuttle/ftl/medical/chemistry)
+/turf/open/floor/plasteel/green/side{
+	tag = "icon-green (SOUTHWEST)";
+	icon_state = "green";
+	dir = 10
+	},
+/area/shuttle/ftl/hydroponics)
 "TWL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24255,14 +24676,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/virology)
-"TZC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/atmos)
 "UbC" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -24292,12 +24705,6 @@
 "Uec" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/loading)
-"Ueo" = (
-/obj/item/weapon/banner,
-/turf/open/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/ftl/bridge/eva)
 "UeA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
@@ -24771,21 +25178,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/nuke_storage)
-"UQp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/locker)
 "UUq" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/decal/cleanable/dirt,
@@ -24943,6 +25335,21 @@
 "VfT" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/mining)
+"Vgf" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/engine/chiefs_office)
 "VgH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25112,6 +25519,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/research/server)
+"Vzi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "VCL" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
@@ -25402,6 +25820,21 @@
 "Wfb" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/security/main)
+"Wga" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "Whx" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -25417,18 +25850,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
-"WmS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/medical/cmo)
 "Wnf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25700,13 +26121,6 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"WKn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/gravity_generator)
 "WMT" = (
 /obj/effect/landmark/start{
 	name = "Research Director"
@@ -26206,6 +26620,23 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
+"XIh" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
 "XIn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -26244,17 +26675,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"XMd" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/security_space_law,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
 "XMg" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -26281,6 +26701,19 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
+"XON" = (
+/obj/structure/window{
+	icon_state = "window";
+	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "XPf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26318,6 +26751,17 @@
 "XSX" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/break_room)
+"XTS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/central)
 "XVI" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge/meeting_room)
@@ -26520,6 +26964,21 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge/meeting_room)
+"YrX" = (
+/obj/machinery/computer/med_data,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "Ysm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/suit_storage_unit/atmos,
@@ -26781,22 +27240,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
-"YNL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/fore)
 "YOd" = (
 /obj/machinery/camera{
 	busy = 0;
@@ -27040,15 +27483,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
-"Zvs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
 "ZAW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/decal/cleanable/greenglow,
@@ -34090,7 +34524,7 @@ IvE
 IvE
 IvE
 IvE
-IvE
+QdH
 gkR
 VHM
 xpr
@@ -34112,7 +34546,7 @@ Qfe
 VPN
 DmU
 VPN
-XkS
+TkI
 XkS
 XkS
 XkS
@@ -34605,7 +35039,7 @@ VCL
 NQy
 ToY
 OtG
-LQq
+sbQ
 yMw
 Ebw
 OPU
@@ -35149,7 +35583,7 @@ wTC
 OPU
 PeA
 ADa
-VvS
+vAL
 hZG
 sme
 sme
@@ -36423,10 +36857,10 @@ uqe
 ouh
 POZ
 Pdv
-QJU
+OPh
 Twv
-TZC
-SSB
+oqp
+BIE
 Enm
 dtl
 OLO
@@ -37180,7 +37614,7 @@ yDB
 GmN
 OPU
 Jmm
-QIt
+rLn
 NlB
 AeB
 MmL
@@ -37188,7 +37622,7 @@ rxl
 LiV
 Jes
 kqs
-rxl
+weW
 mPb
 fMr
 Ncx
@@ -37701,7 +38135,7 @@ zcw
 SIy
 wft
 NFh
-pGK
+jwZ
 XSX
 iUN
 ixJ
@@ -37719,7 +38153,7 @@ vUe
 rPy
 lxd
 sWN
-mnz
+Vzi
 hZG
 sme
 sme
@@ -37948,7 +38382,7 @@ mOZ
 IJs
 qTu
 swy
-ZPF
+mMU
 ptB
 pwP
 PAj
@@ -38200,7 +38634,7 @@ bVR
 skF
 skF
 xsN
-Ueo
+MMb
 onT
 IJs
 qTu
@@ -38467,7 +38901,7 @@ iXC
 sLN
 XSX
 EPk
-aRb
+zOv
 Zdg
 hin
 WNG
@@ -38985,9 +39419,9 @@ kcn
 iKt
 snn
 fIA
-fLU
+Vgf
 SYw
-sMG
+ztr
 XgR
 AsQ
 mDa
@@ -39512,7 +39946,7 @@ psx
 YUf
 Ysm
 xte
-iJj
+dbZ
 fFd
 vke
 ajU
@@ -39752,7 +40186,7 @@ iXC
 Oct
 cAO
 LnG
-yEE
+qfy
 Ksi
 ZWF
 lvi
@@ -40514,7 +40948,7 @@ mNZ
 oDt
 ERX
 fFX
-eWU
+KIZ
 mNZ
 qTu
 swy
@@ -40784,14 +41218,14 @@ AOf
 AOf
 aXz
 AOf
-WKn
+QVu
 VsD
 qIA
 qvR
 rxF
 Yhr
 XDw
-nhU
+PcU
 FBu
 Ddv
 Cou
@@ -41279,7 +41713,7 @@ sme
 uKJ
 XJK
 aIK
-tng
+aBK
 QNF
 rsI
 wrE
@@ -41795,7 +42229,7 @@ Plk
 xcF
 nKu
 QHv
-PLQ
+kGL
 mNZ
 jNx
 DrI
@@ -42077,7 +42511,7 @@ wQt
 KcB
 XDw
 wiF
-wiF
+Fmw
 SMX
 fcr
 XDw
@@ -42323,10 +42757,10 @@ YJV
 YJV
 wQt
 LPJ
-nNs
+LfM
 qZl
 CHm
-SId
+oFx
 KaO
 AYj
 ISg
@@ -43088,7 +43522,7 @@ gJT
 ffs
 bYv
 qLN
-ZPF
+mMU
 iXC
 YJV
 Dgo
@@ -43103,16 +43537,16 @@ lMJ
 nmE
 OzD
 isB
-AdZ
+MfS
 DWK
 Ipy
-MLR
+TUB
 CKy
 KcB
 HEH
 kZU
 yxK
-AEG
+fCT
 HEH
 KQV
 bYM
@@ -44362,7 +44796,7 @@ sme
 sme
 EKA
 sFn
-Icp
+Pat
 OSx
 zaE
 glv
@@ -44636,11 +45070,11 @@ YJV
 xaf
 erp
 JJy
-gOt
+skn
 bgt
 Xdc
 KuJ
-vfg
+XON
 MPe
 MPe
 CKy
@@ -45918,7 +46352,7 @@ nLv
 Qvj
 pJo
 pJo
-seF
+BzU
 pJo
 pJo
 Kmr
@@ -45934,7 +46368,7 @@ Ihn
 OZN
 eii
 lRJ
-lRJ
+OPy
 nwO
 lRJ
 pHH
@@ -46419,7 +46853,7 @@ sme
 snV
 cfg
 Jmt
-cfg
+ndv
 doQ
 ijO
 aGg
@@ -46431,7 +46865,7 @@ bLx
 bLx
 wSV
 bLx
-bLx
+Nzv
 DzJ
 qEq
 bLx
@@ -46937,12 +47371,12 @@ DAF
 Tus
 VZz
 tai
-vIW
+wSL
 cVx
 Pqq
 Pqq
 Tpn
-zGT
+raW
 MVg
 QXe
 fMG
@@ -46959,7 +47393,7 @@ sme
 Gkh
 TCs
 gjg
-Jwx
+qIT
 vTG
 cGF
 UUq
@@ -46970,7 +47404,7 @@ flI
 twQ
 Rom
 Lfs
-qoh
+hoP
 vsK
 ZJO
 rai
@@ -47194,9 +47628,9 @@ AxL
 FJv
 dHH
 TMM
-INs
+OQO
 LGN
-yaB
+nAE
 DBO
 PzY
 uZg
@@ -47224,7 +47658,7 @@ SDb
 OYB
 mqV
 Aqc
-ERV
+pLV
 yHC
 Kko
 qQE
@@ -47730,8 +48164,8 @@ sme
 xXk
 Rtg
 HVe
-TSw
-NhV
+Cbb
+mLF
 fTJ
 slQ
 KCi
@@ -49016,7 +49450,7 @@ Uvr
 stV
 rFT
 NYv
-HVR
+YrX
 WNK
 LoQ
 wXP
@@ -49257,7 +49691,7 @@ tyy
 TZf
 xrT
 gos
-tCW
+ont
 mlW
 FdQ
 sme
@@ -49284,7 +49718,7 @@ XOg
 TdB
 lVS
 UzS
-uKG
+phJ
 SWo
 sme
 sme
@@ -49505,7 +49939,7 @@ UPn
 AxL
 AxL
 NXI
-dHH
+BRS
 LXo
 mbn
 TIJ
@@ -49798,7 +50232,7 @@ yWF
 sWX
 AFi
 VXo
-qXp
+HFR
 mrt
 sme
 sme
@@ -50018,7 +50452,7 @@ sme
 gJO
 gJO
 gJO
-CGi
+Ayz
 Ixj
 Nke
 Qhy
@@ -50287,7 +50721,7 @@ kfJ
 xGP
 AmT
 wDi
-SfI
+JPU
 YTQ
 UnH
 Ytm
@@ -50792,14 +51226,14 @@ cdr
 cdr
 cdr
 KOd
-eld
+luG
 Ele
 JIh
 JJP
 Fjg
 HcR
 jzw
-Efx
+uJe
 CoN
 WCw
 sme
@@ -50822,7 +51256,7 @@ ivW
 oIu
 ZCx
 EXi
-WmS
+ajA
 CAA
 mrt
 sme
@@ -51583,7 +52017,7 @@ EWl
 EWl
 EWl
 EfT
-FjQ
+iRa
 GGT
 tfm
 Edt
@@ -52600,7 +53034,7 @@ ulp
 NMe
 Whx
 gQb
-jfI
+Ppk
 DxI
 xWI
 ZWw
@@ -52873,7 +53307,7 @@ CTP
 UZD
 eIl
 aWu
-goE
+dMN
 NSu
 NSu
 Cqj
@@ -53893,7 +54327,7 @@ Yhk
 pFy
 JuQ
 PMr
-qKP
+Oab
 vpM
 EgI
 aRR
@@ -55422,7 +55856,7 @@ ksn
 xPT
 WOT
 Uic
-XKk
+cdP
 HEe
 qAo
 rPo
@@ -55437,7 +55871,7 @@ JuQ
 RSY
 inK
 IJa
-LCO
+zro
 RFB
 Spz
 Spz
@@ -56197,7 +56631,7 @@ aQT
 xCC
 TeG
 rPo
-hse
+RyM
 WOT
 LYM
 QQb
@@ -56706,13 +57140,13 @@ sme
 WOT
 ZYN
 Otm
-Otm
+SaE
 Otm
 DnX
 GAV
 rPo
 BsU
-Yzz
+MEp
 Yzz
 glX
 Wfb
@@ -57224,7 +57658,7 @@ vsn
 vsn
 DVI
 ada
-XMd
+ulf
 PwK
 mJg
 vRt
@@ -57739,7 +58173,7 @@ KFK
 LHX
 hRD
 dzn
-Avd
+sBE
 yDw
 gcK
 rqK
@@ -58011,7 +58445,7 @@ Rwn
 sqY
 ngK
 hFL
-lFQ
+jzy
 PpC
 KNb
 Rwn
@@ -58504,7 +58938,7 @@ sme
 sme
 bhJ
 JOO
-FDm
+Hbi
 grC
 IEr
 mFr
@@ -58524,9 +58958,9 @@ fAp
 cLC
 cLC
 vyJ
-wFi
+IZP
 iSS
-tAA
+XTS
 dtC
 IkS
 zbA
@@ -60322,12 +60756,12 @@ COt
 kWO
 bSM
 jaU
-FhS
+svo
 Oef
 MNi
 Fbx
 bSM
-Zvs
+SpP
 lMr
 jPM
 sme
@@ -61072,7 +61506,7 @@ sme
 sme
 VGU
 gUK
-gUK
+Pme
 zLe
 VGU
 Dft
@@ -61087,7 +61521,7 @@ QmH
 HzW
 DdT
 Ghn
-rik
+FHq
 uko
 sme
 sme
@@ -62364,7 +62798,7 @@ Dft
 Nry
 zGB
 Etg
-Lvq
+dbV
 alv
 oyE
 Lav
@@ -62621,7 +63055,7 @@ Dft
 BIM
 rkv
 Etg
-UQp
+twN
 DCt
 UiW
 paU
@@ -62873,7 +63307,7 @@ CCT
 erg
 CCT
 zgm
-QtE
+afh
 Dft
 Dft
 ntv
@@ -63135,7 +63569,7 @@ CCT
 GEk
 JxK
 NyF
-YNL
+qxW
 mqY
 cKm
 nuu
@@ -63145,7 +63579,7 @@ Nqn
 UwF
 qbb
 caU
-otX
+kkX
 otX
 otX
 otX
@@ -64949,9 +65383,9 @@ sme
 Vdi
 BCf
 ZaG
-JpK
+mPj
 tDX
-wBc
+yPS
 BqZ
 XiI
 WQA
@@ -65457,13 +65891,13 @@ XFA
 hCn
 cgo
 rvv
-umz
+LhR
 umz
 umz
 xtO
-slK
+Eqy
 eVb
-uAG
+XIh
 Xsv
 csS
 jxC
@@ -65973,7 +66407,7 @@ QJh
 nwq
 DQS
 DQS
-PHD
+dam
 Arj
 jsE
 UMt
@@ -66489,7 +66923,7 @@ EsB
 EsB
 pRM
 tpz
-EUR
+DsJ
 OWB
 efT
 jxC
@@ -66744,7 +67178,7 @@ Juj
 NqL
 Ogh
 ctY
-ctY
+LuP
 tpz
 WzA
 ESg
@@ -67763,7 +68197,7 @@ sme
 sme
 sme
 oYr
-Owq
+Wga
 Bkr
 gDU
 vwA


### PR DESCRIPTION
:cl: EvilJackCarver
add: adds missing fire alarms to several areas.
add: adds missing firelocks to munitions and R&D
add: adds signs pointing to most of the departments
add: medbay and genetics have exit buttons now
add: Faster-Than-Lizard(13) has signed up as Lizard.
add: Added a small fan to the phase cannon accessway to reduce space wind.
del: Fired the other cleaner. Most vents now have glowing goo near them.
del: Fired the exterminator. 
tweak: redid the vast majority of the ship's lighting to be moodier. A LOT moodier.
tweak: redid most, if not all, status displays to be visible through one wall only. (There are some exceptions.)
tweak: Replaced some grilles with broken grilles. According to the code.
fix: fixed a fire alarm in sec that had too high an offset value
fix: Fixed firelocks near the docking airlocks being above said airlocks.
/:cl:

fixes most of #119 
