### PR TITLE
Reduces round time

### DIFF
--- a/code/controllers/subsystem/starmap.dm
+++ b/code/controllers/subsystem/starmap.dm
@@ -20,7 +20,7 @@ var/datum/subsystem/starmap/SSstarmap
 	var/to_distance = 0 //how far is it? used in FTL travel
 	var/travel_time = 0 //how long should it take?
 	
-	var/target_round_time_in_minutes = 270		//target round time, where the 'go home' objective is made
+	var/target_round_time_in_minutes = 150		//target round time, where the 'go home' objective is made
 
 	var/datum/planet/current_planet
 	var/datum/planet/from_planet

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -13,5 +13,5 @@ eissendargwell = Game Admin
 segalowitz = Game Admin
 leon962 = Game Admin
 jessica_stark = Game Admin
-christ110 = Trial Admin
-auris456852 = Trial Admin
+christ110 = Game Admin
+auris456852 = Game Admin


### PR DESCRIPTION
:cl: EvilJackCarver
tweak: Reduces default target round time to 2h 30:00. Admins can varedit it to be longer if needed.
/:cl:
