### PR TITLE
Fire Alarm Update 2

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -83,7 +83,7 @@
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 50, 1)
 
 /obj/machinery/firealarm/temperature_expose(datum/gas_mixture/air, temperature, volume)
-	if(!emagged && detecting && !stat && (temperature > T0C + 200 || temperature < BODYTEMP_COLD_DAMAGE_LIMIT))
+	if(!emagged && detecting && !stat && (temperature > T0C + 200 || temperature < T0C - 15))
 		alarm()
 
 /obj/machinery/firealarm/proc/alarm()


### PR DESCRIPTION
:cl: EvilJackCarver
fix: Fire alarms should now trigger properly if it's too cold.
/:cl:

Fire alarms are set to trigger at -15 Celsius. I could make the high-temp trigger more sensitive if need be.