### PR TITLE
The Trailblazer now has a cleaner again

### DIFF
--- a/_maps/map_files/Trailblazer/Trailblazer.dmm
+++ b/_maps/map_files/Trailblazer/Trailblazer.dmm
@@ -28,19 +28,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/fore)
-"aaL" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/bridge)
 "acy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plasteel/black,
@@ -81,12 +68,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
-"adJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "afh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
@@ -153,6 +134,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
+"akE" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "akF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -212,17 +200,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
-"aqk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "aqq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -382,6 +359,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"aCd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "aCw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -397,21 +389,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"aDL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "aDM" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -421,13 +398,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
-"aGg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "aKq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
@@ -479,14 +449,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"aVw" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "aVN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -558,16 +520,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/yellow,
 /area/shuttle/ftl/engine/tool_storage)
-"bce" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "bcD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -580,6 +532,17 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"bcG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "bgn" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -645,6 +608,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"blJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "bmd" = (
 /obj/machinery/light{
 	dir = 1
@@ -682,6 +654,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"bqd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "bqk" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer"
@@ -697,6 +675,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engineering)
+"bqW" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Janitor's Closet";
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/darkgreen/side,
+/area/shuttle/ftl/janitor)
 "brG" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -716,6 +709,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"brH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "bsR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -760,17 +765,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"btK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "bua" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -792,6 +786,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"byb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "bzq" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
@@ -840,6 +842,24 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/mining)
+"bFr" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
+"bGY" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "bJs" = (
 /obj/machinery/meter,
 /obj/structure/window/reinforced,
@@ -847,18 +867,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
-"bKm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "bKI" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -875,11 +883,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"bLx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
+"bLl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark{
+	name = "Observer-Start"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
+"bLt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/area/shuttle/ftl/hallway/primary/central)
 "bND" = (
 /obj/machinery/computer/message_monitor,
 /obj/effect/decal/cleanable/dirt,
@@ -898,26 +930,6 @@
 "bSM" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/storage/tech)
-"bUL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "bVB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -940,17 +952,6 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"bWI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 5";
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "bXF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -973,46 +974,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"bYo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
-"bYv" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
-"bYM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "bZS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -1031,14 +992,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"caU" = (
-/obj/structure/disposalpipe/segment,
+"cbk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
+/area/shuttle/ftl/hallway/primary/starboard)
 "cbm" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
@@ -1079,16 +1043,18 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"cfG" = (
-/obj/structure/sign/directions/evac{
-	dir = 1
+"cgj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = -8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/security/armory)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "cgo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -1112,11 +1078,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"chn" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "ciF" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -1185,6 +1146,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
+"cml" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "cok" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -1282,16 +1257,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"cti" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"ctr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "ctW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm{
@@ -1310,6 +1284,19 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"cya" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "cyk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1348,15 +1335,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"cAN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 4";
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "cAO" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/chiefs_office)
@@ -1371,23 +1349,34 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"cCP" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "cDN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"cEN" = (
-/obj/structure/disposalpipe/segment{
+"cDO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/area/shuttle/ftl/hallway/primary/starboard)
 "cFp" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/decal/cleanable/dirt,
@@ -1407,21 +1396,6 @@
 "cJy" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/security)
-"cKm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "cLC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -1454,6 +1428,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
+"cRV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "cRY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -1462,6 +1443,30 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"cTs" = (
+/obj/structure/sign/securearea{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
+"cTA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "cTD" = (
 /obj/machinery/conveyor{
 	dir = 2;
@@ -1587,6 +1592,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"dfq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "dfZ" = (
 /obj/machinery/chem_master/condimaster,
 /obj/structure/cable{
@@ -1704,35 +1718,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"dmt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
-"dmu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "dnq" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1789,13 +1774,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"doQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "dpa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1919,6 +1897,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"dyl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "dyF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	tag = "icon-intact (NORTH)";
@@ -1979,17 +1969,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/nuke_storage)
-"dCD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "dDg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /obj/effect/decal/cleanable/dirt,
@@ -2093,19 +2072,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"dLM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "dMN" = (
 /obj/structure/rack{
 	dir = 8;
@@ -2117,18 +2083,23 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"dNB" = (
-/obj/structure/window/reinforced{
-	dir = 4
+"dOY" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/medical/sleeper)
+/area/shuttle/ftl/hallway/primary/starboard)
 "dPR" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/bridge)
+"dQD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "dQJ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -2177,6 +2148,19 @@
 	dir = 5
 	},
 /area/shuttle/ftl/security/nuke_storage)
+"dVq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway 2";
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "dWP" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -2216,29 +2200,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
-"eii" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
-"ejz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "ejB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2362,17 +2323,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"eub" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "euL" = (
 /obj/machinery/telecomms/server/presets/common/birdstation,
 /obj/effect/decal/cleanable/dirt,
@@ -2556,20 +2506,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"eIo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "eJf" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -2637,6 +2573,17 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
+"eLX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/central)
 "eNZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -2677,13 +2624,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"eRb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"eQu" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
 "eUE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -2700,15 +2649,19 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
+"eWf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "eWk" = (
 /obj/effect/landmark/ship_fire,
 /turf/open/space,
 /area/shuttle/ftl/space)
-"eXq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
 "eZD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -2737,6 +2690,17 @@
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/wood,
 /area/shuttle/ftl/medical/cmo)
+"fal" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	busy = 0;
+	c_tag = "Port Primary Hallway 3";
+	dir = 10
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "fcr" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -2755,20 +2719,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/eva)
-"feh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "few" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/locker)
@@ -2838,15 +2788,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/cargo/mining)
-"fje" = (
-/obj/machinery/door/airlock{
-	name = "Unit 1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/ftl/crew_quarters/toilet)
 "fjt" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
@@ -2870,30 +2811,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"fmE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
-"fnq" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (NORTHWEST)";
-	icon_state = "darkblue";
-	dir = 9
-	},
-/area/shuttle/ftl/hallway/primary/central)
 "fnK" = (
 /obj/effect/landmark/start{
 	name = "Munitions Officer";
@@ -2901,6 +2818,13 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"foo" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "foK" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood,
@@ -2935,16 +2859,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"fqM" = (
+"frr" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/viewscreen{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/rust,
+/turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge)
 "frF" = (
 /turf/closed/wall,
@@ -2978,6 +2904,13 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
+"fuN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "fvF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -3076,28 +3009,20 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"fCT" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Janitor's Closet";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 2;
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "fCZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"fDl" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "fDE" = (
 /obj/effect/landmark/start{
 	name = "Botanist";
@@ -3110,6 +3035,24 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
+"fDN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
+"fDW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "fEi" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -3201,32 +3144,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/cargo/mining)
-"fNg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
-"fNG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
-"fNS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "fOz" = (
 /obj/structure/table/glass,
 /obj/item/device/healthanalyzer,
@@ -3277,17 +3194,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"fQW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "fRF" = (
 /obj/effect/landmark/start{
 	name = "Cook";
@@ -3410,30 +3316,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"gaq" = (
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/medical/sleeper)
 "gaD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3445,16 +3327,6 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/meeting_room)
-"gbt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "gbO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /obj/effect/decal/cleanable/dirt,
@@ -3564,18 +3436,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/chemistry)
-"glA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "glX" = (
 /obj/machinery/computer/security,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3592,6 +3452,23 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"gnX" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	sortType = 12
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "gop" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -3637,14 +3514,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"gqx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "grC" = (
 /obj/machinery/camera{
 	c_tag = "HoS Office";
@@ -3656,6 +3525,29 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
+"gsd" = (
+/obj/structure/disposalpipe/junction,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
+"gsL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "gvb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3673,6 +3565,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"gwm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "gxJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -3775,6 +3677,21 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"gFH" = (
+/obj/effect/landmark/start{
+	name = "Janitor";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/darkgreen,
+/area/shuttle/ftl/janitor)
 "gGR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3797,6 +3714,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
+"gHz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "gJi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/guncase/shotgun{
@@ -3966,6 +3896,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
+"gQX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "gRr" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -4074,26 +4016,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"haL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
-"hcv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "hea" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4137,6 +4059,16 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
+"hgG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "hhr" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/shovel/spade,
@@ -4216,17 +4148,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"hre" = (
+"hpe" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
 "hrJ" = (
 /obj/structure/closet/secure_closet/detective,
@@ -4349,16 +4282,6 @@
 	},
 /turf/open/floor/plasteel/darkyellow,
 /area/shuttle/ftl/engine/tool_storage)
-"hDn" = (
-/obj/structure/sign/directions/engineering{
-	dir = 8
-	},
-/obj/structure/sign/directions/security{
-	dir = 8;
-	pixel_y = 8
-	},
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/hallway/primary/fore)
 "hDM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 2
@@ -4475,14 +4398,6 @@
 "hRD" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"hTJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "hTL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -4502,6 +4417,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"hWy" = (
+/obj/structure/closet/jcloset,
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 1
+	},
+/area/shuttle/ftl/janitor)
 "hWB" = (
 /obj/structure/table,
 /obj/item/clothing/head/welding{
@@ -4512,6 +4433,20 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"hXA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "hYu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -4548,6 +4483,16 @@
 "hZG" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/starboard)
+"iat" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "iaz" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey{
@@ -4578,16 +4523,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"icv" = (
-/obj/structure/disposalpipe/segment,
+"icL" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/hallway/primary/fore)
 "idd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -4627,6 +4574,12 @@
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"ieE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/medical/sleeper)
 "igr" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1;
@@ -4700,30 +4653,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"ijO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
-"ikg" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	sortType = 13
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "ilr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -4782,6 +4711,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/computer)
+"ioe" = (
+/obj/structure/table,
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/key/janitor,
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 5
+	},
+/area/shuttle/ftl/janitor)
 "ios" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4913,6 +4853,13 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/office)
+"iAX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "iBo" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -4938,19 +4885,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/starboard)
-"iGG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "iHq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5026,27 +4960,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"iPT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "iRa" = (
 /obj/machinery/dna_scannernew{
 	tag = ""
@@ -5112,18 +5025,6 @@
 "iXC" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/engineering)
-"iXX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	busy = 0;
-	c_tag = "Port Primary Hallway 3";
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "iYD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/warning{
@@ -5132,12 +5033,36 @@
 	dir = 1
 	},
 /area/shuttle/ftl/bridge/eva)
+"jae" = (
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 8
+	},
+/area/shuttle/ftl/janitor)
 "jaU" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"jbH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "jel" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5262,26 +5187,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
-"jpC" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
+"jpi" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/darkgreen/side,
+/area/shuttle/ftl/janitor)
 "jqa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/requests_console{
@@ -5321,6 +5230,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
+"juo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "jut" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/effect/decal/cleanable/dirt,
@@ -5415,16 +5329,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/xenobiology)
-"jyE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "jzw" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/decal/cleanable/dirt,
@@ -5515,31 +5419,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/bridge/eva)
-"jEB" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/ftl/crew_quarters/toilet)
-"jIJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "jJj" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5557,14 +5436,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"jMd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/fore)
 "jNA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -5695,6 +5566,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"jZn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "jZv" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer"
@@ -5803,23 +5682,27 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"khb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "kiH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"kiX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "kjJ" = (
 /obj/structure/table/wood,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -5831,6 +5714,19 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"kjX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "kkD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5855,20 +5751,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
-"kkX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "kmu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/cargo/office)
+"kmH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
+"kmJ" = (
+/obj/structure/sign/directions/engineering{
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/primary/fore)
 "kpy" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -5913,16 +5824,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
-"krd" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "ksn" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -5966,6 +5867,26 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
+"kws" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
+"kwu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 4
+	},
+/area/shuttle/ftl/janitor)
 "kyj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6008,18 +5929,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/chemistry)
-"kzy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 1";
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
 "kAj" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -6039,6 +5948,27 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
+"kDX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
+"kEP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "kFr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -6087,17 +6017,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/xenobiology)
-"kGI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "kGL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -6129,9 +6048,21 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"kJQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
+"kKz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
+"kKQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
 "kLl" = (
@@ -6173,6 +6104,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"kQo" = (
+/obj/machinery/cryopod/right,
+/obj/machinery/airalarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/warnwhite{
+	dir = 4
+	},
+/area/shuttle/ftl/medical/sleeper)
 "kQB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6199,13 +6140,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"kWO" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
+"kUt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/area/shuttle/ftl/crew_quarters/toilet)
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
+"kWP" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "kXa" = (
 /obj/machinery/camera{
 	c_tag = "Vacant Office";
@@ -6241,21 +6196,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"kZB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
-"kZU" = (
-/obj/vehicle/janicart,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "lap" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -6274,20 +6214,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/office)
+"lby" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "lck" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"lda" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
 "ldb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6335,22 +6276,6 @@
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
 /area/shuttle/ftl/medical/medbay)
-"lgR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "lhc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6394,17 +6319,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"lkQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 2";
-	dir = 6
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "lkW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
@@ -6431,18 +6345,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/cmo)
-"lnn" = (
+"lnS" = (
 /obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
 "lqk" = (
 /obj/machinery/button/door{
@@ -6528,16 +6439,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"lxd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "lxy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkwarning{
@@ -6546,6 +6447,18 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"lye" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "lyB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -6661,11 +6574,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"lRJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "lSC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6673,6 +6581,15 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"lSV" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "lTb" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel{
@@ -6759,6 +6676,21 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"lXF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "mbn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -7034,18 +6966,93 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"mrO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"mso" = (
+/obj/structure/filingcabinet/security,
+/obj/item/weapon/folder/documents,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
+/obj/item/weapon/paper{
+	desc = null;
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> OVERVIEW <HR> <B>Name:</B> Spitzer, Randall Philip <U>Jonas</U><BR> <B>Known Aliases:</B> Kicks-The-Tyres<BR> <B>Date of Birth:</B> February 16, 2528<BR> <B>Height:</B> 1.95m / <B>Weight:</B> 80 kg / <B>Physique:</B> Medium<BR> <B>Eyes:</B> BLU / <B>Scales</B>: GRN / <B>Tail:</B> DARK STRIPES<BR> <B>Bloodtype</B>: L/Rh.NULL<BR> <B>LKA:</B> 6237 RM 1308, Skal, Obristan, Eridanis II<BR> <B>Known Affiliations:</B> The Syndicate<BR> <B>Suspected Affiliations:</B> <B>Physical State:</B> <I>PHYSICALLY UNFIT FOR DUTY</I><BR> <B>Mental State:</B> <I>* WATCH *</I><BR> <B>Fingerprint:</B> \[FINGERPRINT REDACTED\]<BR></font>";
+	name = "paper - Jonas Spitzer dossier: Overview"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> MEDICAL INFORMATION (as of 19.02.2557 - Eridanis Defence Corps file) <HR> <B>Bloodtype</B>: L (No Rh. subtype)<BR> <B>Fingerprint:</B> \[FINGERPRINT REDACTED\] <BR> <B>DNA:</B> \[DNA REDACTED\]<BR> <B>Diseases:</B> Tinnitus - Stage 1, Myopia - Stage 2, Nyctalopia/Night Blindness - Stage 3, Tachycardia - Stage 2, Hypertension - Stage 1<BR> <B>Resting heartrate:</B> 113<BR> <B>Blood pressure:</B> <I>Systolic:</I> 146 mmHg / <I>Diastolic:</I> 93 mmHg <B>Body temperature:</B> 33.6 Celsius<BR> <B>Vision (Corrected):</B> 6/7.5m Left / 6/6 Right<BR> <B>Smoker:</B> YES<BR> <B>Alcohol consumption:</B> Seasonal<BR> <B>Other notes:</B> Family history of hypertension and anxiety distorders.<BR> <B>Prescribed medications:</B> Plisrelax (for stress/active ingredient: haloperidol)<BR> <B>Known allergies:</B> None known</font>";
+	name = "paper - Jonas Spitzer dossier: Medical Information"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> DUGA-3 ARREST RECORD<BR> <HR> <B>Suspect:</B> Kicks-The-Tyres<BR> <B>Date of Arrest:</B> 2546-11-30<BR> <B>Fingerprint:</B> \[FINGERPRINT REDACTED\] <BR> <B>Date of Birth:</B> 2528-02-16<BR> <B>Charge(s):</B> Misdemeanour Trespass<BR> <B>Arresting Officer:</B> Greenholme, Landon<BR> <B>Plea:</B> No Contest<BR> <BR> Complaintant called police asking the suspect to be removed from the complaintant&#39;s front yard. Suspect willingly complied with officers. Suspect was charged with Misdemeanour Trespass and sentenced to 2 weeks in jail. Suspect had no home address at the time of the arrest.</font>";
+	name = "paper - Jonas Spitzer dossier: Duga-3 Arrest Report (1)"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> DUGA-3 ARREST RECORD<BR> <HR> <B>Suspect:</B> Kicks-The-Tyres<BR> <B>Date of Arrest:</B> 2546-12-28<BR> <B>Fingerprint:</B> \[FINGERPRINT REDACTED\] <BR> <B>Date of Birth:</B> 2528-02-16<BR> <B>Charge(s):</B> Petty Theft<BR> <B>Arresting Officer:</B> Cooper, Lauren<BR> <B>Plea:</B> No Contest<BR> <BR> Police were alerted to an automated theft alarm at Ronald&#39;s Food Mart. Owner Ronald Jacobs was on scene with the suspect, talking to him. Suspect admitted to stealing a loaf of bread to officers on scene. Suspect was arrested and charged with Petty Theft, but was released due to Ronald Jacobs&#39; request to drop charges against the suspect. Suspect had no home address at the time of the arrest.</font> ";
+	name = "paper - Jonas Spitzer dossier: Duga-3 Arrest Record (2)"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> ERIDANIS DEFENCE CORPS PERSONNEL FILE<BR> <HR> <B>Last update: 19.02.2557</B><BR> <B>Name:</B> Spitzer, Randall Philip <U>Jonas</U><BR> <B>Known Aliases:</B> None<BR> <B>Fingerprint:</B> \[FINGERPRINT REDACTED\] <BR> <B>Date of Birth:</B> 16.02.2528<BR> <B>Height:</B> 1,96m / <B>Weight:</B> 81 kg / <B>Build:</B> Athletic<BR> <B>Eyes:</B> Blue / <B>Hair/Scales</B>: Green / <B>Tail:</B> Striped, dark<BR> <B>Bloodtype</B>: L (No Rh. subtype)/NKDA<BR> <B>Home Address:</B> 6237 RM 1308, Skal, Obristan, Eridanis II<BR> <B>Next of Kin:</B> None listed<BR> <B>Commanding Officer(s):</B> Staff-Sergeant Juliet Michaels, Technical Sergeant Harold Temple<BR><B>Awards/Commendations:</B> Eridanis Orbital Defence Medal of Valour - Awarded 10.06.2555. Reason: &#34;Selflessly risking his life to run into a burning wreckage and rescuing all six crew aboard the vessel before fire crews could arrive to contain the fire.&#34;<BR> <B>Other notes:</B> Authorised per Technical Sergeant Temple per Notification 2830-C to carry a lethal-capable firearm on base. Currently on medical leave until 19.03.2557. Promotion to Senior Airman&#39;s Mechanic pending. Suffers from tinnitus (ringing in ear) due to working near loud machinery. Diagnosed with myopia (nearsightedness) and nyctalopia (night-blindness) due to using welding implements without PPE. Prescribed Plisrelax to help with stress and hypertension.</font> ";
+	name = "paper - Jonas Spitzer dossier: EDC Personnel File"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> ERIDANIS DEFENCE CORPS MEDICAL DISCHARGE PAPERWORK<BR> <HR> <center>ERIDANIS DEFENCE CORPS DISCHARGE NOTIFICATION</center><BR> <HR> <B>RANK/NAME/SERIAL</B>: AMech1C/Randall <U>Jonas</U> Spitzer/1684986965<BR> <B>BRANCH</B>: Orbital Defence<BR> <B>ADDRESS</B>: 6237 RM 1308, Skal, Obristan, Eridanis II<BR> <B>DATE OF DISCHARGE</B>: 19.02.2557<BR> <B>DISCHARGE CLASS</B>: Medical<BR> <U>X</U> <B>TO RETURN TO ACTIVE DUTY /</B> <U> </U> <B>NOT TO RETURN TO ACTIVE DUTY</B><BR> <B>IF TO RETURN TO DUTY, DO SO WITHIN ONE MONTH OF DISCHARGE DATE, UNLESS NOTED OTHERWISE.</B> <HR> <B>DISTINGUISHING MARKS</B>: <BR> - Eridanis Orbital Defence Medal of Valour: Awarded 10.06.2555</font> ";
+	name = "paper - Jonas Spitzer dossier: EDC Discharge Form"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> NCV BASILISK ARREST REPORT<BR> <HR> <B>Date of Arrest:</B> 2557-02-22<BR> <B>Suspect:</B> Spitzer, Randall Philip Jonas<BR> <B>Date of Birth:</B> 2528-02-16<BR> <B>Fingerprint:</B> \[FINGERPRINT REDACTED\] <BR> <B>Charge(s):</B> Enemy of the Corporation<BR> <B>Arresting Officer:</B> Bash, Marshall<BR> <B>Processing Officer:</B> 2dLT Richard Dunn<BR> <B>Plea:</B> Guilty<BR> <BR>Suspect was arrested after attempting to hijack the nuclear authentication disk and detonate the onboard self-destruct device (ONSDD). Suspect was interrogated by 2dLT Richard Dunn. During interrogation, suspect willingly gave information regarding his involvement with the Syndicate, both past and present.<BR> <BR> Subject was cut a deal: serve the Basilisk until their debt was repaid. In exchange, the arrest warrant would be deleted and the case re-closed, all copies of the CCTV footage of the incident will be wiped permanently, and news of the incident and/or this arrest report will not be forwarded to Russell Andreas Spitzer, nor the Eridanis Defence Corps.<BR> See further information on &#34;Orders for the RO&#34;.</font> ";
+	name = "paper - Jonas Spitzer dossier: NCV Basilisk Arrest Report"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> INCIDENT REPORT: RADMEER 2 ASSASSINATIONS<BR> <HR> The following is an incident report in regard to the following event, past or present:<BR> <BR> <B>RADMEER 2 ASSASSINATIONS re: SPITZER, RANDALL PHILIP JONAS</B><BR> <HR> Randall spoke to me about his involvement in the high-profile killing of Mayor Joseph Davis et alli in 2547. Due to getting kicked out of his home, Randall was homeless. Randall was offered and accepted a contract to take out two men, both lawyers, in exchange for SC 50,000. He says he was issued an L115A3 bolt-action rifle chambered in .338 Lapua Magnum, as well as two photos identifying the men. This is corroborated by the autopsy reports of Daniel Smith and Walter Johnson, which list the two men&#39;s occupation as public legal counsel. Randall stated he did not know the reasoning behind why they were to be killed.<BR><BR> Randall stated he set up in a building across the street from a four-star hotel in mid-March 2547; this contradicts the autopsy reports and the Affidavit of Probable Cause, which have the date listed as April 1, 2547. I did not press Randall on this inconsistency. Randall says the first shot he took went where he intended, into the center of mass of one lawyer; likely Johnson according to the autopsy reports. The second shot was affected by tailwind and hit the second lawyer (likely Smith) in the skull. Randall stated the second bullet over-penetrated and hit Mayor Davis in the jugular.<BR> <BR> Randall claimed he ditched the rifle; there is no evidence supporting or refuting this. He stated that he forgot to clean up the spent .338 LM cartridges; this is corroborated by the Affidavit of Probable Cause submitted by Detective Frank McKendrick. Randall tells me that afterwards, he stowed away on a freighter bound for the Eridanis system.<BR> <BR> Autopsy reports and Affidavit of Probable Cause attached.</font> ";
+	name = "paper - Jonas Spitzer dossier: Incident Report - Radmeer 2"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> INCIDENT REPORT: NCV BASILISK NUCLEAR DETONATION ATTEMPT<BR> <HR> The following is an incident report in regard to the following event, past or present:<BR> <BR> <B>NCV BASILISK ONSDD ACTIVATION ATTEMPT</B><BR> <HR> Randall spoke to me about his involvement in the attempt against the onboard nuclear self-destruct device (ONSDD) of the NCV Basilisk. After becoming paranoid regarding seeing the copy of the arrest warrant the dossier I&#39;d prepared, he turned to the Syndicate to try to have them &#39;bail \[him\] out of this mess they got \[him\] into&#39;. Randall states he was told to detonate the Basilisk&#39;s ONSDD in exchange for the illegal deletion of the arrest warrant.<BR> <BR>Randall told me he was armed with mostly less-than-lethal weaponry, the lethal exceptions being a P12-SD Compact and his service rifle. He says his plan was to call the escape pods and then activate the device, so the crew would have enough time to evacuate. He says he boarded the Basilisk through the left engine nacelle&#39;s maintenance area, which triggered an alarm; this was corroborated by data from the Basilisk&#39;s blackbox recorder. Randall states he immediately ducked into the maintenance behind mining but was somehow spotted. Randall states he discharged his Taser at Chief Medic Eats-The-Glue when she entered, and attempted to run into the EVA bay, but got cornered due to a weapons malfunction with the Bulldog shotgun he had been issued. <BR> <BR> He states he attempted to run back to the back corner of the EVA bay and pulled out his Taser to try to buy time, but was foiled due to a hyper-localised bluespace anomaly and taken down by Chief Medic Eats-The-Glue and the Head of Personnel at the time. (Records show the HoP was Loads-Sixteen-Tons.)<BR> <BR> Randall states he remembers waking up in Surgery and &#39;cracking \[his\] cyanide cap in \[his\] molar&#39;, in an attempt to kill himself. Afterwards, the next thing he remembers was having his legs cut off with a surgical saw, then was killed by being put in a chokehold. Unfortunately, the camera footage in that area at that time is corrupt, so I am unable to corroborate that.<BR> <BR> Randall tells me he was cloned, and that he surrendered immediately after he exited the cloner, and was brought to the bridge for interrogation. The cameras&#39; audio feed from the interrogation is on file. After interrogation, he was dropped off at a station by Captain Marshall Bash, where he was recovered. Randall mentions that he&#39;d have rather died at the hands of the crew than be captured by the Radmeer System Police - &#34;That way it can pass as an unfortunate accident&#34;, he said, then noted that it would work in the interest of avoiding an intergalactic war with the Eridanis Defence Corps</font>";
+	name = "paper - Jonas Spitzer dossier: Incident Report - NCV Basilisk ONSDD activation attempt"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> RADMEER 2 ARREST WARRANT<BR> <HR> <B>KICKS-THE-TYRES; DOB.: 16/02/2528</B> Whereas, F.MCKENDRICK, Detective, Amadeus Valley Police Department has made an Application and Affidavit to the Court for the issuance of an Arrest Warrant, and;<BR> <BR> Whereas the application is in proper form and probable cause is found to believe that the person named in the application has committed, or has connection to, the offence of Section 187, MURDER IN THE FIRST DEGREE, CLASS 1 FELONY (3 cts.) in violation of the Radmeer System Code of Laws:<BR> <BR> THEREFORE, any Law Enforcement Officer into whose hands this Arrest Warrant shall come is hereby ordered to arrest KICKS-THE-TYRES; DOB.: 16/02/2528 and bring him/her without unnecessary delay before the nearest Judge of the System of Radmeer.<BR> <BR> It is further ordered that Bond is set in the amount of: <U>NO BOND</U><BR>DONE this <U>4th</U> day of <U>APRIL</U>, <U>2547</U> - TIME: <U>22:50</U> BY THE COURT: JUDGE <U>Jack D. Harrison Jr.</U><BR> <HR> RETURN AND SERVICE: I have duly served this Arrest Warrant by arresting the aforementioned Defendant as required on the _________ day of _________, 25____________.<BR> Signed: _______________________________<BR>Law Enforcement Agency:_______________________________________</font> ";
+	name = "paper - Jonas Spitzer dossier: Radmeer 2 arrest warrant"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> AUTOPSY REPORT re: RADMEER 2 ASSASSINATIONS<BR> JOSEPH DAVIS<BR> <HR> <B>Date of Autopsy:</B> 2547-04-02<BR> <B>Victim:</B> Davis, Joseph Alan<BR> <B>Victim&#39;s Occupation:</B> Mayor of Amadeus Valley<BR> <B>Coroner:</B> Van der Haagen, Sheila<BR> <B>Report number:</B> 35685342<BR> <HR> <B>Cause of Death:</B> Blood loss resultant to single gunshot wound to neck<BR> <B>Time of Death approx.:</B> 13:56 2547-04-01<BR> <HR> Subject suffered gunshot wound to the jugular. Subject was standing behind Daniel Smith (AUTOPSY NO.35685340) and was stricken by the bullet exiting Smith. Bullet passed through and exited the back of the neck. Large wound suggests rifle cartridge.<BR> <BR> <I>(Below are various schematics detailing entry and exit wounds.)</I></font> ";
+	name = "paper - Jonas Spitzer dossier: Autopsy Report - Joseph Davis"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> AUTOPSY REPORT re: RADMEER 2 ASSASSINATIONS<BR> DANIEL SMITH<BR> <HR> <B>Date of Autopsy:</B> 2547-04-02<BR> <B>Victim:</B> Smith, Daniel James<BR> <B>Victim&#39;s Occupation:</B> Attorney at Law<BR> <B>Coroner:</B> Van der Haagen, Sheila<BR> <B>Report number:</B> 35685340<BR> <HR> <B>Cause of Death:</B> Single gunshot wound to the head.<BR> <B>Time of Death approx.:</B> 13:51 2547-04-01<BR> <HR> Subject suffered single gunshot wound entering at the frontal lobe over the right eye and exited at the cerebellar hemisphere. Diameter of the entry wound puts the round between .30-06 (7,62mm) and .38 (9,00mm). Length of internal wounds when the bullet began to tumble and large exit wound size suggests rifle cartridge.<BR> <BR> <I>(Below are various schematics detailing entry and exit wounds.)</I></font> ";
+	name = "paper - Jonas Spitzer dossier: Autopsy Report - Daniel Smith"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> AUTOPSY REPORT re: RADMEER 2 ASSASSINATIONS<BR> WALTER JOHNSON<BR> <HR> <B>Date of Autopsy:</B> 2547-04-02<BR> <B>Victim:</B> Johnson, Walter Gregory<BR> <B>Victim&#39;s Occupation:</B> Attorney at Law<BR> <B>Coroner:</B> Van der Haagen, Sheila<BR> <B>Report number:</B> 35685341<BR> <HR> <B>Cause of Death:</B> Single gunshot wound to the heart.<BR> <B>Time of Death approx.:</B> 13:51 2547-04-01<BR> <HR> Subject suffered single gunshot wound passing through aorta. Diameter of entry wound puts the round between .30-06 (7,62mm) and .38 (9,00mm). Large exit wound size suggests rifle cartridge.<BR> <BR> <I>(Below are various schematics detailing entry and exit wounds.)</I></font> ";
+	name = "paper - Jonas Spitzer dossier: Autopsy Report - Walter Johnson"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> PROBABLE CAUSE AFFIDAVIT re: RADMEER 2 ASSASSINATIONS<BR> <HR> On 2547-04-01 at approximately 1355 hours, the Amadeus Valley Emergency Services Switchboard received a 112 emergency services call in reference to a shots fired at the Benelux Hotel Resort in District 3. Upon arrival at the scene, Patrolmen Stoddard and Falkes called for cadaver transport for Mayor Joseph Davis, and Daniel Smith and Walter Johnson, two Attorneys at Law. After determining that the shots most likely came from the Bonneville Apartments, a high-rise complex across the street, the Amadeus Valley Emergency Services Switchboard received a 102 direct-to-police call stating that one of the tenants found spent .338 Lapua Magnum shells in Room 718.<BR><BR> Detective Frank McKendrick (hereafter referred to as &#34;I&#34;) arrived on the scene and found fingerprints on the two spent pieces of brass. The fingerprints, datum \[FINGERPRINT REDACTED\], matched a criminal arrest record of one Kicks-The-Tyres from the Duga System Police Database. These prints were also found on the doorknob. As a result of this investigation, I find that probable cause exists that the aforementioned Kicks-The-Tyres did intentionally shoot Smith and Johnson, with over-penetration claiming the life of Davis, and in doing so committed Murder in the First Degree, in violation of Section 187 of the Radmeer System Code of Laws.<BR> <BR> F.MCKENDRICK<BR> <HR> <B>FILED:</B> <U> April 4, 2547</U></font> ";
+	name = "paper - Jonas Spitzer dossier: Radmeer 2 Probable Cause Affidavit"
+	},
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> ORDERS FOR THE RANKING OFFICER (RO) OF THE NCV BASILISK<BR> <HR> PER THE ORDERS OF RO EATS-THE-GLUE:<BR> <B>REQUIREMENTS:</B> <ul><li>RANDALL IS TO WORK ABOARD THE SHIP UNTIL THE RANKING OFFICER ON DUTY STATES TO CENTRAL COMMAND THAT HE HAS REPAID HIS DEBT TO THE SHIP IN LABOR. DERELICTION OF DUTY IS TO BE PUNISHED BY INCARCERATION OR EXECUTION, PREFERABLY THE FORMER. <li>Randall is not permitted to carry weapons, be it lethal, less-than-lethal, or electrostun. <li>Randall is not permitted to communicate outside the ship, except when aboard Central Command. <li>Randall is not permitted to leave the ship, except as escorted by a Central Command officer, the RO, or a person designated by the RO. <li>Randall is not permitted to possess a PDA. <li>Randall is to have a mindshield implant. <li>Randall is to be searched upon boarding. <li>Randall is to take his prescription medication every four hours.</ul> <B>OPTIONAL REQUIREMENTS:</B><BR> <ul><li>Regular searches/shakedowns are at the discretion of the RO. <li>Randall may be legcuffed, at the discretion of the RO. <li>Randall is to be assigned to Janitor, or another insensitive assignment at the RO&#39;s discretion. Randall IS NOT to have access to sensitive areas, such as Engineering. <li>At the RO&#39;s discretion, Randall may have a tracking or chemical implant. Chemical implants are to have 15u Beepsky Smash and 25u Chloral Hydrate. <li>Randall may wear the jumpsuit of his current assignment at the RO&#39;s discretion, as long as it is not degrading.</ul> Central Command will notify you when they&#39;re about to send Randall to the Basilisk. If the RO wishes for Randall to have any of the optional requirements or an assignment other than custodial work, please contact Central Command within a reasonable timeframe for these requests to be fulfilled.<BR><BR> As we are at war with the Syndicate, and Randall was captured while acting on their behalf, Randall is technically an <I>hors de combat</I> by detention, and is thus protected by the Geneva and Altessa Conventions from: <ul> <li>Violence to life and person, in particular murder of all kinds, mutilation, cruel treatment and torture; <li>Taking of hostages; <li>Outrages upon dignity, in particular humiliating and degrading treatment; and <li>Failure to deliver adequate medical aid as necessary.</ul> <BR> <font face=\"Times New Roman\"><b><i>RDunn</i></b></font></font>";
+	name = "paper - Jonas Spitzer dossier: Orders for the Ranking Officer"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "mtE" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -7059,6 +7066,14 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
+"mtK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkgreen,
+/area/shuttle/ftl/janitor)
 "mvF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7089,6 +7104,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
+"mBR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "mCR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7224,38 +7246,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/medical/chemistry)
-"mMU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"mMi" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 2;
-	pixel_y = -24
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
+"mNA" = (
+/obj/machinery/cryopod/right,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/warnwhite{
+	tag = "icon-white_warn (SOUTHEAST)";
+	icon_state = "white_warn";
+	dir = 6
+	},
+/area/shuttle/ftl/medical/sleeper)
 "mNZ" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/mining)
-"mOD" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	sortType = 12
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "mOQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7330,17 +7339,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"mUS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+"mUn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (SOUTHEAST)";
-	icon_state = "darkblue";
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
+"mUA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "mVd" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -7351,17 +7369,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"mVn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "mWl" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -7378,22 +7385,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"mXF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "nag" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -7429,6 +7420,16 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"nca" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "ncx" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/light/small{
@@ -7450,14 +7451,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"ndv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "ndH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7569,6 +7562,23 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_3)
+"nhN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
+"nib" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "nll" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -7734,22 +7744,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"nwO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "nxy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7763,16 +7757,26 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/storage)
-"nzi" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
+"nza" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "nAE" = (
 /obj/item/device/radio/intercom{
 	pixel_y = 24
@@ -7790,6 +7794,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/secure_construction)
+"nDg" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 5";
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "nDT" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7830,16 +7844,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"nLv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "nOc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -7897,25 +7901,21 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"nUa" = (
+"obp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/fore)
-"nYR" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
 "obA" = (
@@ -7971,6 +7971,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"ogg" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "ohe" = (
 /obj/machinery/telecomms/relay/portable/preset,
 /obj/structure/window/reinforced{
@@ -7982,6 +7989,18 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/bridge/eva)
+"ohu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "ohL" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
@@ -7995,16 +8014,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
-"omu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"omj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/central)
 "omC" = (
 /obj/effect/landmark/start{
@@ -8039,6 +8058,19 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/hor)
+"onu" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTHWEST)";
+	icon_state = "darkblue";
+	dir = 9
+	},
+/area/shuttle/ftl/hallway/primary/central)
 "onF" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable{
@@ -8058,6 +8090,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"opR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "oqh" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenence Hatch";
@@ -8144,6 +8184,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"owo" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "oyE" = (
 /obj/item/clothing/under/shorts/black,
 /obj/item/clothing/head/bearpelt,
@@ -8170,14 +8216,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"oEi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/fore)
 "oEE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8299,21 +8337,20 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"oLo" = (
-/obj/structure/disposalpipe/segment,
+"oLC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "oLW" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -8325,6 +8362,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
+"oNV" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "oOj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8353,6 +8410,21 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engineering)
+"oRD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "oUm" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/airalarm{
@@ -8415,21 +8487,6 @@
 "oZg" = (
 /turf/open/space,
 /area/shuttle/ftl/munitions/cannon)
-"oZK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "paU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -8463,6 +8520,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/cargo/office)
+"pbn" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 9
+	},
+/area/shuttle/ftl/janitor)
 "pcV" = (
 /obj/machinery/door/window/brigdoor{
 	id = "Cell 2";
@@ -8557,42 +8629,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
-"pjY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
-"plh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"pmS" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 1";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
-"pll" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (NORTHEAST)";
-	icon_state = "darkblue";
-	dir = 5
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
 	},
+/turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
 "pnY" = (
 /obj/structure/disposalpipe/segment{
@@ -8640,6 +8689,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
+"psb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "psr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8730,19 +8790,6 @@
 "pxO" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/sleeper)
-"pyf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/ftl/hallway/primary/fore)
 "pzc" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -8822,24 +8869,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"pFy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
-"pHH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "pIr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -8860,11 +8889,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/xenobiology)
-"pJo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "pJR" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/bar)
@@ -8896,19 +8920,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
-"pLQ" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/ftl/crew_quarters/toilet)
 "pLV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /obj/item/device/radio/intercom{
@@ -8980,6 +8991,16 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"pSl" = (
+/obj/structure/sign/directions/evac{
+	dir = 1
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/hallway/primary/fore)
 "pSv" = (
 /obj/structure/shuttle/engine/propulsion/burst/right,
 /obj/structure/window/reinforced{
@@ -9027,15 +9048,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"pVR" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "pXe" = (
 /obj/machinery/computer/security,
 /obj/effect/decal/cleanable/dirt,
@@ -9090,17 +9102,19 @@
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"qcY" = (
-/obj/machinery/cryopod/right,
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/warnwhite{
-	tag = "icon-white_warn (SOUTHEAST)";
-	icon_state = "white_warn";
-	dir = 6
+"qcz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/shuttle/ftl/medical/sleeper)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "qfy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -9156,23 +9170,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"qlS" = (
-/obj/structure/disposalpipe/segment,
+"qkh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "qnP" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32;
@@ -9250,26 +9263,15 @@
 	dir = 8
 	},
 /area/shuttle/ftl/bridge/eva)
-"qxW" = (
+"qxQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/fore)
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "qyM" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -9329,15 +9331,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"qEq" = (
+"qEG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/area/shuttle/ftl/hallway/primary/central)
 "qFw" = (
 /obj/structure/chair{
 	dir = 8
@@ -9357,6 +9360,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"qGk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "qIT" = (
 /obj/structure/table/glass,
 /obj/item/weapon/grenade/chem_grenade,
@@ -9412,20 +9424,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"qKp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "qLr" = (
 /obj/machinery/conveyor_switch{
 	id = "munitions"
@@ -9436,23 +9434,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
-"qLN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "qMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9513,11 +9494,32 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/hor)
-"qQj" = (
-/obj/structure/closet/jcloset,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
+"qOL" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
+"qQi" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "qQE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9544,20 +9546,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
-"qRs" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	icon_state = "pipe-j2s";
-	sortType = 19
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (NORTHWEST)";
-	icon_state = "darkblue";
-	dir = 9
-	},
-/area/shuttle/ftl/hallway/primary/central)
 "qRP" = (
 /obj/machinery/disposal/deliveryChute{
 	tag = "icon-intake (NORTH)";
@@ -9598,13 +9586,16 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
-"qTu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"qTP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "qTY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenence Hatch";
@@ -9634,17 +9625,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/ftl/medical/sleeper)
-"qWM" = (
-/obj/machinery/cryopod/right,
-/obj/machinery/airalarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/warnwhite{
-	dir = 4
-	},
 /area/shuttle/ftl/medical/sleeper)
 "qZl" = (
 /obj/structure/disposaloutlet{
@@ -9685,18 +9665,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
-"rdx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "rdF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9705,15 +9673,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"rfu" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "rik" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9790,27 +9749,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"rml" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "rnF" = (
 /obj/structure/table/wood,
 /obj/item/device/paicard,
@@ -9831,6 +9769,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
+"rqc" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 7
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "rqh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9871,11 +9822,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai_upload)
-"rvu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "rvv" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -9944,6 +9890,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"rBh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "rBl" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -10137,14 +10092,6 @@
 "rPy" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
-"rQC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/bridge)
 "rSC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -10205,6 +10152,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/mining)
+"rXw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/fore)
 "rXD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -10243,16 +10204,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"sbQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_x = -26
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "scI" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/lab)
@@ -10310,21 +10261,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/eva)
-"sfA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Restrooms";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/ftl/crew_quarters/toilet)
 "sfX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
@@ -10528,22 +10464,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"ssQ" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/lights/mixed{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/box/mousetraps{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "stV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10556,11 +10476,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"sug" = (
-/obj/structure/janitorialcart,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "sux" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -10626,23 +10541,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
-"swy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
-"swD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "sxj" = (
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
@@ -10671,6 +10569,17 @@
 	dir = 5
 	},
 /area/shuttle/ftl/medical/medbay)
+"sBE" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "sBX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -10686,22 +10595,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
-"sCC" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	sortType = 10
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "sCI" = (
 /obj/effect/landmark/start{
 	name = "Chief Engineer"
@@ -10810,14 +10703,26 @@
 	dir = 6
 	},
 /area/shuttle/ftl/engine/engineering)
-"sPR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"sOV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/fore)
 "sPZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10837,22 +10742,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"sSb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "sTk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -11113,27 +11002,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"tbp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
-"tbG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "tbS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -11224,6 +11092,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
+"thE" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (SOUTHEAST)";
+	icon_state = "darkblue";
+	dir = 6
+	},
+/area/shuttle/ftl/hallway/primary/central)
 "til" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11367,28 +11248,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"tAo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "tBy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11436,6 +11295,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/central)
+"tHh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "tIY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
@@ -11558,24 +11423,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"tNJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
-"tNP" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	sortType = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "tOf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11634,6 +11481,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"tVN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "tWI" = (
 /obj/structure/table/wood/bar,
 /obj/item/stack/tile/carpet{
@@ -11642,14 +11499,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
-"tXr" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "tZf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11660,6 +11509,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/genetics)
+"tZS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTHEAST)";
+	icon_state = "darkblue";
+	dir = 5
+	},
+/area/shuttle/ftl/hallway/primary/port)
 "ubv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11728,6 +11588,19 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"ult" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "ulz" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -11746,6 +11619,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"umO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "unO" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/decal/cleanable/dirt,
@@ -11810,6 +11702,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/medical/cmo)
+"utn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (SOUTHEAST)";
+	icon_state = "darkblue";
+	dir = 6
+	},
+/area/shuttle/ftl/hallway/primary/port)
 "uvK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -11879,6 +11781,15 @@
 	dir = 5
 	},
 /area/shuttle/ftl/security/nuke_storage)
+"uCs" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "uCW" = (
 /obj/structure/cryofeed/right,
 /obj/effect/decal/cleanable/dirt,
@@ -11939,19 +11850,30 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"uSW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"uTD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 2";
+	dir = 6
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
+"uUA" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 10
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
 "uVz" = (
 /obj/structure/cable{
@@ -12007,17 +11929,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"vae" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "vdu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12065,6 +11976,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
+"vfN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "vhk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12106,26 +12021,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"vml" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark{
-	name = "Observer-Start"
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "vmD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12179,21 +12074,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"vuf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "vuu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12245,14 +12125,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"vvm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "vwA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12276,16 +12148,18 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"vAL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"vzC" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
+/area/shuttle/ftl/hallway/primary/port)
 "vBE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12319,25 +12193,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"vCU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
-"vGQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "vHI" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -12368,16 +12223,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"vMb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "vMu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12479,16 +12324,15 @@
 	},
 /turf/open/floor/engine/o2,
 /area/shuttle/ftl/atmos)
-"vUx" = (
-/obj/item/weapon/mop,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct/small{
-	dir = 8
+"vUO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "vVh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12498,18 +12342,16 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"vWh" = (
+"wbm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway 4";
-	dir = 10
+	c_tag = "Central Primary Hallway 1"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
 "weo" = (
@@ -12570,17 +12412,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"wfF" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "wgZ" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c (EAST)";
@@ -12629,10 +12460,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"wjv" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/medical/sleeper)
 "wlS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12660,13 +12487,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_3)
-"wpV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "wqu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12769,14 +12589,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"wyj" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "wyl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -12807,6 +12619,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"wzK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "wAk" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
@@ -12861,18 +12679,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/cargo/mining)
-"wIo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "wIr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -12924,20 +12730,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"wNr" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/effect/decal/cleanable/greenglow,
-/mob/living/simple_animal/cockroach,
-/mob/living/simple_animal/cockroach,
-/mob/living/simple_animal/cockroach,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "wOv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/requests_console{
@@ -12990,13 +12782,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"wSV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "wTC" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -13004,19 +12789,15 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"wUK" = (
+"wVj" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "wWi" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/gravity_generator)
@@ -13053,24 +12834,23 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"wYt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+"wZo" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j2s";
+	sortType = 21
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
-"wYM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway 3";
-	dir = 6
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
+/turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/starboard)
 "xaa" = (
 /obj/effect/landmark/start{
@@ -13089,12 +12869,41 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
+"xbg" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 4";
+	dir = 10
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "xcF" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/storage)
+"xdm" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 23
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "xfb" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 1
@@ -13108,6 +12917,27 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
+"xfK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "xhe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13117,34 +12947,36 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
-"xih" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"xhp" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
+"xiD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"xjS" = (
+"xjp" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
+"xnf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "xpS" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
@@ -13183,6 +13015,14 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/computer)
+"xrG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "xrT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -13245,41 +13085,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/chemistry)
-"xvG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
-"xwH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/ftl/security/nuke_storage)
 "xxg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13335,22 +13140,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"xFU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/fore)
 "xGP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -13496,6 +13285,18 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
+"xTE" = (
+/obj/structure/disposalpipe/junction,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "xUq" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 4
@@ -13506,6 +13307,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"xVR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "xWI" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses,
@@ -13524,6 +13331,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"yaF" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel/darkgreen,
+/area/shuttle/ftl/janitor)
 "yaW" = (
 /obj/machinery/vending/cart,
 /obj/structure/disposalpipe/segment{
@@ -13680,6 +13497,35 @@
 	},
 /turf/open/floor/plasteel/whiteblue,
 /area/shuttle/ftl/medical/medbay_lobby)
+"ync" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Bar Entry";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/partyalarm{
+	desc = "Cuban Pete is in the house! (Mapper note: If you are prone to seizures and you press this, you might be in for a gnarly ride.)";
+	dir = 8;
+	name = "\improper PARTY BUTTON";
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"ynl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/medical/sleeper)
 "ynt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13769,6 +13615,19 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"ywf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "ywu" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -13789,16 +13648,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"yxK" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "yys" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch{
@@ -13881,16 +13730,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"yDB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "yED" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
@@ -13902,11 +13741,6 @@
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"yFO" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "yHC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
@@ -13932,15 +13766,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"yKi" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "yMw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13989,29 +13814,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"ySk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar Entry";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/partyalarm{
-	desc = "Cuban Pete is in the house! (Mapper note: If you are prone to seizures and you press this, you might be in for a gnarly ride.)";
-	dir = 8;
-	name = "\improper PARTY BUTTON";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "yTo" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/door/firedoor,
@@ -14057,6 +13859,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/cmo)
+"yZb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "yZu" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14125,14 +13936,15 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"zdM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"zed" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "zeA" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -14166,9 +13978,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"zgp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/fore)
 "zgu" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/computer)
+"zhL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "ziM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -14202,14 +14046,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"zng" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "zno" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -14217,19 +14053,6 @@
 /obj/effect/landmark/ship_fire,
 /turf/open/space,
 /area/shuttle/ftl/space)
-"znY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "zov" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -14255,21 +14078,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"zrk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "zro" = (
 /obj/item/device/radio/off{
 	pixel_x = -4;
@@ -14307,20 +14115,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"zua" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+"zuo" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
+/area/shuttle/ftl/hallway/primary/fore)
 "zvH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
@@ -14371,6 +14176,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
+"zCI" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/fore)
+"zCM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "zEv" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -14394,6 +14214,15 @@
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"zFF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "zGp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -14431,34 +14260,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/office)
-"zNY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "zOB" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"zRv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "zSK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14565,14 +14369,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"AaA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "AaM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14608,6 +14404,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"AbR" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "Aej" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -14673,6 +14477,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
+"Ajd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Ajp" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start{
@@ -14684,16 +14492,15 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"Akr" = (
-/obj/structure/sign/directions/engineering{
-	dir = 8
+"AjO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/sign/directions/security{
-	dir = 8;
-	pixel_y = -8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/security/armory)
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "AlM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -14923,6 +14730,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
+"AzT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "ABk" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -14980,6 +14798,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
+"AEU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "AFi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15009,35 +14835,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/nuke_storage)
-"AFM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
-"AIo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "AJi" = (
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -15071,6 +14868,25 @@
 "AKO" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
+"ALk" = (
+/obj/structure/chair/stool,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"ALx" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "AMs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15103,18 +14919,6 @@
 "AQD" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/medbay)
-"ARf" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "ARI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -15184,6 +14988,22 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"AWs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "AWO" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /obj/structure/window/reinforced{
@@ -15191,18 +15011,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_3)
-"AWQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "AYf" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom,
@@ -15222,24 +15030,6 @@
 "AZq" = (
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/telecomms/computer)
-"Bah" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "BbH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15300,6 +15090,10 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"Bfs" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Bjp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -15320,17 +15114,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"Bjq" = (
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/maintenance/bridge)
-"BmL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"Bms" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Bnd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/loadingarea{
@@ -15373,6 +15169,14 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/computer)
+"Bqq" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 13
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "BqZ" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/heads)
@@ -15421,23 +15225,20 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"BuZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "Bxj" = (
 /obj/machinery/computer/card/minor/ce,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
+"Bzq" = (
+/obj/vehicle/janicart,
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 1
+	},
+/area/shuttle/ftl/janitor)
 "BzH" = (
 /obj/machinery/door/window/southleft{
 	name = "Medbay";
@@ -15445,18 +15246,16 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"BzU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 5";
-	dir = 5
+"BBI" = (
+/obj/structure/sign/directions/engineering{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_x = -26
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_y = -8
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/armory)
 "BCf" = (
 /obj/machinery/pdapainter,
 /obj/effect/decal/cleanable/dirt,
@@ -15501,16 +15300,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"BHm" = (
-/obj/structure/table,
-/obj/item/weapon/grenade/chem_grenade/cleaner,
-/obj/item/weapon/grenade/chem_grenade/cleaner,
-/obj/item/weapon/grenade/chem_grenade/cleaner,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/item/key/janitor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "BIE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
@@ -15540,6 +15329,25 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"BLU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "BOm" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/weapon/storage/toolbox/mechanical{
@@ -15634,6 +15442,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
+"BTi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "BUJ" = (
 /obj/machinery/conveyor_switch{
 	id = "CargoMunitions"
@@ -15681,6 +15502,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
+"BWF" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
+"BXe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/paper{
+	icon_state = "paper_words";
+	info = "<font face=\"Verdana\" color=black><font size=\"4\"><center>NANOTRASEN DOSSIER FILE</center></font><BR><center>CLASSIFIED</center><BR> SPITZER, RANDALL PHILIP JONAS<BR> ORDERS FOR THE RANKING OFFICER (RO) OF THE NCV BASILISK<BR> <HR> PER THE ORDERS OF RO EATS-THE-GLUE:<BR> <B>REQUIREMENTS:</B> <ul><li>RANDALL IS TO WORK ABOARD THE SHIP UNTIL THE RANKING OFFICER ON DUTY STATES TO CENTRAL COMMAND THAT HE HAS REPAID HIS DEBT TO THE SHIP IN LABOR. DERELICTION OF DUTY IS TO BE PUNISHED BY INCARCERATION OR EXECUTION, PREFERABLY THE FORMER. <li>Randall is not permitted to carry weapons, be it lethal, less-than-lethal, or electrostun. <li>Randall is not permitted to communicate outside the ship, except when aboard Central Command. <li>Randall is not permitted to leave the ship, except as escorted by a Central Command officer, the RO, or a person designated by the RO. <li>Randall is not permitted to possess a PDA. <li>Randall is to have a mindshield implant. <li>Randall is to be searched upon boarding. <li>Randall is to take his prescription medication every four hours.</ul> <B>OPTIONAL REQUIREMENTS:</B><BR> <ul><li>Regular searches/shakedowns are at the discretion of the RO. <li>Randall may be legcuffed, at the discretion of the RO. <li>Randall is to be assigned to Janitor, or another insensitive assignment at the RO&#39;s discretion. Randall IS NOT to have access to sensitive areas, such as Engineering. <li>At the RO&#39;s discretion, Randall may have a tracking or chemical implant. Chemical implants are to have 15u Beepsky Smash and 25u Chloral Hydrate. <li>Randall may wear the jumpsuit of his current assignment at the RO&#39;s discretion, as long as it is not degrading.</ul> Central Command will notify you when they&#39;re about to send Randall to the Basilisk. If the RO wishes for Randall to have any of the optional requirements or an assignment other than custodial work, please contact Central Command within a reasonable timeframe for these requests to be fulfilled.<BR><BR> As we are at war with the Syndicate, and Randall was captured while acting on their behalf, Randall is technically an <I>hors de combat</I> by detention, and is thus protected by the Geneva and Altessa Conventions from: <ul> <li>Violence to life and person, in particular murder of all kinds, mutilation, cruel treatment and torture; <li>Taking of hostages; <li>Outrages upon dignity, in particular humiliating and degrading treatment; and <li>Failure to deliver adequate medical aid as necessary.</ul> <BR> <font face=\"Times New Roman\"><b><i>RDunn</i></b></font></font>";
+	name = "paper - Jonas Spitzer dossier: Orders for the Ranking Officer"
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/bridge)
 "BXi" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -15769,6 +15619,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"Cgu" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "CiM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15778,15 +15633,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
-"CjW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "Cks" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -15799,19 +15645,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"CnE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "Cou" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/decal/cleanable/dirt,
@@ -15865,29 +15698,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"Cvm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
-"CwD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "Cxc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -15911,6 +15721,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
+"Cyk" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "CzC" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16133,17 +15954,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"COt" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/ftl/crew_quarters/toilet)
 "COZ" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1;
@@ -16179,6 +15989,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"CSD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "CTH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -16210,6 +16026,15 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"CVS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "CYp" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
@@ -16332,6 +16157,19 @@
 "Dft" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/turret_protected/ai_upload)
+"DfO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "Dgd" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/black,
@@ -16348,6 +16186,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
+"Dhd" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Djt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16394,25 +16239,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"Dni" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "DnX" = (
 /obj/machinery/vending/security,
 /obj/effect/decal/cleanable/dirt,
@@ -16426,6 +16252,18 @@
 	dir = 9
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"DqI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Dro" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -16514,6 +16352,18 @@
 "DtP" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/chemistry)
+"DwZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/meter{
+	name = "distribution pressure meter";
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "DxI" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green,
@@ -16533,14 +16383,12 @@
 "DyA" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/research/xenobiology)
-"DzJ" = (
-/obj/machinery/light{
-	dir = 4
+"Dzl" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/area/shuttle/ftl/janitor)
 "DAF" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
@@ -16617,24 +16465,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/meeting_room)
-"DER" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
-"DFa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "DGy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
@@ -16643,16 +16473,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
-"DIR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "DJp" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -16688,19 +16508,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"DJS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "DKV" = (
 /obj/structure/table/wood,
 /obj/structure/cable{
@@ -16812,17 +16619,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/telecomms/server)
-"Ebh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "Ebw" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
@@ -16946,20 +16742,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"EeH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "Efl" = (
 /obj/structure/disposalpipe/sortjunction{
 	sortType = 6
@@ -17116,13 +16898,20 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"Erm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+"EpI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Restrooms";
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "EsB" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
@@ -17292,26 +17081,16 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"EAf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
+"ECw" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
-"ECr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
 "EFx" = (
 /obj/structure/table,
@@ -17387,6 +17166,31 @@
 "ELr" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/engine/chiefs_office)
+"EML" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTHEAST)";
+	icon_state = "darkblue";
+	dir = 5
+	},
+/area/shuttle/ftl/hallway/primary/central)
+"EMZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "ENs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	tag = "icon-intact (NORTH)";
@@ -17469,18 +17273,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
-"EQL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/meter{
-	name = "distribution pressure meter";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "EQS" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -17526,17 +17318,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"ESX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "ETo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel{
@@ -17608,6 +17389,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"EZI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Fag" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
+"Fas" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "Fat" = (
 /obj/effect/landmark/start{
 	name = "Bartender";
@@ -17725,6 +17528,23 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"FjZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
+"Fkm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "Fkx" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17739,6 +17559,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
+"FkO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Flq" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -17947,6 +17775,16 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
+"FDR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "FEK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -17956,20 +17794,23 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"FHq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"FHi" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/lights/mixed{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/item/weapon/storage/box/mousetraps{
+	pixel_x = -2;
+	pixel_y = -1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 1
+	},
+/area/shuttle/ftl/janitor)
 "FHv" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/locker)
@@ -18166,16 +18007,6 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
-"Ghk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "Ghn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18212,20 +18043,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
-"GlP" = (
-/obj/machinery/door/window/southleft{
-	name = "Longsleep Cryopods"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/medical/sleeper)
-"GmN" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "GnT" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/camera{
@@ -18313,17 +18130,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/virology)
-"Gtm" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	sortType = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "GtG" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -18406,26 +18212,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/lab)
-"GxS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "GzL" = (
 /obj/structure/chair{
 	dir = 1
@@ -18455,6 +18241,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
+"GCo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "GCA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -18526,14 +18320,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/research/division)
-"GHM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood,
-/area/shuttle/ftl/bridge)
 "GIN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -18571,11 +18357,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"GRx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "GRA" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -18639,6 +18420,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"GUm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "GUI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18679,17 +18473,6 @@
 	},
 /turf/open/floor/plasteel/whiteblue,
 /area/shuttle/ftl/medical/medbay)
-"GWq" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "GWB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch{
@@ -18746,14 +18529,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"HaA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/fore)
 "HaX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18826,19 +18601,16 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"HhG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Hgn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
+/obj/machinery/firealarm{
+	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "HjJ" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/decal/cleanable/dirt,
@@ -18852,13 +18624,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Hkk" = (
-/obj/machinery/cryopod/right,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/warnwhite{
-	dir = 4
-	},
-/area/shuttle/ftl/medical/sleeper)
 "HlR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -19010,17 +18775,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"HGC" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "HHd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -19043,6 +18797,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"HHX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "HJO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19066,6 +18826,12 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/central)
+"HQe" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "HSV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -19190,14 +18956,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"Ihn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "IiO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
@@ -19209,22 +18967,16 @@
 "IiQ" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/turret_protected/ai)
-"Ijm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"Ikh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 1";
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "IkR" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/bridge/meeting_room)
@@ -19246,19 +18998,6 @@
 	dir = 9
 	},
 /area/shuttle/ftl/medical/chemistry)
-"Imu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/fore)
 "ImK" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
@@ -19270,30 +19009,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"ImS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway 1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
-"InD" = (
-/obj/structure/filingcabinet/security,
-/obj/item/weapon/folder/documents,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/nuke_storage)
 "Ipy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19310,6 +19025,17 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
+"IpG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 5";
+	dir = 5
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "Iqb" = (
 /obj/machinery/telecomms/processor/preset_one/birdstation,
 /obj/effect/decal/cleanable/dirt,
@@ -19328,28 +19054,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"Isa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Itk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "Itx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
@@ -19382,6 +19086,17 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
+"Iwy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway 3";
+	dir = 6
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Ixb" = (
 /obj/structure/chair{
 	dir = 1
@@ -19405,6 +19120,13 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/research/server)
+"IxR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "ICv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -19519,6 +19241,12 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"ILJ" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "INw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/window/reinforced{
@@ -19860,6 +19588,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
+"Jse" = (
+/obj/structure/closet/l3closet/janitor,
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 10
+	},
+/area/shuttle/ftl/janitor)
 "JtB" = (
 /obj/machinery/computer/atmos_alert,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19895,14 +19629,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"JuQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "Jvv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -19911,6 +19637,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/fore)
+"JvP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Jwf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -20003,6 +19744,17 @@
 /obj/machinery/ftl_drive,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
+"JBS" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "JCe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20029,20 +19781,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
-"JFa" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/landmark/start{
-	name = "Assistant";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "JFf" = (
 /obj/machinery/computer/ftl_weapons{
 	req_access_txt = "45"
@@ -20050,6 +19788,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"JFC" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "JFU" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plating,
@@ -20079,11 +19820,16 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"JJy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
+"JJt" = (
+/obj/structure/sign/directions/evac{
+	dir = 1
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/armory)
 "JJP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20103,19 +19849,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"JKJ" = (
+"JKm" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "JKW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -20133,6 +19878,16 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"JLI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (SOUTHEAST)";
+	icon_state = "darkblue";
+	dir = 6
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
 "JMZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20148,21 +19903,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos/equipment)
-"JOU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (SOUTHWEST)";
-	icon_state = "darkblue";
-	dir = 10
-	},
-/area/shuttle/ftl/hallway/primary/central)
 "JPU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/emcloset,
@@ -20199,6 +19939,14 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"JVV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "JWt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20211,6 +19959,16 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
+"JWZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "JXK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -20354,14 +20112,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Kmr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+"Kmp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/security/nuke_storage)
 "KnJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20389,19 +20159,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"Kpz" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	sortType = 11
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "Kqy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20413,13 +20170,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"KqV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "KtD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20477,6 +20227,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/research/server)
+"KyS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "KzI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20544,20 +20303,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"KEc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "KEQ" = (
 /obj/structure/table,
 /obj/item/weapon/wrench,
@@ -20570,6 +20315,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"KEU" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms";
+	req_access_txt = "0"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "KFi" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/central)
@@ -20666,33 +20425,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/research/lab)
-"KPf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/fore)
-"KQV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "KRb" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -20717,17 +20449,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
-"KTk" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "KTG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20802,6 +20523,25 @@
 "KWF" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/office)
+"KXd" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "KXj" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/belt/champion,
@@ -20838,6 +20578,12 @@
 	dir = 9
 	},
 /area/shuttle/ftl/cargo/mining)
+"Lao" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Lav" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
@@ -20851,6 +20597,12 @@
 "LdK" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/nuke_storage)
+"Lej" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Lek" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -20917,6 +20669,18 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"LiA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "LiV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -20992,6 +20756,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"LqI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "LrQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21085,15 +20857,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
-"LBd" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "LCu" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start{
@@ -21144,17 +20907,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"LGG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (SOUTHEAST)";
-	icon_state = "darkblue";
-	dir = 6
-	},
-/area/shuttle/ftl/hallway/primary/port)
 "LGN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21193,16 +20945,12 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"LIz" = (
+"LIo" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
 "LKb" = (
 /obj/structure/cable{
@@ -21213,6 +20961,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"LMt" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"LMY" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "LNy" = (
 /obj/machinery/door/poddoor/multi_tile/four_tile_hor{
 	id = "miningpodbay";
@@ -21310,30 +21083,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/genetics)
-"LVO" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
-"LWa" = (
-/obj/structure/sign/directions/evac{
-	dir = 1
-	},
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = -8
-	},
-/turf/closed/wall/rust,
-/area/shuttle/ftl/hallway/primary/fore)
 "LWn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21388,43 +21137,10 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"LZN" = (
-/obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "MaG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/engine/engine_smes)
-"MbK" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "Mdx" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
@@ -21471,6 +21187,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
+"Mkr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "MkP" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -21512,6 +21237,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"MrO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "Mtl" = (
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater";
@@ -21563,27 +21309,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"Myp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/fore)
-"MyP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/central)
 "MAk" = (
 /obj/structure/chair{
 	dir = 1
@@ -21669,10 +21394,6 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/locker)
-"MPe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "MPt" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -21687,22 +21408,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/bridge/eva)
-"MRf" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	sortType = 14
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "MRI" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -21785,19 +21490,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/hos)
-"Ncc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "Ncx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -21834,6 +21526,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/assembly/robotics)
+"Ndz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "NeI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21873,6 +21577,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
+"Nis" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "Njg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -21880,27 +21592,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
+"Nji" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "Njr" = (
 /obj/structure/tank_dispenser,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
-"NjM" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "Nke" = (
 /obj/machinery/computer/rdservercontrol,
 /obj/structure/cable{
@@ -22019,19 +21721,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
-"NtA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "Nut" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -22057,6 +21746,14 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"NxN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "Nyn" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/bar)
@@ -22073,15 +21770,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
-"Nzv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "Nzx" = (
 /obj/structure/rack{
 	dir = 8;
@@ -22181,6 +21869,15 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"NKD" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/darkgreen/side,
+/area/shuttle/ftl/janitor)
 "NLL" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/emergency,
@@ -22255,19 +21952,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"NPh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "NPO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22287,26 +21971,28 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/detectives_office)
-"NQb" = (
-/obj/structure/disposalpipe/junction,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "NQy" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall3";
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_3)
+"NQE" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"NSf" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkgreen,
+/area/shuttle/ftl/janitor)
 "NSu" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/disposal)
@@ -22408,17 +22094,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
-"ObV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "Oct" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -22571,27 +22246,25 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/server)
+"Opy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "OqN" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"OsE" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "OsF" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/decal/cleanable/dirt,
@@ -22609,48 +22282,11 @@
 "OtG" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/port)
-"Ozg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "OzD" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/hydroponics)
-"OBz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
-"OEf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "OFv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 2
@@ -22759,18 +22395,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
-"ONW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "OPh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -22779,14 +22403,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
-"OPy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "OPU" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engine_smes)
@@ -22884,6 +22500,27 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/cmo)
+"OXw" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/fore)
+"OXD" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j2s";
+	sortType = 19
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTHWEST)";
+	icon_state = "darkblue";
+	dir = 9
+	},
+/area/shuttle/ftl/hallway/primary/central)
 "OYB" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/toxin{
@@ -22908,20 +22545,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"OZN" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "OZP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -22944,13 +22567,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"PaH" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/medical/sleeper)
 "PbP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23014,6 +22630,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/office)
+"Pgk" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "Pjt" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -23064,18 +22697,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"Pmj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "Pmv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23085,19 +22706,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"Pnw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "PoT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -23162,15 +22770,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"PwC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "PwK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -23231,6 +22830,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"PAz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (SOUTHWEST)";
+	icon_state = "darkblue";
+	dir = 10
+	},
+/area/shuttle/ftl/hallway/primary/central)
 "PAR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -23416,6 +23029,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos)
+"PQf" = (
+/obj/machinery/cryopod/right,
+/turf/open/floor/plasteel/warnwhite{
+	dir = 4
+	},
+/area/shuttle/ftl/medical/sleeper)
 "PQu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -23450,6 +23069,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/engine/chiefs_office)
+"PUK" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "PVQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23665,6 +23291,14 @@
 "QqQ" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/munitions)
+"Qre" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "Qrx" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/fire{
@@ -23686,18 +23320,6 @@
 "QtE" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"Qvj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (NORTHEAST)";
-	icon_state = "darkblue";
-	dir = 5
-	},
-/area/shuttle/ftl/hallway/primary/port)
 "Qwl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23739,6 +23361,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"Qyg" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 1";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"QAE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/landmark/start{
+	name = "Assistant";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
 "QCq" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -23749,6 +23395,13 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/meeting_room)
+"QDf" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "QDQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23830,20 +23483,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge/meeting_room)
-"QKb" = (
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c";
-	icon_state = "pipe-c";
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (SOUTHEAST)";
-	icon_state = "darkblue";
-	dir = 6
-	},
-/area/shuttle/ftl/hallway/primary/central)
 "QMh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -23896,6 +23535,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/vacantoffice)
+"QSH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway 4";
+	dir = 10
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "QSW" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23921,24 +23573,22 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/server)
-"QWv" = (
-/obj/structure/disposalpipe/junction,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "QXe" = (
 /turf/open/floor/plasteel/warnwhite{
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
+"QXK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "QZt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -23967,19 +23617,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"RcQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "Rdk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -24032,6 +23669,33 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/lab)
+"RiU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Rjj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "RkK" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/decal/cleanable/dirt,
@@ -24041,6 +23705,34 @@
 	dir = 10
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"RlV" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
+"Rnz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
+"RnR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Rom" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24090,23 +23782,6 @@
 	dir = 5
 	},
 /area/shuttle/ftl/medical/chemistry)
-"RvN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "RvQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24123,6 +23798,15 @@
 "Rwn" = (
 /turf/closed/wall,
 /area/shuttle/ftl/assembly/robotics)
+"Rxh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "RyM" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -24149,36 +23833,9 @@
 "RAv" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/telecomms/server)
-"RAD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
 "RCW" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/crew_quarters/hor)
-"RCX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "RDQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24248,6 +23905,19 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
+"ROL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/fore)
 "RQe" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24274,29 +23944,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/telecomms/computer)
-"RUi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "RWG" = (
 /turf/closed/wall/rust,
 /area/shuttle/ftl/crew_quarters/locker)
-"RZG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "SaE" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/decal/cleanable/dirt,
@@ -24341,59 +23991,40 @@
 	dir = 9
 	},
 /area/shuttle/ftl/atmos)
-"SeQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
-"Sgu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
+"Sdr" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
-	},
-/area/shuttle/ftl/medical/medbay_lobby)
-"Sgv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway 2";
-	dir = 1
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"Sdu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
+"SdX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Skr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
+/area/shuttle/ftl/hallway/primary/fore)
 "SlH" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/fore)
@@ -24403,16 +24034,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engine_smes)
-"Smf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "SmP" = (
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/ftl/telecomms/computer)
@@ -24575,6 +24196,16 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/heads)
+"SsI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "SuE" = (
 /obj/machinery/conveyor{
 	id = "QMLoad";
@@ -24601,21 +24232,23 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Swy" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
+"Syt" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/fore)
 "SAI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24642,9 +24275,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
-"SBQ" = (
-/turf/closed/wall/rust,
-/area/shuttle/ftl/hallway/primary/fore)
 "SCc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -24660,9 +24290,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"SDE" = (
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/security/armory)
 "SEB" = (
 /obj/structure/sign/securearea{
 	name = "SERVER ROOM";
@@ -24695,6 +24322,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
+"SGH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/fore)
 "SIk" = (
 /obj/structure/table,
 /obj/item/weapon/surgical_drapes,
@@ -24762,6 +24399,26 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
+"SLq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "SMk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24879,22 +24536,23 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/shuttle/ftl/security/nuke_storage)
+"SWn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/fore)
 "SWo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/medbay)
-"SWD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "SXf" = (
 /obj/structure/rack,
 /obj/item/weapon/aiModule/core/full/asimov{
@@ -24917,6 +24575,22 @@
 	},
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/turret_protected/ai)
+"SXS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "SYw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -25030,15 +24704,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
-"Tde" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "TdB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -25052,21 +24717,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"TdR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue/side{
-	tag = "icon-darkblue (NORTHEAST)";
-	icon_state = "darkblue";
-	dir = 5
-	},
-/area/shuttle/ftl/hallway/primary/central)
 "TeG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -25075,6 +24725,16 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
+"Tfp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "TgB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
@@ -25096,6 +24756,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"TgU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "ThA" = (
 /obj/machinery/computer/pmanagement,
 /obj/effect/decal/cleanable/dirt,
@@ -25118,6 +24790,29 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"TkG" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/medical/sleeper)
 "ToY" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
 /obj/structure/window/reinforced{
@@ -25128,15 +24823,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_3)
-"Tpk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "Tpn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -25159,22 +24845,25 @@
 "Tpw" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/secure_construction)
-"Tqn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "TqG" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/eva)
+"TrK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "Tvp" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -25229,16 +24918,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
-"TxO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/port)
 "TAk" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -25252,20 +24931,16 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"TCJ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 4";
-	dir = 10
+"TBM" = (
+/obj/structure/toilet,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
+/turf/open/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/ftl/crew_quarters/toilet)
 "TCO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25291,9 +24966,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"TEw" = (
-/turf/closed/wall/r_wall/rust,
-/area/shuttle/ftl/hallway/primary/fore)
 "TEy" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -25302,20 +24974,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/nuke_storage)
-"TFC" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	sortType = 7
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "TIq" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer"
@@ -25463,20 +25121,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"TSG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/fore)
 "TUB" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -25629,6 +25273,14 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/circuit/rcircuit/animated,
 /area/shuttle/ftl/turret_protected/ai)
+"Udk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/fore)
 "UdH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25687,14 +25339,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Uhz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
 "UhL" = (
 /obj/machinery/door/poddoor{
 	id = "EvaGarage";
@@ -25734,6 +25378,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"UkI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 4";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "UmG" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor";
@@ -25751,6 +25403,21 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
+"Unr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "UnH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25781,6 +25448,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
+"UoT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "Upc" = (
 /obj/structure/table/glass,
 /obj/item/weapon/stock_parts/manipulator,
@@ -25880,6 +25559,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/fore)
+"UwI" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "Uxs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch{
@@ -25894,28 +25577,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Uxt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
-"UyQ" = (
-/obj/effect/landmark/start{
-	name = "Janitor";
-	shuttle_abstract_movable = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "Uzr" = (
 /obj/machinery/computer/card,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25966,16 +25627,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
-"UCV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "UDb" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -26012,13 +25663,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/hor)
-"UEI" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
+"UGW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/shuttle/ftl/crew_quarters/toilet)
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "UIC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26082,6 +25735,30 @@
 	},
 /turf/open/floor/engine/n2,
 /area/shuttle/ftl/atmos)
+"ULh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
+"ULO" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 14
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "UMf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -26150,6 +25827,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/nuke_storage)
+"USD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "UUA" = (
 /obj/machinery/disposal/bin{
 	name = "corpse disposal unit"
@@ -26171,6 +25862,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
+"UVo" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "UVI" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/toilet)
@@ -26188,6 +25886,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"UXH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "UZr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26235,21 +25943,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/heads)
-"Vea" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "VeA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -26387,6 +26080,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"Vja" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Vjp" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1;
@@ -26451,6 +26153,20 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/hos)
+"VmW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/fore)
 "Vnr" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -26523,17 +26239,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/research/server)
-"Vzi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 2;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "VAd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26547,16 +26252,6 @@
 /obj/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/ftl/subshuttle/pod_3)
-"VCV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "VEC" = (
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTH)";
@@ -26564,16 +26259,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/cargo/mining)
-"VFP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/central)
 "VGo" = (
 /obj/item/weapon/storage/book/bible,
 /obj/structure/table,
@@ -26690,14 +26375,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/munitions)
-"VUc" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
 "VUj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
@@ -26725,17 +26402,6 @@
 	},
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/cargo/office)
-"VUW" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "VVD" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -26775,6 +26441,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
+"VXO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "VYg" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -26879,6 +26555,17 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/bridge)
+"Wgl" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/central)
 "Whx" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -26909,21 +26596,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/office)
-"Wnf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/fore)
 "WnF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26962,6 +26634,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
+"Wou" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "WpR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/atmos_alert,
@@ -27021,20 +26704,16 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"WxS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "WyM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/fore)
+"Wzx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "WzA" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/captain,
@@ -27092,6 +26771,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/assembly/robotics)
+"WEj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "WFe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -27118,29 +26805,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"WGD" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	sortType = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
-"WGP" = (
+"WGl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
 "WHl" = (
@@ -27285,23 +26958,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/fore)
-"WUn" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	sortType = 23
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "WUB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
@@ -27363,6 +27019,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/locker)
+"WZG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "XaA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -27387,19 +27049,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/shuttle/ftl/crew_quarters/bar)
-"XdH" = (
+"XeS" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkgreen/side,
+/area/shuttle/ftl/janitor)
 "XfL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -27515,6 +27173,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"XlJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge)
 "Xnm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -27595,6 +27261,22 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/munitions)
+"Xyq" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
+"XzT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "XAS" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
@@ -27632,6 +27314,19 @@
 "XDw" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos/equipment)
+"XEx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/starboard)
 "XFA" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -27805,17 +27500,6 @@
 "XSX" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/break_room)
-"XTS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/device/radio/intercom{
-	pixel_x = -26
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/central)
 "XVI" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge/meeting_room)
@@ -27829,18 +27513,23 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"XXe" = (
+"XXM" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel{
-	icon_state = "white"
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTHEAST)";
+	icon_state = "darkblue";
+	dir = 5
 	},
-/area/shuttle/ftl/medical/medbay_lobby)
+/area/shuttle/ftl/hallway/primary/central)
 "XYF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -27855,6 +27544,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"XZN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "Ybu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -27889,6 +27589,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
+"Ydd" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	sortType = 11
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Yef" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -27910,17 +27622,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"Yhk" = (
+"YhJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/port)
 "Yje" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27967,6 +27680,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"Ylk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "YlR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -28002,14 +27726,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Ypz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "YqI" = (
 /obj/machinery/smartfridge/chemistry/virology,
 /obj/effect/decal/cleanable/dirt,
@@ -28052,6 +27768,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/shuttle/ftl/medical/cmo)
+"YrB" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 1
+	},
+/area/shuttle/ftl/janitor)
 "YrI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -28179,25 +27911,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"YAK" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	icon_state = "pipe-j2s";
-	sortType = 21
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/hallway/primary/starboard)
 "YAV" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -28213,18 +27926,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"YDd" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/latejoin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "YFd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28244,14 +27945,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/atmos/equipment)
-"YHL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/starboard)
 "YHX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28290,6 +27983,13 @@
 	},
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/cargo/office)
+"YJn" = (
+/obj/machinery/door/window/southleft{
+	name = "Longsleep Cryopods"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/medical/sleeper)
 "YJV" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
@@ -28348,6 +28048,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
+"YNQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "YOd" = (
 /obj/machinery/camera{
 	busy = 0;
@@ -28366,16 +28070,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/loading)
-"YSr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "YTQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/firecloset,
@@ -28484,6 +28178,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
+"ZgA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/viewscreen{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge)
 "Zhq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -28536,21 +28241,21 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Zny" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+"ZnW" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	icon_state = "freezerfloor"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/area/shuttle/ftl/crew_quarters/toilet)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "ZoE" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -28677,6 +28382,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/research/server)
+"ZEq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "ZEU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -28702,6 +28414,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"ZHw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "ZHO" = (
 /obj/effect/landmark/start{
 	name = "Scientist"
@@ -28729,6 +28448,25 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
+"ZJX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (WEST)";
+	icon_state = "whiteblue";
+	dir = 8
+	},
+/area/shuttle/ftl/medical/medbay_lobby)
 "ZNn" = (
 /obj/machinery/door/airlock/glass_large{
 	name = "Medical Bay Airlock"
@@ -28789,26 +28527,31 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"ZOW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+"ZPp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
-"ZPF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"ZQD" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/hallway/primary/starboard)
 "ZQL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28832,6 +28575,10 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"ZRG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
 "ZTY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /obj/effect/decal/cleanable/dirt,
@@ -36195,7 +35942,7 @@ VCL
 NQy
 ToY
 OtG
-sbQ
+hgG
 yMw
 Ebw
 OPU
@@ -36482,7 +36229,7 @@ FDJ
 OPU
 PeA
 ADa
-RAD
+Hgn
 hZG
 sme
 sme
@@ -36709,8 +36456,8 @@ CUe
 CUe
 ewr
 xCx
-aVw
-yMw
+NQE
+JVV
 GzL
 qgP
 IaL
@@ -36739,7 +36486,7 @@ wTC
 OPU
 PeA
 ADa
-vAL
+qTP
 hZG
 sme
 sme
@@ -36967,7 +36714,7 @@ Ixb
 ToY
 bvC
 LQq
-Ghk
+JVV
 GzL
 qgP
 IaL
@@ -37223,9 +36970,9 @@ CUe
 MAk
 AWO
 OtG
-sSb
-wUK
-YDd
+LMt
+XZN
+GzL
 qgP
 IaL
 Jqu
@@ -37480,8 +37227,8 @@ CUe
 Ixb
 pSv
 bvC
-bce
-Ghk
+gsL
+JVV
 GzL
 qgP
 iyj
@@ -37509,7 +37256,7 @@ UCn
 oKO
 OPU
 PeA
-eXq
+ADa
 VvS
 dRD
 sme
@@ -37737,9 +37484,9 @@ CUe
 CUe
 CGq
 xCx
-LQq
-yMw
-plh
+Fas
+JVV
+Ikh
 OPU
 SBn
 ybQ
@@ -37765,9 +37512,9 @@ UfQ
 UfQ
 rPy
 rPy
-kzy
-lda
-zdM
+Qyg
+ZEq
+VvS
 dRD
 sme
 sme
@@ -37994,9 +37741,9 @@ CUe
 xaH
 ToY
 ZCP
-LQq
-swy
-ZPF
+Fas
+mUn
+wzK
 OPU
 QdY
 Hfq
@@ -38023,7 +37770,7 @@ OLO
 dcI
 ptk
 NTj
-eXq
+ADa
 VvS
 awP
 sme
@@ -38251,9 +37998,9 @@ VCL
 NQy
 pSv
 bvC
-qTu
-swy
-ZPF
+XzT
+mUn
+wzK
 OPU
 FvQ
 ITG
@@ -38508,9 +38255,9 @@ Ppy
 Ppy
 Ppy
 Ppy
-hTJ
-SWD
-xih
+fuN
+vUO
+cTA
 OPU
 gRr
 GWT
@@ -38536,9 +38283,9 @@ LAW
 bJs
 mqu
 rPy
-YHL
-rvu
-gqx
+opR
+xjp
+FkO
 dRD
 sme
 sme
@@ -38765,9 +38512,9 @@ VNi
 Jyv
 iYD
 IJs
-qTu
-yDB
-GmN
+XzT
+Fag
+Cgu
 OPU
 dpm
 rLn
@@ -39022,9 +38769,9 @@ TLZ
 saR
 iYD
 IJs
-qTu
-swy
-ZPF
+XzT
+mUn
+wzK
 OPU
 qgP
 qgP
@@ -39279,9 +39026,9 @@ VNi
 saR
 iYD
 IJs
-qTu
-swy
-ZPF
+XzT
+mUn
+wzK
 ptB
 YJV
 XSX
@@ -39307,9 +39054,9 @@ TxJ
 bJs
 vUe
 rPy
-lxd
+gwm
 sWN
-Vzi
+AzT
 hZG
 sme
 sme
@@ -39536,9 +39283,9 @@ EVL
 qxu
 LQL
 IJs
-qTu
-swy
-mMU
+XzT
+mUn
+kUt
 ptB
 pwP
 PAj
@@ -39793,9 +39540,9 @@ ohe
 nPP
 arR
 IJs
-qTu
-swy
-ZPF
+XzT
+mUn
+wzK
 ptB
 ZtZ
 XSX
@@ -40050,9 +39797,9 @@ IJs
 IJs
 IJs
 IJs
-BuZ
-swy
-ZPF
+Ylk
+mUn
+wzK
 iXC
 sLN
 XSX
@@ -40307,9 +40054,9 @@ GnT
 TqG
 TqG
 IJs
-qTu
-swy
-ZPF
+XzT
+mUn
+wzK
 iXC
 sLN
 cAO
@@ -40564,9 +40311,9 @@ nRv
 Hdk
 nRv
 swf
-TxO
-bYo
-ZPF
+eWf
+gHz
+wzK
 iXC
 sLN
 cAO
@@ -40821,9 +40568,9 @@ DGy
 egJ
 Iws
 ygW
-eRb
-nYR
-Tqn
+zCM
+kws
+lnS
 iXC
 sLN
 cAO
@@ -41078,9 +40825,9 @@ Enk
 aZA
 TqG
 IJs
-lkQ
-swy
-vMb
+uTD
+mUn
+dfq
 iXC
 sLN
 cAO
@@ -41106,7 +40853,7 @@ dbZ
 fFd
 vke
 ajU
-EQL
+DwZ
 iFp
 oCV
 dRD
@@ -41335,9 +41082,9 @@ IJs
 IJs
 IJs
 IJs
-hTJ
-SWD
-cEN
+fuN
+vUO
+UXH
 iXC
 Oct
 cAO
@@ -41363,9 +41110,9 @@ rPy
 rPy
 rPy
 OIP
-YHL
-rvu
-gqx
+opR
+xjp
+FkO
 dRD
 sme
 sme
@@ -41592,9 +41339,9 @@ gop
 qSU
 WaJ
 sdQ
-CnE
-zRv
-swD
+Ndz
+ZPp
+mMi
 qTY
 sLN
 wWi
@@ -41620,7 +41367,7 @@ hub
 Tap
 UNZ
 WFe
-DIR
+RnR
 Iao
 mnz
 dRD
@@ -41849,9 +41596,9 @@ rUX
 mNZ
 mNZ
 mNZ
-qTu
-swy
-fQW
+XzT
+mUn
+eQu
 iXC
 sLN
 wWi
@@ -41877,8 +41624,8 @@ bpC
 xPF
 Tbk
 sZx
-RhC
-fmE
+SdX
+LqI
 mnz
 hZG
 sme
@@ -42106,9 +41853,9 @@ ERX
 TLm
 fMT
 mNZ
-qTu
-swy
-vMb
+XzT
+mUn
+dfq
 iXC
 sLN
 wWi
@@ -42134,9 +41881,9 @@ Mvd
 Mvd
 Mvd
 Mvd
-ObV
-XdH
-Ypz
+Vja
+Rnz
+xVR
 hZG
 sme
 sme
@@ -42363,9 +42110,9 @@ sjs
 IeX
 cFp
 mNZ
-DER
-swy
-vMb
+Mkr
+mUn
+dfq
 iXC
 sLN
 wWi
@@ -42391,9 +42138,9 @@ POG
 mol
 olz
 wXQ
-RhC
-HGC
-mnz
+SdX
+lSV
+xVR
 dRD
 sme
 sme
@@ -42620,9 +42367,9 @@ cLH
 ViP
 fpJ
 mNZ
-qTu
-swy
-vMb
+XzT
+mUn
+dfq
 iXC
 sPZ
 wWi
@@ -42648,9 +42395,9 @@ Txe
 nuf
 mgh
 QRI
-zua
-EeH
-mnz
+XEx
+Bms
+xVR
 dRD
 sme
 sme
@@ -42877,9 +42624,9 @@ OlA
 aCw
 fRO
 mNZ
-qTu
-zNY
-vMb
+XzT
+mUn
+dfq
 iXC
 sLN
 wWi
@@ -42905,9 +42652,9 @@ kpy
 SRx
 kXa
 wXQ
-KQV
-bYM
-mnz
+ULh
+LqI
+xVR
 dRD
 sme
 sme
@@ -43134,9 +42881,9 @@ VPL
 ABr
 BOm
 mNZ
-Uhz
-HhG
-Ozg
+fDN
+ECw
+TgU
 iXC
 sLN
 wWi
@@ -43162,9 +42909,9 @@ jPC
 lVd
 rwN
 wXQ
-KQV
-bYM
-UKk
+ULh
+LqI
+Dhd
 hZG
 sme
 sme
@@ -43391,9 +43138,9 @@ WYO
 DrI
 HdR
 mNZ
-qTu
-zNY
-vMb
+XzT
+mUn
+dfq
 iXC
 wqu
 vBE
@@ -43419,9 +43166,9 @@ bBM
 ZZr
 LSy
 EvK
-vae
-RUi
-oCV
+FDR
+blJ
+kKz
 hZG
 sme
 sme
@@ -43648,9 +43395,9 @@ bjB
 RqT
 BoZ
 mNZ
-qTu
-Bah
-QWv
+XzT
+obp
+xTE
 Uxs
 hAx
 kaR
@@ -43676,9 +43423,9 @@ rGl
 lVd
 DgH
 wXQ
-KQV
-bYM
-mnz
+ULh
+LqI
+xVR
 dRD
 sme
 sme
@@ -43905,9 +43652,9 @@ bCs
 Wcv
 mvF
 mNZ
-tXr
-AWQ
-ZPF
+PUK
+EMZ
+wzK
 iXC
 kRA
 YJV
@@ -43933,9 +43680,9 @@ HEH
 HEH
 HEH
 HEH
-kGI
-WxS
-gqx
+Tfp
+zFF
+IxR
 dRD
 sme
 sme
@@ -44162,9 +43909,9 @@ kRB
 jnk
 SqN
 mNZ
-hTJ
-iGG
-xih
+fuN
+YhJ
+cTA
 iXC
 YJV
 YJV
@@ -44186,13 +43933,13 @@ mTG
 sMm
 Tvp
 HEH
-LVO
-vUx
-yFO
+pbn
+jae
+Jse
 HEH
-bUL
-EeH
-mnz
+umO
+Bms
+xVR
 dRD
 sme
 sme
@@ -44419,9 +44166,9 @@ CGn
 ZFw
 lIj
 mNZ
-qTu
-AWQ
-ZPF
+XzT
+EMZ
+wzK
 iXC
 YJV
 YJV
@@ -44443,13 +44190,13 @@ CKy
 CKy
 rEB
 GWB
-oLo
-wNr
-VUW
+YrB
+yaF
+NKD
 nag
-wYM
-tbp
-oCV
+Iwy
+CVS
+kKz
 hZG
 sme
 sme
@@ -44676,9 +44423,9 @@ jVe
 IQd
 IgV
 mNZ
-bYv
-qLN
-mMU
+qQi
+qkh
+kUt
 iXC
 YJV
 Dgo
@@ -44700,13 +44447,13 @@ TUB
 CKy
 KcB
 HEH
-kZU
-yxK
-fCT
+Bzq
+NSf
+bqW
 HEH
-KQV
-bYM
-mnz
+ULh
+LqI
+xVR
 hZG
 sme
 sme
@@ -44933,9 +44680,9 @@ bCs
 Ybu
 mvF
 mNZ
-qTu
-AWQ
-wyj
+XzT
+EMZ
+QDf
 iXC
 YJV
 Dgo
@@ -44957,13 +44704,13 @@ YMH
 CKy
 vva
 HEH
-qQj
-zng
-chn
+hWy
+mtK
+jpi
 HEH
-Vea
-bYM
-mnz
+jbH
+LqI
+xVR
 dRD
 sme
 sme
@@ -45190,9 +44937,9 @@ wMS
 agv
 HFJ
 ffs
-BuZ
-AWQ
-iXX
+Ylk
+EMZ
+fal
 iXC
 zqf
 xaf
@@ -45214,13 +44961,13 @@ YMH
 CKy
 pMf
 HEH
-ssQ
-UyQ
-cti
+FHi
+gFH
+XeS
 VZB
-mXF
-oZK
-oCV
+khb
+USD
+kKz
 dRD
 sme
 sme
@@ -45447,9 +45194,9 @@ tdv
 uyi
 yza
 ffs
-DER
-AWQ
-ZPF
+Mkr
+EMZ
+wzK
 iXC
 YJV
 xaf
@@ -45460,7 +45207,7 @@ fBN
 miO
 hPG
 Idq
-VUc
+akE
 gZm
 CKy
 kIB
@@ -45471,13 +45218,13 @@ YMH
 CKy
 KcB
 HEH
-BHm
-UCV
-sug
+ioe
+kwu
+Dzl
 HEH
-KQV
-bYM
-mnz
+ULh
+LqI
+xVR
 dRD
 sme
 sme
@@ -45704,13 +45451,13 @@ zXi
 uyi
 gJT
 ffs
-qTu
-AWQ
-ZPF
+XzT
+EMZ
+wzK
 iXC
 YJV
 xaf
-krd
+ALk
 bzq
 rDN
 YbN
@@ -45732,9 +45479,9 @@ HEH
 HEH
 HEH
 HEH
-Isa
-bYM
-mnz
+kEP
+LqI
+xVR
 hZG
 sme
 sme
@@ -45961,13 +45708,13 @@ zXi
 uyi
 lTb
 ffs
-qTu
-AWQ
-ZPF
+XzT
+EMZ
+wzK
 iXC
 dWP
 xaf
-JFa
+QAE
 rDN
 RMh
 uZS
@@ -45989,9 +45736,9 @@ xTr
 sMm
 sMm
 Uxs
-NQb
-Dni
-oCV
+gsd
+RiU
+kKz
 hZG
 sme
 sme
@@ -46218,21 +45965,21 @@ nxy
 YXz
 Wio
 ffs
-qTu
-AWQ
-nzi
+XzT
+EMZ
+uCs
 iXC
 YJV
 xaf
 TXm
-JJy
+bzq
 skn
 bgt
 Xdc
 KuJ
 XON
-MPe
-MPe
+bzq
+bzq
 CKy
 Spu
 vlR
@@ -46246,9 +45993,9 @@ pxO
 pxO
 pxO
 pxO
-YHL
-Pnw
-gqx
+cDO
+dyl
+IxR
 dRD
 sme
 sme
@@ -46475,9 +46222,9 @@ fWe
 YIW
 lvt
 Gvl
-vvm
-dmu
-vGQ
+ZHw
+BTi
+ZRG
 iXC
 YJV
 xaf
@@ -46503,9 +46250,9 @@ uCW
 uCW
 uCW
 yyY
-RhC
-glA
-mnz
+SdX
+ZQD
+xVR
 dRD
 sme
 sme
@@ -46732,18 +46479,18 @@ FWc
 jPj
 EQH
 zGp
-ECr
-swy
-ZPF
+bGY
+mUn
+wzK
 iXC
 YJV
 iXC
 sme
 sme
 nQi
-jyE
-ySk
-lgR
+xnf
+ync
+lXF
 nQi
 sme
 sme
@@ -46754,15 +46501,15 @@ cHM
 dSs
 WbT
 CKy
-qWM
-Hkk
-Hkk
-Hkk
-Hkk
-qcY
-RhC
-glA
-mnz
+kQo
+PQf
+PQf
+PQf
+PQf
+mNA
+SdX
+ZQD
+xVR
 dRD
 sme
 sme
@@ -46989,9 +46736,9 @@ ESR
 VUt
 ntC
 zLg
-qTu
-swy
-ZPF
+XzT
+mUn
+wzK
 iXC
 YJV
 iXC
@@ -46999,7 +46746,7 @@ sme
 sme
 vHI
 bgt
-Itk
+NxN
 vVh
 nQi
 sme
@@ -47015,11 +46762,11 @@ zbO
 UBq
 UBq
 UBq
-wjv
-GlP
-kJQ
-glA
-UKk
+UBq
+YJn
+Bfs
+ZQD
+Dhd
 hZG
 sme
 sme
@@ -47246,9 +46993,9 @@ zLg
 NYq
 zLg
 zLg
-hTJ
-SWD
-xih
+fuN
+vUO
+cTA
 ZbN
 qTY
 iXC
@@ -47268,15 +47015,15 @@ oEE
 gjb
 cYM
 CKy
-gaq
-PaH
+TkG
+ieE
 yoa
-PaH
-PaH
-dNB
-RhC
-glA
-TCJ
+ieE
+ieE
+ynl
+SdX
+ZQD
+xbg
 hZG
 sme
 sme
@@ -47495,45 +47242,45 @@ sme
 tlT
 cfg
 Jmt
-cfg
-Pmj
-cfg
-hcv
-cfg
-Uxt
-cfg
-jIJ
-LGG
-nLv
-Qvj
-pJo
-pJo
-BzU
-pJo
-pJo
-Kmr
-QKb
-rfu
-pll
-DFa
-adJ
-adJ
-adJ
-adJ
-Ihn
-OZN
-eii
-lRJ
-OPy
-nwO
-lRJ
-pHH
-lRJ
-lRJ
-lRJ
-mUS
-glA
-mnz
+JFC
+psb
+JFC
+tHh
+JFC
+CSD
+JFC
+UwI
+utn
+kDX
+tZS
+xiD
+xiD
+IpG
+xiD
+xiD
+Sdu
+thE
+AEU
+XXM
+LIo
+nhN
+nhN
+nhN
+nhN
+UVo
+GUm
+cbk
+Ajd
+EZI
+JvP
+Ajd
+dOY
+Ajd
+Ajd
+Ajd
+JLI
+ZQD
+xVR
 dRD
 sme
 sme
@@ -47752,45 +47499,45 @@ sme
 ETz
 YOd
 QcZ
-cfg
-ZOW
-mOD
-NtA
-VCV
-lnn
-VCV
-Ebh
+JFC
+gQX
+gnX
+Sdr
+UGW
+vzC
+UGW
+iat
+qxQ
+hXA
+UoT
+qxQ
+qxQ
+qxQ
 tCy
-OsE
-RcQ
-tCy
-tCy
-tCy
-tbG
-tCy
-bKm
-Ijm
-vml
-iPT
-rdx
-icv
-icv
-icv
-icv
-Kpz
-YAK
-EAf
-Cvm
-icv
-rml
-LIz
-feh
-LIz
-icv
-icv
-icv
-JKJ
-mnz
+qxQ
+Wou
+Unr
+bLl
+nza
+JBS
+LMY
+LMY
+LMY
+LMY
+Ydd
+wZo
+oRD
+DqI
+LMY
+oNV
+LMY
+xhp
+LMY
+LMY
+LMY
+LMY
+nib
+xVR
 dRD
 sme
 sme
@@ -48009,45 +47756,45 @@ sme
 snV
 cfg
 Jmt
-ndv
-doQ
-ijO
-aGg
-cAN
-BmL
-yKi
-fNS
-bLx
-bLx
-wSV
-bLx
-Nzv
-DzJ
-qEq
-bLx
-Erm
-JOU
-xvG
-qRs
-KqV
-GRx
-AaA
-GRx
-GRx
-Tpk
-CjW
-AFM
-bWI
-pVR
-wpV
-GRx
-tNJ
-GRx
-GRx
-AaA
-GRx
-fNG
-wYt
+ogg
+Nji
+TrK
+HQe
+UkI
+iAX
+Qre
+juo
+YNQ
+YNQ
+WZG
+YNQ
+WEj
+cRV
+xrG
+YNQ
+bqd
+PAz
+hpe
+OXD
+Lej
+vfN
+foo
+vfN
+vfN
+jZn
+byb
+kKQ
+nDg
+fDl
+HHX
+vfN
+vfN
+vfN
+vfN
+foo
+vfN
+Lao
+Wzx
 dRD
 sme
 sme
@@ -48283,9 +48030,9 @@ cAn
 OtG
 OtG
 vuE
-ESX
-Smf
-ejz
+JWZ
+rBh
+bLt
 ZmN
 hZG
 hZG
@@ -48540,9 +48287,9 @@ cAn
 sme
 sme
 biz
-YSr
-gbt
-JuQ
+ctr
+Rjj
+mBR
 biz
 sme
 sme
@@ -48797,9 +48544,9 @@ cAn
 sme
 sme
 biz
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 mGq
 sme
 sme
@@ -49054,9 +48801,9 @@ AUs
 sme
 sme
 biz
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 mGq
 sme
 sme
@@ -49311,9 +49058,9 @@ Gxn
 sme
 sme
 biz
-ImS
-hea
-PAZ
+wbm
+GCo
+AjO
 biz
 sme
 sme
@@ -49568,9 +49315,9 @@ AUs
 sme
 sme
 mGq
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 biz
 sme
 sme
@@ -49825,17 +49572,17 @@ Gxn
 sme
 sme
 mGq
-YSr
-VFP
-PAZ
+ctr
+hea
+AjO
 biz
 sme
 sme
 Juf
 HsM
-SeQ
-jpC
-Sgu
+AWs
+ZJX
+MrO
 wim
 VeA
 heg
@@ -50082,16 +49829,16 @@ iUc
 sme
 sme
 mGq
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 biz
 sme
 sme
 Kar
 eOQ
 hBM
-XXe
+Cyk
 jXL
 VaB
 SMk
@@ -50339,9 +50086,9 @@ Zhq
 sme
 sme
 mGq
-YSr
-hea
-dCD
+ctr
+GCo
+nca
 iMG
 WNK
 WNK
@@ -50596,9 +50343,9 @@ UCp
 sme
 sme
 mGq
-OBz
-CwD
-tNP
+yZb
+KyS
+sBE
 ZNn
 GYW
 oOj
@@ -50853,9 +50600,9 @@ FdQ
 sme
 sme
 biz
-YSr
-vuf
-sCC
+ctr
+cya
+uUA
 AJC
 QZt
 AJC
@@ -51110,9 +50857,9 @@ iUc
 cdr
 cdr
 KFi
-wIo
-qKp
-mrO
+VXO
+LiA
+bLt
 iMG
 WNK
 WNK
@@ -51367,9 +51114,9 @@ duP
 zdL
 GHp
 KuI
-ikg
-RZG
-PAZ
+Bqq
+GCo
+AjO
 biz
 sme
 sme
@@ -51624,9 +51371,9 @@ miW
 pCH
 Ypi
 LKb
-zrk
-vCU
-PAZ
+kmH
+ywf
+AjO
 mGq
 sme
 sme
@@ -51881,9 +51628,9 @@ JPU
 YTQ
 UnH
 Ytm
-GWq
-pFy
-JuQ
+qOL
+wVj
+mBR
 mGq
 sme
 sme
@@ -52138,9 +51885,9 @@ cdr
 cdr
 cdr
 KFi
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 mGq
 sme
 sme
@@ -52395,9 +52142,9 @@ vPo
 sme
 sme
 biz
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 mGq
 sme
 sme
@@ -52652,9 +52399,9 @@ WCw
 sme
 sme
 mGq
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 biz
 sme
 sme
@@ -52909,9 +52656,9 @@ WCw
 sme
 sme
 mGq
-YSr
-hea
-Sgv
+ctr
+GCo
+dVq
 biz
 sme
 sme
@@ -53166,9 +52913,9 @@ cdr
 sme
 sme
 KFi
-Ncc
-hea
-omu
+ohu
+GCo
+PAZ
 EWl
 EWl
 EWl
@@ -53423,9 +53170,9 @@ cdr
 scI
 scI
 KFi
-ESX
-DJS
-Tde
+JWZ
+mUA
+dQD
 EWl
 qsP
 qsP
@@ -53680,9 +53427,9 @@ KwO
 Ywt
 fVE
 OmO
-NjM
-tAo
-WUn
+ZnW
+xfK
+xdm
 nKZ
 gLk
 gLk
@@ -53937,9 +53684,9 @@ ZWw
 TCV
 NJs
 NJs
-YSr
-gbt
-LBd
+ctr
+Rjj
+RlV
 NSu
 NSu
 NSu
@@ -54193,10 +53940,10 @@ gQb
 Ppk
 DxI
 xWI
-ZWw
-YSr
-hea
-Gtm
+NJs
+ctr
+GCo
+Xyq
 WNj
 tlQ
 MhA
@@ -54450,10 +54197,10 @@ VgH
 FMv
 omC
 iek
-ZWw
-YSr
-hea
-WGP
+NJs
+ctr
+GCo
+JKm
 NSu
 JeA
 OYG
@@ -54707,10 +54454,10 @@ DaK
 hrJ
 FPY
 iaz
-ZWw
-xjS
-vCU
-KTk
+NJs
+BLU
+ywf
+ALx
 NSu
 NSu
 veR
@@ -54965,9 +54712,9 @@ NJs
 NJs
 NJs
 NJs
-OBz
-CwD
-btK
+yZb
+KyS
+Fkm
 rXD
 NLL
 Zlp
@@ -55222,9 +54969,9 @@ cxL
 bgx
 cOS
 ITj
-sPR
-KEc
-Swy
+FjZ
+cya
+bFr
 IvT
 hDm
 inJ
@@ -55479,9 +55226,9 @@ vpn
 PoT
 cyU
 lSC
-Yhk
-pFy
-JuQ
+qEG
+wVj
+mBR
 PMr
 Oab
 vpM
@@ -55736,9 +55483,9 @@ NMe
 NMe
 NMe
 NMe
-eub
-OEf
-ejz
+VXO
+cgj
+bLt
 zgu
 SmP
 SmP
@@ -55993,9 +55740,9 @@ cxL
 LfY
 ryK
 ITj
-sPR
-RCX
-MbK
+FjZ
+SXS
+cCP
 mmp
 FBV
 xrE
@@ -56250,9 +55997,9 @@ vpn
 PoT
 cyU
 lSC
-Yhk
-pFy
-JuQ
+qEG
+wVj
+mBR
 SEB
 YyZ
 AZq
@@ -56507,9 +56254,9 @@ NMe
 NMe
 NMe
 NMe
-RvN
-hea
-PAZ
+zhL
+GCo
+AjO
 RSY
 bND
 AZq
@@ -56764,9 +56511,9 @@ idn
 INY
 heb
 lis
-TFC
-vCU
-kZB
+rqc
+ywf
+zed
 CzC
 auZ
 rHx
@@ -57021,9 +56768,9 @@ BbH
 FOW
 FOW
 eHX
-WGD
-pFy
-JuQ
+kWP
+wVj
+mBR
 RSY
 inK
 IJa
@@ -57278,9 +57025,9 @@ WOT
 cpq
 sTk
 WOT
-aDL
-hea
-PAZ
+pmS
+GCo
+AjO
 zgu
 zgu
 zgu
@@ -57535,9 +57282,9 @@ GTc
 EcH
 ClC
 tJs
-YSr
-AIo
-MRf
+ctr
+oLC
+ULO
 yys
 nqT
 nqT
@@ -57792,9 +57539,9 @@ WOT
 LYM
 QQb
 EWq
-mVn
-fNg
-kiX
+SsI
+fDW
+tVN
 Rwn
 Rwn
 Rwn
@@ -58049,9 +57796,9 @@ WOT
 IiO
 Glt
 WOT
-eIo
-RZG
-PAZ
+kjX
+lby
+AjO
 NcR
 HnJ
 GJB
@@ -58306,9 +58053,9 @@ MEp
 Yzz
 glX
 Wfb
-znY
-hea
-PAZ
+brH
+GCo
+AjO
 NcR
 HnJ
 tCV
@@ -58563,9 +58310,9 @@ SAI
 CPa
 ldn
 Wfb
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 ExJ
 dYh
 Yxv
@@ -58820,9 +58567,9 @@ mJg
 vRt
 DYz
 Wfb
-ESX
-Smf
-ejz
+JWZ
+rBh
+bLt
 Rwn
 GpB
 OHL
@@ -59077,9 +58824,9 @@ hRD
 Wwx
 jel
 hRD
-YSr
-hea
-PAZ
+ctr
+GCo
+AjO
 mVd
 TaE
 Tbl
@@ -59333,10 +59080,10 @@ QFu
 aak
 gcK
 ghp
-SDE
-YSr
-hea
-PAZ
+hRD
+ctr
+GCo
+AjO
 Rwn
 fYf
 dpa
@@ -59590,10 +59337,10 @@ VnH
 gJi
 gcK
 Eop
-SDE
-YSr
-gbt
-JuQ
+hRD
+ctr
+Rjj
+mBR
 Rwn
 xxg
 YwR
@@ -59847,10 +59594,10 @@ EmB
 YLo
 rqh
 NLX
-cfG
-YSr
-hea
-vWh
+JJt
+ctr
+GCo
+QSH
 Rwn
 WCX
 GCA
@@ -60104,10 +59851,10 @@ yOM
 rKZ
 gcK
 XHi
-Akr
-OBz
-CwD
-TdR
+BBI
+yZb
+KyS
+EML
 XaA
 ZQL
 fAp
@@ -60116,7 +59863,7 @@ cLC
 vyJ
 IZP
 iSS
-XTS
+eLX
 dtC
 IkS
 zbA
@@ -60362,9 +60109,9 @@ kiH
 QDQ
 ilr
 hRD
-Ncc
-uSW
-dmt
+ohu
+qcz
+cml
 BeI
 UqY
 ipc
@@ -60619,9 +60366,9 @@ Onb
 urD
 DsK
 hRD
-YSr
-ARf
-fnq
+ctr
+Wgl
+onu
 lCJ
 CYK
 SZZ
@@ -60632,7 +60379,7 @@ ptj
 idd
 ujm
 HvU
-MyP
+omj
 YLu
 biz
 sme
@@ -60876,12 +60623,12 @@ hRD
 hRD
 hRD
 hRD
-hre
+bcG
 MkP
-ONW
+WGl
 UVI
 UVI
-Zny
+KEU
 jPM
 jPM
 zko
@@ -61137,8 +60884,8 @@ DdT
 Ghn
 rik
 UVI
-jEB
-sfA
+KXd
+EpI
 bSM
 cqi
 Eex
@@ -61394,8 +61141,8 @@ hOS
 VkF
 rik
 UVI
-pLQ
-UEI
+lye
+owo
 bSM
 dyh
 dLj
@@ -61652,7 +61399,7 @@ Ghn
 HaX
 UVI
 UVI
-fje
+AbR
 bSM
 lXj
 Aoz
@@ -61908,8 +61655,8 @@ DdT
 OQG
 Jwv
 Hvt
-COt
-kWO
+TBM
+ILJ
 bSM
 jaU
 svo
@@ -62419,7 +62166,7 @@ PDj
 PDj
 SlH
 NzP
-Myp
+SGH
 aaD
 SlH
 sme
@@ -62675,9 +62422,9 @@ EQS
 ONo
 QmH
 HzW
-dLM
+Opy
 Ghn
-FHq
+VmW
 uko
 sme
 sme
@@ -62931,9 +62678,9 @@ BeW
 Taa
 jzE
 rTI
-SBQ
-GxS
-TSG
+HzW
+SLq
+rXw
 rik
 mrr
 sme
@@ -63188,7 +62935,7 @@ KBE
 taK
 peQ
 nlV
-SBQ
+HzW
 hOS
 VkF
 rik
@@ -63445,8 +63192,8 @@ hDM
 ggV
 jzE
 igr
-SBQ
-Wnf
+HzW
+aCd
 Ghn
 rik
 mrr
@@ -63702,8 +63449,8 @@ alv
 WZz
 Lav
 Vjp
-SBQ
-haL
+HzW
+DfO
 Ghn
 rik
 mrr
@@ -63711,7 +63458,7 @@ sme
 sme
 Ods
 LdK
-InD
+mso
 leX
 awC
 LdK
@@ -63959,7 +63706,7 @@ alv
 oyE
 Lav
 COZ
-SBQ
+HzW
 sZa
 Ghn
 rik
@@ -64220,13 +63967,13 @@ HzW
 qMx
 Ghn
 rik
-TEw
+SlH
 sme
 sme
 sme
 Fgg
 VhW
-xwH
+Kmp
 dck
 SRI
 sme
@@ -64473,17 +64220,17 @@ jfz
 few
 pqw
 RWG
-LWa
-aqk
-nUa
-PwC
-hDn
-TEw
+pSl
+QXK
+SWn
+Rxh
+kmJ
+SlH
 uko
 uko
 uko
 PYK
-pyf
+icL
 ldb
 uko
 uko
@@ -64725,27 +64472,27 @@ CCT
 GEk
 JxK
 NyF
-qxW
+sOV
 mqY
-cKm
+BWF
 nuu
 nuu
-NPh
+ult
 Nqn
 UwF
 qbb
-caU
-kkX
+Skr
+qGk
 otX
 otX
 otX
 yoh
-wfF
+zuo
 Hyv
 WSX
 MSb
 MSb
-oEi
+zCI
 uko
 sme
 sme
@@ -64988,7 +64735,7 @@ WyM
 XoY
 WyM
 SlH
-xFU
+zgp
 Ghn
 tOf
 SlH
@@ -64996,9 +64743,9 @@ WyM
 WyM
 WyM
 WyM
-HaA
-Imu
-jMd
+OXw
+ROL
+Udk
 ykQ
 MSb
 MSb
@@ -65244,20 +64991,20 @@ seL
 rdo
 Jvv
 rdo
-pjY
+Nis
 aqu
 qnP
 tKt
-LZN
+cTs
 cok
 cok
 sgq
 cok
 mnO
-qlS
+Pgk
 DJv
 GUI
-KPf
+Syt
 dzx
 MSb
 mrr
@@ -65774,7 +65521,7 @@ bsR
 BqZ
 ORo
 Nzx
-Bjq
+dPR
 sme
 sme
 sme
@@ -66031,7 +65778,7 @@ vdT
 BqZ
 YNs
 Nzx
-Bjq
+dPR
 sme
 sme
 sme
@@ -66288,7 +66035,7 @@ yaW
 BqZ
 NcE
 cmc
-Bjq
+dPR
 sme
 sme
 sme
@@ -66545,7 +66292,7 @@ BPs
 BqZ
 XiI
 WQA
-Bjq
+dPR
 sme
 sme
 sme
@@ -66802,7 +66549,7 @@ jxC
 jxC
 Rdk
 sjb
-Bjq
+dPR
 sme
 sme
 sme
@@ -67059,7 +66806,7 @@ csS
 jxC
 uAB
 iIV
-Bjq
+dPR
 sme
 sme
 sme
@@ -67316,7 +67063,7 @@ jTU
 jxC
 cyk
 tjq
-Bjq
+dPR
 sme
 sme
 sme
@@ -69871,7 +69618,7 @@ pXe
 sjL
 evU
 JjP
-GHM
+BXe
 Lwj
 wOv
 evU
@@ -70380,7 +70127,7 @@ sme
 sme
 sme
 sme
-qVj
+LtU
 wfo
 evU
 evU
@@ -70637,8 +70384,8 @@ sme
 sme
 sme
 sme
-qVj
-qVj
+LtU
+LtU
 skt
 PED
 AoY
@@ -70895,13 +70642,13 @@ sme
 sme
 sme
 sme
-qVj
-qVj
+LtU
+LtU
 qRi
 YlR
-rQC
-aaL
-fqM
+XlJ
+frr
+ZgA
 NNI
 Wqi
 LtU


### PR DESCRIPTION
:cl: EvilJackCarver
add: The NCV Basilisk now has a cleaner again - areas Jonas has repeatedly cleaned now have a lot less round-start detritis.
add: Added Jonas' entire dossier to the vault filing cabinet. All 14 pages. Ree.
add: Added floor tiles to custodial.
add: Re-added lightbulbs in the halls where the bulb assembly was partially deconned.
add: Added a sink to the custodial closet.
fix: Jonas has been fixing parts of the ship up.
/:cl:

The IC justification is that Jonas is permitted to do maintenance while the Basilsik is at drydock (albeit heavily watched), so areas he can access are getting cared for as part of his effort to repay his debt to the ship.
