### PR TITLE
Removes planetary check from ship disengagement code

### DIFF
--- a/code/controllers/subsystem/ships.dm
+++ b/code/controllers/subsystem/ships.dm
@@ -117,9 +117,6 @@ var/global/list/ftl_weapons_consoles = list()
 		if(SSstarmap.in_transit || SSstarmap.in_transit_planet)
 			return
 		if(S.planet != SSstarmap.current_planet)
-			if(ships_disengage_on_ftl_jump)
-				S.attacking_player = 0
-				broadcast_message("<span class=notice> Left weapons range of enemy ship ([S.name]). Enemy ship disengaging.</span>",notice_sound)
 			return
 		if(S.system != SSstarmap.current_system)
 			if(ships_disengage_on_ftl_jump)


### PR DESCRIPTION
:cl: EvilJackCarver
fix: Removes planetary check from ship disengagement code.
/:cl:

[10:21] Marshall Bash: I'm on my own solo server, breaking another ship in a solo run to hone my skills.
[10:22] Marshall Bash: ...But they keep disengaging, then reengaging repeatedly if they're not on the same planet for some reason.