### PR TITLE
nerfs percent chance to get a 'kill pirates' objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -904,7 +904,7 @@ var/global/list/possible_items_special = list()
 
 /datum/objective/ftl/killships/find_target()
 	ship_count = rand(5,10)
-	if(prob(25))
+	if(prob(5))
 		faction = "pirate"
 	else
 		faction = "syndicate"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -903,11 +903,12 @@ var/global/list/possible_items_special = list()
 	var/ships_killed = 0
 
 /datum/objective/ftl/killships/find_target()
-	ship_count = rand(5,10)
 	if(prob(5))
 		faction = "pirate"
+		ship_count = rand(1,3)
 	else
 		faction = "syndicate"
+		ship_count = rand(5,10)
 	..()
 
 /datum/objective/ftl/killships/update_explanation_text()


### PR DESCRIPTION
:cl: EvilJackCarver
tweak: Pirates are now less of a threat to Nanotrasen.
/:cl:

Reduces chance to get a "destroy pirates" objective to 5%, down from 25%. You get told to kill 1 to 3 pirate ships, down from 5 to 10.

Pirates tend to get wiped out pretty early with the slow rate we play at, so giving them a lower chance to be the target is beneficial to the ship as a whole when you're doing objectives. ***Thoughts on this change are welcomed.***

At some point we do need to get back to doing objectives rather than doing ERP all day. I'll resume work on the cab-forward Astraeus variant in the meantime. 