### PR TITLE
Gun revamp

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -42,7 +42,8 @@
 							"Medical",
 							"Misc",
 							"Dinnerware",
-							"Imported"
+							"Imported",
+							"Ammunition"
 							)
 
 /obj/machinery/autolathe/New()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -665,9 +665,9 @@
 	always_up = 1
 	use_power = 0
 	has_cover = 0
-	scan_range = 9
-	projectile = /obj/item/projectile/bullet/nerfed
-	eprojectile = /obj/item/projectile/bullet/nerfed
+	scan_range = 7
+	projectile = /obj/item/projectile/bullet/calibre/cal762x51
+	eprojectile = /obj/item/projectile/bullet/calibre/cal762x51
 	shot_sound = 'sound/weapons/Gunshot.ogg'
 	eshot_sound = 'sound/weapons/Gunshot.ogg'
 	base_icon_state = "syndie"
@@ -683,8 +683,8 @@
 
 /obj/machinery/porta_turret/syndicate/pod
 	health = 40
-	projectile = /obj/item/projectile/bullet/weakbullet3
-	eprojectile = /obj/item/projectile/bullet/weakbullet3
+	projectile = /obj/item/projectile/bullet/calibre/cal45acp
+	eprojectile = /obj/item/projectile/bullet/calibre/cal45acp
 
 /obj/machinery/porta_turret/ai
 	faction = "silicon"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -233,7 +233,7 @@
 	icon_state = "mecha_carbine"
 	origin_tech = "materials=4;combat=4"
 	equip_cooldown = 5
-	projectile = /obj/item/projectile/bullet/incendiary/shell/dragonsbreath
+	projectile = /obj/item/projectile/bullet/shotshell/incendiary/dragon
 	projectiles = 24
 	projectile_energy_cost = 7
 
@@ -253,7 +253,7 @@
 	icon_state = "mecha_scatter"
 	origin_tech = "combat=4"
 	equip_cooldown = 20
-	projectile = /obj/item/projectile/bullet/midbullet
+	projectile = /obj/item/projectile/bullet/calibre/cal57x28
 	projectiles = 40
 	projectile_energy_cost = 12
 	projectiles_per_shot = 4
@@ -265,7 +265,7 @@
 	icon_state = "mecha_uac2"
 	origin_tech = "combat=4"
 	equip_cooldown = 10
-	projectile = /obj/item/projectile/bullet/weakbullet3
+	projectile = /obj/item/projectile/bullet/calibre/cal45acp
 	projectiles = 300
 	projectile_energy_cost = 10
 	projectiles_per_shot = 3

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -100,7 +100,7 @@
 	minimum_distance = 5
 	icon_state = "syndicateranged"
 	icon_living = "syndicateranged"
-	casingtype = /obj/item/ammo_casing/c45nostamina
+	casingtype = /obj/item/ammo_casing/c45
 	projectilesound = 'sound/weapons/Gunshot_smg.ogg'
 	loot = list(/obj/effect/gibspawner/human)
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -12,6 +12,7 @@
 	var/projectile_type = null					//The bullet type to create when New() is called
 	var/obj/item/projectile/BB = null 			//The loaded bullet
 	var/pellets = 1								//Pellets for spreadshot
+	var/ismagnum = 0					//Is it a magnum/+P/+P+ round?
 	var/variance = 0							//Variance for inaccuracy fundamental to the casing
 	var/randomspread = 0						//Randomspread for automatics
 	var/delay = 0								//Delay for energy weapons

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -375,21 +375,21 @@
 	projectile_type = /obj/item/projectile/bullet/shotshell/slug/ap
 
 /obj/item/ammo_casing/shotgun/buckshot
-	name = "\improper 00 buckshot shell"
+	name = "00 buckshot shell"
 	desc = "A 12 gauge, 00 buckshot shell."
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/shotshell/doubleaught
 	pellets = 6
 	variance = 25
 
-/obj/item/ammo_casing/shotgun/buckshot/000
+/obj/item/ammo_casing/shotgun/buckshot/tripleaught
 	name = "\improper 000 buckshot shell"
 	desc = "A 12 gauge, 000 buckshot shell."
 	projectile_type = /obj/item/projectile/bullet/shotshell/tripleaught
 	pellets = 4
 	variance = 20
 
-/obj/item/ammo_casing/shotgun/buckshot/0000
+/obj/item/ammo_casing/shotgun/buckshot/quadrupleaught
 	name = "\improper 0000 buckshot shell"
 	desc = "A 12 gauge, 0000 buckshot shell."
 	icon_state = "gshell"
@@ -406,14 +406,14 @@
 	variance = 25
 	materials = list(MAT_METAL=4000)
 	
-/obj/item/ammo_casing/shotgun/rubbershot/000
+/obj/item/ammo_casing/shotgun/rubbershot/tripleaught
 	name = "rubber 000 shot"
 	desc = "A shotgun casing filled with 000-buckshot-sized rubber balls, used to incapacitate crowds from a distance."
 	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/tripleaught 
 	pellets = 5
 	variance = 20
 
-/obj/item/ammo_casing/shotgun/rubbershot/0000
+/obj/item/ammo_casing/shotgun/rubbershot/quadrupleaught
 	name = "rubber 0000 shot"
 	desc = "A shotgun casing filled with 0000-buckshot-sized rubber balls, used to incapacitate crowds from a distance."
 	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/tripleaught 

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -375,7 +375,7 @@
 	projectile_type = /obj/item/projectile/bullet/shotshell/slug/ap
 
 /obj/item/ammo_casing/shotgun/buckshot
-	name = "00 buckshot shell"
+	name = "\improper 00 buckshot shell"
 	desc = "A 12 gauge, 00 buckshot shell."
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/shotshell/doubleaught
@@ -383,14 +383,14 @@
 	variance = 25
 
 /obj/item/ammo_casing/shotgun/buckshot/000
-	name = "000 buckshot shell"
+	name = "\improper 000 buckshot shell"
 	desc = "A 12 gauge, 000 buckshot shell."
 	projectile_type = /obj/item/projectile/bullet/shotshell/tripleaught
 	pellets = 4
 	variance = 20
 
 /obj/item/ammo_casing/shotgun/buckshot/0000
-	name = "0000 buckshot shell"
+	name = "\improper 0000 buckshot shell"
 	desc = "A 12 gauge, 0000 buckshot shell."
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/shotshell/quadrupleaught
@@ -398,7 +398,7 @@
 	variance = 15
 
 /obj/item/ammo_casing/shotgun/rubbershot
-	name = "00 rubber shot"
+	name = "rubber 00 shot"
 	desc = "A shotgun casing filled with 00-buckshot-sized rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/doubleaught 
@@ -407,14 +407,14 @@
 	materials = list(MAT_METAL=4000)
 	
 /obj/item/ammo_casing/shotgun/rubbershot/000
-	name = "000 rubber shot"
+	name = "rubber 000 shot"
 	desc = "A shotgun casing filled with 000-buckshot-sized rubber balls, used to incapacitate crowds from a distance."
 	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/tripleaught 
 	pellets = 5
 	variance = 20
 
 /obj/item/ammo_casing/shotgun/rubbershot/0000
-	name = "0000 rubber shot"
+	name = "rubber 0000 shot"
 	desc = "A shotgun casing filled with 0000-buckshot-sized rubber balls, used to incapacitate crowds from a distance."
 	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/tripleaught 
 	pellets = 4

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -335,25 +335,25 @@
 	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39
 	
 /obj/item/ammo_casing/a762x39hp
-	desc = "A bullet casing. The headstamp reads \"7.62x39mm SpHP\".
+	desc = "A bullet casing. The headstamp reads \"7.62x39mm SpHP\"."
 	icon_state = "casing_762x39"
 	caliber = "7.62x39"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39/hp
 	
 /obj/item/ammo_casing/a762x39ap
-	desc = "A bullet casing. The headstamp reads \"7.62x39mm AP-T\".
+	desc = "A bullet casing. The headstamp reads \"7.62x39mm AP-T\"."
 	icon_state = "casing_762x39"
 	caliber = "7.62x39"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39/ap
 
 /obj/item/ammo_casing/a762		//7.62x51mm
-	desc = "A bullet casing. The headstamp reads \"7.62x51mm FMJ\".
+	desc = "A bullet casing. The headstamp reads \"7.62x51mm FMJ\"."
 	icon_state = "762-casing"
 	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal762x51
 	
 /obj/item/ammo_casing/a762/ap
-	desc = "A bullet casing. The headstamp reads \"7.62x51mm AP-T\".
+	desc = "A bullet casing. The headstamp reads \"7.62x51mm AP-T\"."
 	projectile_type = /obj/item/projectile/bullet/calibre/cal762x51/ap
 
 /obj/item/ammo_casing/a762/enchanted

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -22,16 +22,19 @@
 /obj/item/ammo_casing/a357		//.357 Magnum
 	desc = "A bullet casing.  The headstamp reads \".357 MAG FMJ\"."
 	caliber = "357"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal357
 	
 /obj/item/ammo_casing/a357hp		
 	desc = "A bullet casing.  The headstamp reads \".357 MAG JHP\"."
 	caliber = "357"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal357/hp
 	
 /obj/item/ammo_casing/a357ap		
 	desc = "A bullet casing.  The headstamp reads \".357 MAG HV AP\"."
 	caliber = "357"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal357/hp
 
 /obj/item/ammo_casing/c38		//.38 Special
@@ -47,16 +50,19 @@
 /obj/item/ammo_casing/c44mag		//.44 Magnum
 	desc = "A bullet casing. The headstamp reads \".44 MAG FMJ\"."
 	caliber = "44mag"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal44mag
 
 /obj/item/ammo_casing/c44magap
 	desc = "A bullet casing. The headstamp reads \".44 MAG HV AP\"."
 	caliber = "44mag"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal44mag/ap
 	
 /obj/item/ammo_casing/c44maghp
 	desc = "A bullet casing. The headstamp reads \".44 MAG JHP\"."
 	caliber = "44mag"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal44mag/ap
 	
 /obj/item/ammo_casing/c44spl		//.44 Special
@@ -77,11 +83,13 @@
 /obj/item/ammo_casing/c45plus
 	desc = "A bullet casing. The headstamp reads \".45 ACP +P\"."		//overpressure
 	caliber = ".45"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal45acp/plus
 	
 /obj/item/ammo_casing/c45plusplus
 	desc = "A bullet casing. The headstamp reads \".45 ACP +P+\"."		//overpressure plus
 	caliber = ".45"
+	ismagnum = 2
 	projectile_type = /obj/item/projectile/bullet/calibre/cal45acp/plusplus
 
 /obj/item/ammo_casing/c45ap
@@ -103,6 +111,7 @@
 /obj/item/ammo_casing/c454		//.454 Casull
 	desc = "A bullet casing. The headstamp reads \"IWB .454 CASULL\"."
 	caliber = ".454"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal454
 	
 /obj/item/ammo_casing/a50		//.50 Action Express
@@ -123,6 +132,7 @@
 /obj/item/ammo_casing/a500sw		//.500 Smith & Wesson Magnum
 	desc = "A bullet casing. The headstamp reads \".500SWM FMJ\"."
 	caliber = ".500 swm"
+	ismagnum = 1
 	projectile_type = /obj/item/projectile/bullet/calibre/cal500sw
 	
 //HANDGUNS AND SMALL ARMS - METRIC

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -1,179 +1,359 @@
-/obj/item/ammo_casing/a357
-	desc = "A .357 bullet casing."
+//HANDGUNS AND SMALL ARMS - IMPERIAL
+/obj/item/ammo_casing/c17		//.17 Hornady Magnum Rimfire
+	desc = "A bullet casing. The headstamp reads \".17 HMR FMJ\"."		//"Full Metal Jacket"
+	caliber = "17hmr"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal17
+	
+/obj/item/ammo_casing/c17hp
+	desc = "A bullet casing. The headstamp reads \".17 HMR JHP\"."		//"Jacketed, Hollow Point"
+	caliber = "17hmr"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal17/hp
+	
+/obj/item/ammo_casing/c17ap
+	desc = "A bullet casing. The headstamp reads \".17 HMR HV AP\"."	//"High-Velocity Armour-Piercing"
+	caliber = "17hmr"
+	projectile_type = "/obj/item/projectile/bullet/calibre/cal17/ap"
+	
+/obj/item/ammo_casing/c22lr		//.22 Long Rifle
+	desc = "A bullet casing. The headstamp reads \".22 LR\"."
+	caliber = "22lr"
+	projectile_type = "/obj/item/projectile/bullet/calibre/cal22lr"
+
+/obj/item/ammo_casing/a357		//.357 Magnum
+	desc = "A bullet casing.  The headstamp reads \".357 MAG FMJ\"."
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal357
+	
+/obj/item/ammo_casing/a357hp		
+	desc = "A bullet casing.  The headstamp reads \".357 MAG JHP\"."
+	caliber = "357"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal357/hp
+	
+/obj/item/ammo_casing/a357hp		
+	desc = "A bullet casing.  The headstamp reads \".357 MAG HV AP\"."
+	caliber = "357"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal357/hp
 
-/obj/item/ammo_casing/a762
-	desc = "A 7.62 bullet casing."
-	icon_state = "762-casing"
-	caliber = "a762"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal762x51
-
-/obj/item/ammo_casing/a762/enchanted
-	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223 
-
-/obj/item/ammo_casing/a50
-	desc = "A .50AE bullet casing."
-	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal50ae 
-
-/obj/item/ammo_casing/c38
-	desc = "A .38 bullet casing."
+/obj/item/ammo_casing/c38		//.38 Special
+	desc = "A bullet casing. The headstamp reads \".38 SPL STUN\"."
 	caliber = "38"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal357/spl
+	
+/obj/item/ammo_casing/c38lethal
+	desc = "A bullet casing. The headstamp reads \".38 SPL FMJ\"."
+	caliber = "38"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal357/spl/lethal
+	
+/obj/item/ammo_casing/c44mag		//.44 Magnum
+	desc = "A bullet casing. The headstamp reads \".44 MAG FMJ\"."
+	caliber = "44mag"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal44mag
 
-/obj/item/ammo_casing/c10mm
-	desc = "A 10mm bullet casing."
-	caliber = "10mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal10x25
-
-/obj/item/ammo_casing/c9mm
-	desc = "A 9mm bullet casing."
-	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19
-
-/obj/item/ammo_casing/c9mmap
-	desc = "A 9mm bullet casing."
-	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/ap
-
-/obj/item/ammo_casing/c9mmtox
-	desc = "A 9mm bullet casing."
-	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/tox
-
-/obj/item/ammo_casing/c9mminc
-	desc = "A 9mm bullet casing."
-	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/incendiary
-
-/obj/item/ammo_casing/c46x30mm
-	desc = "A 4.6x30mm bullet casing."
-	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30
-
-/obj/item/ammo_casing/c46x30mmap
-	desc = "A 4.6x30mm bullet casing."
-	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/ap
-
-/obj/item/ammo_casing/c46x30mmtox
-	desc = "A 4.6x30mm bullet casing."
-	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/tox
-
-/obj/item/ammo_casing/c46x30mminc
-	desc = "A 4.6x30mm bullet casing."
-	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/incendiary
-
-/obj/item/ammo_casing/c45
-	desc = "A .45 bullet casing."
+/obj/item/ammo_casing/c44magap
+	desc = "A bullet casing. The headstamp reads \".44 MAG HV AP\"."
+	caliber = "44mag"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal44mag/ap
+	
+/obj/item/ammo_casing/c44maghp
+	desc = "A bullet casing. The headstamp reads \".44 MAG JHP\"."
+	caliber = "44mag"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal44mag/ap
+	
+/obj/item/ammo_casing/c44spl		//.44 Special
+	desc = "A bullet casing. The headstamp reads \".44 SPL\"."
+	caliber = "44mag"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal44mag/spl
+	
+/obj/item/ammo_casing/c44		//.44 AMP
+	desc = "A .44 AMP cartridge."
+	caliber = ".44"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg
+	
+/obj/item/ammo_casing/c45		//.45 Automatic Colt Pistol
+	desc = "A bullet casing. The headstamp reads \".45 ACP FMJ\"."
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal45acp
+	
+/obj/item/ammo_casing/c45plus
+	desc = "A bullet casing. The headstamp reads \".45 ACP +P\"."		//overpressure
+	caliber = ".45"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal45acp/plus
+	
+/obj/item/ammo_casing/c45plusplus
+	desc = "A bullet casing. The headstamp reads \".45 ACP +P+\"."		//overpressure plus
+	caliber = ".45"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal45acp/plusplus
+
+/obj/item/ammo_casing/c45ap
+	desc = "A bullet casing. The headstamp reads \".45 ACP HV AP\"."
+	caliber = ".45"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal45acp/ap
+	
+/obj/item/ammo_casing/c45hp
+	desc = "A bullet casing. The headstamp reads \".45 ACP JHP\"."
+	caliber = ".45"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal45acp/hp
 /*
 /obj/item/ammo_casing/c45nostamina
 	desc = "A .45 bullet casing."
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 */
-/obj/item/ammo_casing/c44
-	desc = "A .44 AMP cartridge."
-	caliber = ".44"
+
+/obj/item/ammo_casing/c454		//.454 Casull
+	desc = "A bullet casing. The headstamp reads \"IWB .454 CASULL\"."
+	caliber = ".454"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal454
+	
+/obj/item/ammo_casing/a50		//.50 Action Express
+	desc = "A bullet casing. The headstamp reads \".50-AE FMJ\"."
+	caliber = ".50"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50ae
+	
+/obj/item/ammo_casing/a50hp
+	desc = "A bullet casing. The headstamp reads \".50-AE JHP\"."
+	caliber = ".50"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50ae/jhp
+	
+/obj/item/ammo_casing/a50ap
+	desc = "A bullet casing. The headstamp reads \".50-AE HV AP\"."
+	caliber = ".50"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50ae/ap
+	
+/obj/item/ammo_casing/a500sw		//.500 Smith & Wesson Magnum
+	desc = "A bullet casing. The headstamp reads \".500SWM FMJ\"."
+	caliber = ".500 swm"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal500sw
+	
+//HANDGUNS AND SMALL ARMS - METRIC
 
-/obj/item/ammo_casing/caseless/a68
-	desc = "A 6.8x43mm caseless cartridge."
-	caliber = "6.8"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal68x43
+/obj/item/ammo_casing/c46x30mm		//4.6x30mm Heckler & Koch
+	desc = "A bullet casing. The headstamp reads \"4.6x30mm FMJ\"."
+	caliber = "4.6x30mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30
 
-/obj/item/ammo_casing/a762x39
-	desc = "A 7.62x39mm bullet casing."
-	icon_state = "casing_762x39"
-	caliber = "7.62x39"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39
+/obj/item/ammo_casing/c46x30mmap
+	desc = "A bullet casing. The headstamp reads \"4.6x30mm HV AP\"."
+	caliber = "4.6x30mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/ap
 
-/obj/item/ammo_casing/a545
-	desc = "A 5.45x39mm cartridge."
-	icon_state = "casing_545"
-	caliber = "a556"
+/obj/item/ammo_casing/c46x30mmtox
+	desc = "A bullet casing. The headstamp reads \"4.6x30mm HITOX\"."	//"Hitox" is not a real-life headstamp
+	caliber = "4.6x30mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/tox
+
+/obj/item/ammo_casing/c46x30mminc
+	desc = "A bullet casing. The headstamp reads \"4.6x30mm I-T\"."		//Incendiary Tracer
+	caliber = "4.6x30mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/incendiary
+	
+/obj/item/ammo_casing/c57x28mm		//5.7x28mm Fabrique Nationale d'Herstal
+	desc = "A bullet casing. The headstamp reads \"5.7x28mm FMJ\"."
+	caliber = "5.7x28mm"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal57x28
+	
+/obj/item/ammo_casing/c57x28mmap		
+	desc = "A bullet casing. The headstamp reads \"5.7x28mm HV AP\"."
+	caliber = "5.7x28mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal57x28/ap
+	
+/obj/item/ammo_casing/c57x28mmhp		
+	desc = "A bullet casing. The headstamp reads \"5.7x28mm JHP\"."
+	caliber = "5.7x28mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal57x28/hp
 
-/obj/item/ammo_casing/n762
-	desc = "A 7.62x38mmR bullet casing."
-	caliber = "n762"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal357	//nagant revolver, this is a stopgap
+/obj/item/ammo_casing/c9x18mm		//9x18mm Makarov
+	desc = "A bullet casing. The headstamp reads \"9x18mm FMJ\"."
+	caliber = "9x18mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x18
+	
+/obj/item/ammo_casing/c9x18mmhp
+	desc = "A bullet casing. The headstamp reads \"9x18mm JHP\"."
+	caliber = "9x18mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x18/hp
+	
+/obj/item/ammo_casing/c9x18mmap
+	desc = "A bullet casing. The headstamp reads \"9x18mm HV AP\"."
+	caliber = "9x18mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x18/hp
+	
+/obj/item/ammo_casing/c9mm		//9x19mm NATO, or 9mm Luger, or 9mm Parabellum... 
+	desc = "A bullet casing. The headstamp reads \"9mm LUGER FMJ\"."
+	caliber = "9mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19
 
-/obj/item/ammo_casing/a556
-	desc = "A 5.56mm bullet casing."
-	caliber = "a556"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223 
+/obj/item/ammo_casing/c9mmap
+	desc = "A bullet casing. The headstamp reads \"9mm LUGER HV AP\"."
+	caliber = "9mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/ap
 
-/obj/item/ammo_casing/a40mm
-	name = "40mm HE shell"
-	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
-	caliber = "40mm"
-	icon_state = "40mmHE"
-	projectile_type = /obj/item/projectile/bullet/a40mm
+/obj/item/ammo_casing/c9mmap
+	desc = "A bullet casing. The headstamp reads \"9mm LUGER JHP\"."
+	caliber = "9mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/hp
 
+/obj/item/ammo_casing/c9mmtox
+	desc = "A bullet casing. The headstamp reads \"9mm LUGER HITOX\"."
+	caliber = "9mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/tox
 
+/obj/item/ammo_casing/c9mminc
+	desc = "A bullet casing. The headstamp reads \"9mm LUGER I-T\"."
+	caliber = "9mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/incendiary
+	
+/obj/item/ammo_casing/c10mm		//10x25mm Automatic
+	desc = "A bullet casing. The headstamp reads \"10mm AUTO FMJ\"."
+	caliber = "10mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal10x25
+	
+/obj/item/ammo_casing/c10mmap
+	desc = "A bullet casing. The headstamp reads \"10mm AUTO HV AP\"."
+	caliber = "10mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal10x25/ap
+	
+/obj/item/ammo_casing/c10mmap
+	desc = "A bullet casing. The headstamp reads \"10mm AUTO JHP\"."
+	caliber = "10mm"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal10x25/hp
 
-/////SNIPER ROUNDS
+//RIFLE ROUNDS - IMPERIAL
 
-/obj/item/ammo_casing/point50
-	desc = "A .50 bullet casing."
+/obj/item/ammo_casing/c223		//.223 Remington Magnum
+	desc = "A bullet casing. The headstamp reads \".223 FMJ\"."
+	caliber = "5.56x45"				//you can put a .223 in a 5.56 and it will fire safely
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223
+
+/obj/item/ammo_casing/c223hp
+	desc = "A bullet casing. The headstamp reads \".223 SpHP\"."	//SPitzer, Hollow Point
+	caliber = "5.56x45"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223/hp
+	
+/obj/item/ammo_casing/c223hp
+	desc = "A bullet casing. The headstamp reads \".223 AP-T\"."	//Armour-Piercing Tracer
+	caliber = "5.56x45"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223/hp
+	
+/obj/item/ammo_casing/c3006		//.30-06 Springfield
+	desc = "A bullet casing. The headstamp reads \".30-06 SPRG FMJ\"."	//SPRinGfield
+	caliber = ".30-06"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal3006
+	
+/obj/item/ammo_casing/c3006hp
+	desc = "A bullet casing. The headstamp reads \".30-06 SPRG SpHP\"."
+	caliber = ".30-06"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal3006hp
+	
+/obj/item/ammo_casing/c3006ap
+	desc = "A bullet casing. The headstamp reads \".30-06 SPRG AP-T\"."
+	caliber = ".30-06"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal3006ap
+	
+/obj/item/ammo_casing/c308		//.308 Winchester
+	desc = "A bullet casing. The headstamp reads \".308 WIN FMJ\"."
+	caliber = ".308"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal308
+	
+/obj/item/ammo_casing/c308ap
+	desc = "A bullet casing. The headstamp reads \".308 WIN AP-T\"."
+	caliber = ".308"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal308/ap
+
+/obj/item/ammo_casing/c308hp
+	desc = "A bullet casing. The headstamp reads \".308 WIN SpHP\"."
+	caliber = ".308"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal308/hp
+	
+/obj/item/ammo_casing/c338		//.338 Lapua Magnum
+	desc = "A bullet casing. The headstamp reads \".338 LAPUA MAG\"."
+	caliber = ".338"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal338
+	
+/obj/item/ammo_casing/c4570		//.45-70 Government
+	desc = "A bullet casing. The headstamp reads \".45-70 GOVT\"."
+	caliber = ".45-70"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal4570
+
+/obj/item/ammo_casing/point50		//.50 Browning Machine Gun
+	desc = "A bullet casing. The headstamp reads \".50BMG SLAP\"."		//Saboted Light Armour-Piercing
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg
 	icon_state = ".50"
 
-/obj/item/ammo_casing/soporific
-	desc = "A .50 bullet casing, specialised in sending the target to sleep, instead of hell."
+/obj/item/ammo_casing/soporific	
+	desc = "A bullet casing. The headstamp reads \".50BMG TRANQ\". Designed to send the target to sleep, instead of hell."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg/narq
 	icon_state = ".50"
 
 /obj/item/ammo_casing/haemorrhage
-	desc = "A .50 bullet casing, specialised in causing massive bloodloss"
+	desc = "A bullet casing. The headstamp reads \".50BMG SX\". Specializes in causing massive bloodloss."		//Super eXplosive
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg/haemorrhage
 	icon_state = ".50"
 
 /obj/item/ammo_casing/penetrator
-	desc = "A .50 caliber penetrator round casing."
+	desc = "A bullet casing. The headstamp reads \".50BMG DU\". A penetrator round, if there ever was one."		//Depleted Uranium
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg/penetrator
 	icon_state = ".50"
 
+//RIFLE ROUNDS - METRIC
 
-
-/// SAW ROUNDS
-
-/obj/item/ammo_casing/mm556x45
-	desc = "A 556x45mm bullet casing."
+/obj/item/ammo_casing/mm556x45		//5.56x45mm NATO
+	desc = "A bullet casing. The headstamp reads \"5.56x45mm NATO FMJ\"."	
 	icon_state = "762-casing"
 	caliber = "mm55645"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45
 
 /obj/item/ammo_casing/mm556x45/bleeding
-	desc = "A 556x45mm bullet casing with specialized inner-casing, that when it makes contact with a target, release tiny shrapnel to induce internal bleeding."
+	desc = "A bullet casing. The headstamp reads \"5.56x45mm NATO SX\". It has a specialized inner-casing, that when it makes contact with a target, release tiny shrapnel to induce internal bleeding."
 	icon_state = "762-casing"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/bleeding
 
 /obj/item/ammo_casing/mm556x45/hollow
-	desc = "A 556x45mm bullet casing designed to cause more damage to unarmored targets."
+	desc = "A bullet casing. The headstamp reads \"5.56x45mm NATO SpHP\"."
 	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/hp
 
 /obj/item/ammo_casing/mm556x45/ap
-	desc = "A 556x45mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
+	desc = "A bullet casing. The headstamp reads \"5.56x45mm NATO HV AP\"."
 	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/ap
 
 /obj/item/ammo_casing/mm556x45/incen
-	desc = "A 556x45mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames. "
+	desc = "A bullet casing. The headstamp reads \"5.56x45mm NATO I-T\"."
 	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/incen
 
+/obj/item/ammo_casing/a762x39		//7.62x39mm Soviet
+	desc = "A bullet casing. The headstamp reads \"7.62x39mm FMJ\".
+	icon_state = "casing_762x39"
+	caliber = "7.62x39"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39
+	
+/obj/item/ammo_casing/a762x39hp
+	desc = "A bullet casing. The headstamp reads \"7.62x39mm SpHP\".
+	icon_state = "casing_762x39"
+	caliber = "7.62x39"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39/hp
+	
+/obj/item/ammo_casing/a762x39ap
+	desc = "A bullet casing. The headstamp reads \"7.62x39mm AP-T\".
+	icon_state = "casing_762x39"
+	caliber = "7.62x39"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39/ap
 
+/obj/item/ammo_casing/a762		//7.62x51mm
+	desc = "A bullet casing. The headstamp reads \"7.62x51mm FMJ\".
+	icon_state = "762-casing"
+	caliber = "a762"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal762x51
+	
+/obj/item/ammo_casing/a762/ap
+	desc = "A bullet casing. The headstamp reads \"7.62x51mm AP-T\".
+	projectile_type = /obj/item/projectile/bullet/calibre/cal762x51/ap
 
-
+/obj/item/ammo_casing/a762/enchanted
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223 
+	
 //SHOTGUN ROUNDS
 
 /obj/item/ammo_casing/shotgun
@@ -184,32 +364,70 @@
 	projectile_type = /obj/item/projectile/bullet/shotshell/slug
 	materials = list(MAT_METAL=4000)
 
+/obj/item/ammo_casing/shotgun/fletchette
+	name = "shotgun fletchette"
+	desc = "A 12 gauge fletchette shell."
+	projectile_type = /obj/item/projectile/bullet/shotshell/slug/ap
 
 /obj/item/ammo_casing/shotgun/buckshot
-	name = "buckshot shell"
-	desc = "A 12 gauge buckshot shell."
+	name = "00 buckshot shell"
+	desc = "A 12 gauge, 00 buckshot shell."
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/shotshell/doubleaught
 	pellets = 6
 	variance = 25
 
+/obj/item/ammo_casing/shotgun/buckshot/000
+	name = "000 buckshot shell"
+	desc = "A 12 gauge, 000 buckshot shell."
+	projectile_type = /obj/item/projectile/bullet/shotshell/tripleaught
+	pellets = 4
+	variance = 20
+
+/obj/item/ammo_casing/shotgun/buckshot/0000
+	name = "0000 buckshot shell"
+	desc = "A 12 gauge, 0000 buckshot shell."
+	icon_state = "gshell"
+	projectile_type = /obj/item/projectile/bullet/shotshell/quadrupleaught
+	pellets = 3
+	variance = 15
+
 /obj/item/ammo_casing/shotgun/rubbershot
-	name = "rubber shot"
-	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
+	name = "00 rubber shot"
+	desc = "A shotgun casing filled with 00-buckshot-sized rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/doubleaught 
-	pellets = 6
+	pellets = 7
 	variance = 25
 	materials = list(MAT_METAL=4000)
+	
+/obj/item/ammo_casing/shotgun/rubbershot/000
+	name = "000 rubber shot"
+	desc = "A shotgun casing filled with 000-buckshot-sized rubber balls, used to incapacitate crowds from a distance."
+	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/tripleaught 
+	pellets = 5
+	variance = 20
 
+/obj/item/ammo_casing/shotgun/rubbershot/0000
+	name = "0000 rubber shot"
+	desc = "A shotgun casing filled with 0000-buckshot-sized rubber balls, used to incapacitate crowds from a distance."
+	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/tripleaught 
+	pellets = 4
+	variance = 15
 
 /obj/item/ammo_casing/shotgun/beanbag
-	name = "beanbag slug"
-	desc = "A weak beanbag slug for riot control."
+	name = "rubber slug"
+	desc = "A weak rubber slug for riot control."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/shotshell/ltl
 	materials = list(MAT_METAL=250)
 
+/obj/item/ammo_casing/shotgun/stunslug
+	name = "Taser slug"
+	desc = "A Taser slug."
+	icon_state = "stunshell"
+	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/xrep
+	materials = list(MAT_METAL=250)
 
 /obj/item/ammo_casing/shotgun/improvised
 	name = "improvised shell"
@@ -230,14 +448,6 @@
 	materials = list(MAT_METAL=250)
 	pellets = 4
 	variance = 40
-
-
-/obj/item/ammo_casing/shotgun/stunslug
-	name = "taser slug"
-	desc = "A stunning taser slug."
-	icon_state = "stunshell"
-	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/xrep
-	materials = list(MAT_METAL=250)
 
 
 /obj/item/ammo_casing/shotgun/meteorshot
@@ -327,6 +537,33 @@
 	reagents.add_reagent("coniine", 6)
 	reagents.add_reagent("sodium_thiopental", 6)
 
+	
+//UNSORTED
+
+/obj/item/ammo_casing/a545			//Used in the M90 (the P90 clone)
+	desc = "A 5.45x39mm cartridge."
+	icon_state = "casing_545"
+	caliber = "a556"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal57x28
+
+/obj/item/ammo_casing/n762			//Nagant revolver
+	desc = "A 7.62x38mmR bullet casing."
+	caliber = "n762"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal357
+
+/obj/item/ammo_casing/a556			//I don't even
+	desc = "A 5.56mm bullet casing."
+	caliber = "a556"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223 
+
+/obj/item/ammo_casing/a40mm			//grenade launcher
+	name = "40mm HE shell"
+	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
+	caliber = "40mm"
+	icon_state = "40mmHE"
+	projectile_type = /obj/item/projectile/bullet/a40mm
+
+
 // Caseless Ammunition
 
 /obj/item/ammo_casing/caseless
@@ -344,11 +581,22 @@
 	..()
 	icon_state = "[initial(icon_state)]"
 
+/obj/item/ammo_casing/caseless/a68
+	desc = "A 6.8x43mm caseless cartridge."
+	caliber = "6.8"
+	projectile_type = /obj/item/projectile/bullet/calibre/cal68x43
+
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."
 	caliber = "75"
 	icon_state = "s-casing-live"
 	projectile_type = /obj/item/projectile/bullet/gyro
+	
+/obj/item/ammo_casing/caseless/bb
+	desc = "A .177 BB. Don't shoot your eye out."
+	caliber = "177"
+	icon_state = "s-casing-live"	//placeholder
+	projectile_type = /obj/item/projectile/bullet/calibre/cal177
 
 /obj/item/ammo_casing/caseless/magspear
 	name = "magnetic spear"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -1,113 +1,113 @@
 /obj/item/ammo_casing/a357
 	desc = "A .357 bullet casing."
 	caliber = "357"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal357
 
 /obj/item/ammo_casing/a762
 	desc = "A 7.62 bullet casing."
 	icon_state = "762-casing"
 	caliber = "a762"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal762x51
 
 /obj/item/ammo_casing/a762/enchanted
-	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223 
 
 /obj/item/ammo_casing/a50
 	desc = "A .50AE bullet casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50ae 
 
 /obj/item/ammo_casing/c38
 	desc = "A .38 bullet casing."
 	caliber = "38"
-	projectile_type = /obj/item/projectile/bullet/weakbullet2
+	projectile_type = /obj/item/projectile/bullet/calibre/cal357/spl
 
 /obj/item/ammo_casing/c10mm
 	desc = "A 10mm bullet casing."
 	caliber = "10mm"
-	projectile_type = /obj/item/projectile/bullet/midbullet3
+	projectile_type = /obj/item/projectile/bullet/calibre/cal10x25
 
 /obj/item/ammo_casing/c9mm
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19
 
 /obj/item/ammo_casing/c9mmap
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type =/obj/item/projectile/bullet/armourpiercing
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/ap
 
 /obj/item/ammo_casing/c9mmtox
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/toxinbullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/tox
 
 /obj/item/ammo_casing/c9mminc
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/incendiary/firebullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/incendiary
 
 /obj/item/ammo_casing/c46x30mm
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30
 
 /obj/item/ammo_casing/c46x30mmap
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type =/obj/item/projectile/bullet/armourpiercing
+	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/ap
 
 /obj/item/ammo_casing/c46x30mmtox
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/toxinbullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/tox
 
 /obj/item/ammo_casing/c46x30mminc
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/incendiary/firebullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30/incendiary
 
 /obj/item/ammo_casing/c45
 	desc = "A .45 bullet casing."
 	caliber = ".45"
-	projectile_type = /obj/item/projectile/bullet/midbullet
-
+	projectile_type = /obj/item/projectile/bullet/calibre/cal45acp
+/*
 /obj/item/ammo_casing/c45nostamina
 	desc = "A .45 bullet casing."
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/midbullet3
-
+*/
 /obj/item/ammo_casing/c44
 	desc = "A .44 AMP cartridge."
 	caliber = ".44"
-	projectile_type = /obj/item/projectile/bullet/heavybullet2
+	projectile_type = /obj/item/projectile/bullet/calibre/cal500sw
 
 /obj/item/ammo_casing/caseless/a68
 	desc = "A 6.8x43mm caseless cartridge."
 	caliber = "6.8"
-	projectile_type = /obj/item/projectile/bullet/heavybullet3
+	projectile_type = /obj/item/projectile/bullet/calibre/cal68x43
 
 /obj/item/ammo_casing/a762x39
 	desc = "A 7.62x39mm bullet casing."
 	icon_state = "casing_762x39"
 	caliber = "7.62x39"
-	projectile_type = /obj/item/projectile/bullet/heavybullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39
 
 /obj/item/ammo_casing/a545
 	desc = "A 5.45x39mm cartridge."
 	icon_state = "casing_545"
 	caliber = "a556"
-	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	projectile_type = /obj/item/projectile/bullet/calibre/cal57x28
 
 /obj/item/ammo_casing/n762
 	desc = "A 7.62x38mmR bullet casing."
 	caliber = "n762"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal357	//nagant revolver, this is a stopgap
 
 /obj/item/ammo_casing/a556
 	desc = "A 5.56mm bullet casing."
 	caliber = "a556"
-	projectile_type = /obj/item/projectile/bullet/heavybullet
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223 
 
 /obj/item/ammo_casing/a40mm
 	name = "40mm HE shell"
@@ -123,25 +123,25 @@
 /obj/item/ammo_casing/point50
 	desc = "A .50 bullet casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg
 	icon_state = ".50"
 
 /obj/item/ammo_casing/soporific
 	desc = "A .50 bullet casing, specialised in sending the target to sleep, instead of hell."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/soporific
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg/narq
 	icon_state = ".50"
 
 /obj/item/ammo_casing/haemorrhage
 	desc = "A .50 bullet casing, specialised in causing massive bloodloss"
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/haemorrhage
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg/haemorrhage
 	icon_state = ".50"
 
 /obj/item/ammo_casing/penetrator
 	desc = "A .50 caliber penetrator round casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/penetrator
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50bmg/penetrator
 	icon_state = ".50"
 
 
@@ -152,24 +152,24 @@
 	desc = "A 556x45mm bullet casing."
 	icon_state = "762-casing"
 	caliber = "mm55645"
-	projectile_type = /obj/item/projectile/bullet/saw
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45
 
 /obj/item/ammo_casing/mm556x45/bleeding
 	desc = "A 556x45mm bullet casing with specialized inner-casing, that when it makes contact with a target, release tiny shrapnel to induce internal bleeding."
 	icon_state = "762-casing"
-	projectile_type = /obj/item/projectile/bullet/saw/bleeding
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/bleeding
 
 /obj/item/ammo_casing/mm556x45/hollow
 	desc = "A 556x45mm bullet casing designed to cause more damage to unarmored targets."
-	projectile_type = /obj/item/projectile/bullet/saw/hollow
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/hp
 
 /obj/item/ammo_casing/mm556x45/ap
 	desc = "A 556x45mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
-	projectile_type = /obj/item/projectile/bullet/saw/ap
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/ap
 
 /obj/item/ammo_casing/mm556x45/incen
 	desc = "A 556x45mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames. "
-	projectile_type = /obj/item/projectile/bullet/saw/incen
+	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/incen
 
 
 
@@ -181,7 +181,7 @@
 	desc = "A 12 gauge lead slug."
 	icon_state = "blshell"
 	caliber = "shotgun"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/shotshell/slug
 	materials = list(MAT_METAL=4000)
 
 
@@ -189,7 +189,7 @@
 	name = "buckshot shell"
 	desc = "A 12 gauge buckshot shell."
 	icon_state = "gshell"
-	projectile_type = /obj/item/projectile/bullet/pellet
+	projectile_type = /obj/item/projectile/bullet/shotshell/doubleaught
 	pellets = 6
 	variance = 25
 
@@ -197,7 +197,7 @@
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/rpellet
+	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/doubleaught 
 	pellets = 6
 	variance = 25
 	materials = list(MAT_METAL=4000)
@@ -207,7 +207,7 @@
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/weakbullet
+	projectile_type = /obj/item/projectile/bullet/shotshell/ltl
 	materials = list(MAT_METAL=250)
 
 
@@ -215,7 +215,7 @@
 	name = "improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
 	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/weak
+	projectile_type = /obj/item/projectile/bullet/shotshell/metal_shavings
 	materials = list(MAT_METAL=250)
 	pellets = 10
 	variance = 25
@@ -226,7 +226,7 @@
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards. This one has been packed with even more \
 	propellant. It's like playing russian roulette, with a shotgun."
 	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/overload
+	projectile_type = /obj/item/projectile/bullet/shotshell/metal_shavings/overload
 	materials = list(MAT_METAL=250)
 	pellets = 4
 	variance = 40
@@ -236,7 +236,7 @@
 	name = "taser slug"
 	desc = "A stunning taser slug."
 	icon_state = "stunshell"
-	projectile_type = /obj/item/projectile/bullet/stunshot
+	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/xrep
 	materials = list(MAT_METAL=250)
 
 
@@ -244,13 +244,13 @@
 	name = "meteorshot shell"
 	desc = "A shotgun shell rigged with CMC technology, which launches a massive slug when fired."
 	icon_state = "mshell"
-	projectile_type = /obj/item/projectile/bullet/meteorshot
+	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/meteor
 
 /obj/item/ammo_casing/shotgun/breaching
 	name = "breaching shell"
 	desc = "An economic version of the meteorshot, utilizing similar technologies. Great for busting down doors."
 	icon_state = "mshell"
-	projectile_type = /obj/item/projectile/bullet/meteorshot/weak
+	projectile_type = /obj/item/projectile/bullet/shotshell/ltl/meteor/breach
 
 /obj/item/ammo_casing/shotgun/pulseslug
 	name = "pulse slug"
@@ -264,7 +264,7 @@
 	name = "incendiary slug"
 	desc = "An incendiary-coated shotgun slug."
 	icon_state = "ishell"
-	projectile_type = /obj/item/projectile/bullet/incendiary/shell
+	projectile_type =/obj/item/projectile/bullet/shotshell/incendiary
 
 /obj/item/ammo_casing/shotgun/frag12
 	name = "FRAG-12 slug"
@@ -276,7 +276,7 @@
 	name = "dragonsbreath shell"
 	desc = "A shotgun shell which fires a spread of incendiary pellets."
 	icon_state = "ishell2"
-	projectile_type = /obj/item/projectile/bullet/incendiary/shell/dragonsbreath
+	projectile_type = /obj/item/projectile/bullet/shotshell/incendiary/dragon
 	pellets = 4
 	variance = 35
 

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -187,7 +187,7 @@
 	caliber = "9mm"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/ap
 
-/obj/item/ammo_casing/c9mmap
+/obj/item/ammo_casing/c9mmhp
 	desc = "A bullet casing. The headstamp reads \"9mm LUGER JHP\"."
 	caliber = "9mm"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal9x19/hp

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -29,7 +29,7 @@
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal357/hp
 	
-/obj/item/ammo_casing/a357hp		
+/obj/item/ammo_casing/a357ap		
 	desc = "A bullet casing.  The headstamp reads \".357 MAG HV AP\"."
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal357/hp
@@ -131,6 +131,11 @@
 	desc = "A bullet casing. The headstamp reads \"4.6x30mm FMJ\"."
 	caliber = "4.6x30mm"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal46x30
+	
+/obj/item/ammo_casing/c46x30mmhp
+	desc = "A bullet casing. The headstamp reads \"4.6x30mm JHP\"."
+	caliber = "4.6x30mm"
+	projectile_type =/obj/item/projectile/bullet/calibre/cal46x30/hp
 
 /obj/item/ammo_casing/c46x30mmap
 	desc = "A bullet casing. The headstamp reads \"4.6x30mm HV AP\"."
@@ -212,7 +217,7 @@
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal10x25/ap
 	
-/obj/item/ammo_casing/c10mmap
+/obj/item/ammo_casing/c10mmhp
 	desc = "A bullet casing. The headstamp reads \"10mm AUTO JHP\"."
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal10x25/hp
@@ -229,7 +234,7 @@
 	caliber = "5.56x45"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223/hp
 	
-/obj/item/ammo_casing/c223hp
+/obj/item/ammo_casing/c223ap
 	desc = "A bullet casing. The headstamp reads \".223 AP-T\"."	//Armour-Piercing Tracer
 	caliber = "5.56x45"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/cal223/hp
@@ -324,7 +329,7 @@
 	projectile_type = /obj/item/projectile/bullet/calibre/cal556x45/incen
 
 /obj/item/ammo_casing/a762x39		//7.62x39mm Soviet
-	desc = "A bullet casing. The headstamp reads \"7.62x39mm FMJ\".
+	desc = "A bullet casing. The headstamp reads \"7.62x39mm FMJ\"."
 	icon_state = "casing_762x39"
 	caliber = "7.62x39"
 	projectile_type = /obj/item/projectile/bullet/calibre/cal762x39

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -113,7 +113,7 @@
 /obj/item/ammo_casing/a50hp
 	desc = "A bullet casing. The headstamp reads \".50-AE JHP\"."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal50ae/jhp
+	projectile_type = /obj/item/projectile/bullet/calibre/cal50ae/hp
 	
 /obj/item/ammo_casing/a50ap
 	desc = "A bullet casing. The headstamp reads \".50-AE HV AP\"."
@@ -247,12 +247,12 @@
 /obj/item/ammo_casing/c3006hp
 	desc = "A bullet casing. The headstamp reads \".30-06 SPRG SpHP\"."
 	caliber = ".30-06"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal3006hp
+	projectile_type = /obj/item/projectile/bullet/calibre/cal3006/hp
 	
 /obj/item/ammo_casing/c3006ap
 	desc = "A bullet casing. The headstamp reads \".30-06 SPRG AP-T\"."
 	caliber = ".30-06"
-	projectile_type = /obj/item/projectile/bullet/calibre/cal3006ap
+	projectile_type = /obj/item/projectile/bullet/calibre/cal3006/ap
 	
 /obj/item/ammo_casing/c308		//.308 Winchester
 	desc = "A bullet casing. The headstamp reads \".308 WIN FMJ\"."

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -9,11 +9,11 @@
 
 /obj/item/ammo_box/c17hmr/hp
 	name = "ammo box (.17 HMR JHP)"
-	ammo_type = /obj/item/ammo_casing/c17/hp
+	ammo_type = /obj/item/ammo_casing/c17hp
 
 /obj/item/ammo_box/c17hmr/ap
 	name = "ammo box (.17 HMR HV AP)"
-	ammo_type = /obj/item/ammo_casing/c17/ap
+	ammo_type = /obj/item/ammo_casing/c17ap
 
 /obj/item/ammo_box/c22lr
 	name = "ammo box (.22 Long Rifle)"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -1,3 +1,27 @@
+//imperial small arms
+
+/obj/item/ammo_box/c17hmr
+	name = "ammo box (.17 HMR)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c17
+	max_ammo = 30
+
+/obj/item/ammo_box/c17hmr/hp
+	name = "ammo box (.17 HMR JHP)"
+	ammo_type = /obj/item/ammo_casing/c17/hp
+
+/obj/item/ammo_box/c17hmr/ap
+	name = "ammo box (.17 HMR HV AP)"
+	ammo_type = /obj/item/ammo_casing/c17/ap
+
+/obj/item/ammo_box/c22lr
+	name = "ammo box (.22 Long Rifle)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c22lr
+	max_ammo = 30
+	
 /obj/item/ammo_box/a357
 	name = "speed loader (.357)"
 	desc = "Designed to quickly reload revolvers."
@@ -5,42 +29,290 @@
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
 	multiple_sprites = 1
-
+	
+/obj/item/ammo_box/a357/hp
+	name = "speed loader (.357 JHP)"
+	ammo_type = /obj/item/ammo_casing/a357hp
+	
+/obj/item/ammo_box/a357/hp
+	name = "speed loader (.357 HV AP)"
+	ammo_type = /obj/item/ammo_casing/a357ap
+	
 /obj/item/ammo_box/c38
-	name = "speed loader (.38)"
+	name = "speed loader (.38 Special stunshot)"
 	desc = "Designed to quickly reload revolvers."
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
 	multiple_sprites = 1
+	
+/obj/item/ammo_box/c38lethal
+	name = "speed loader (.38 Special FMJ)"
+	ammo_type = /obj/item/ammo_casing/c38lethal
+	
+/obj/item/ammo_box/c44mag
+	name = "ammo box (.44 Magnum)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c44mag
+	max_ammo = 30
+	
+/obj/item/ammo_box/c44mag/hp
+	name = "ammo box (.44 Magnum JHP)"
+	ammo_type = /obj/item/ammo_casing/c44maghp
 
+/obj/item/ammo_box/c44mag/ap
+	name = "ammo box (.44 Magnum JHP)"
+	ammo_type = /obj/item/ammo_casing/c44magap
+
+/obj/item/ammo_box/c45
+	name = "ammo box (.45 ACP)"
+	icon_state = "45box"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c45
+	max_ammo = 30
+
+/obj/item/ammo_box/c45/plus
+	name = "ammo box (.45 ACP +P)"
+	ammo_type = /obj/item/ammo_casing/c45plus
+	max_ammo = 20
+	
+/obj/item/ammo_box/c45/plus/plus
+	name = "ammo box (.45 ACP +P+)"
+	ammo_type = /obj/item/ammo_casing/c45plusplus
+	
+/obj/item/ammo_box/c45/hp
+	name = "ammo box (.45 ACP JHP)"
+	ammo_type = /obj/item/ammo_casing/c45hp
+
+/obj/item/ammo_box/c45/ap
+	name = "ammo box (.45 ACP HV AP)"
+	ammo_type = /obj/item/ammo_casing/c45ap
+	
+/obj/item/ammo_box/c454casull
+	name = "ammo box (.454 wildcat)"
+	desc = "A box of .454 Casull ammunition, carefully loaded by hand."
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c454
+	max_ammo = 10
+
+/obj/item/ammo_box/c50ae
+	name = "ammo box (.50-AE)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/a50
+	max_ammo = 20
+	
+/obj/item/ammo_box/c50ae/hp
+	name = "ammo box (.50-AE JHP)"
+	ammo_type = /obj/item/ammo_casing/a50hp
+
+/obj/item/ammo_box/c50ae/ap
+	name = "ammo box (.50-AE HV AP)"
+	ammo_type = /obj/item/ammo_casing/a50ap
+	
+/obj/item/ammo_box/c500sw
+	name = "ammo box (.500 SWM)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/a500sw
+	max_ammo = 15
+
+//metric small arms
+
+/obj/item/ammo_box/c46x30mm
+	name = "ammo box (4.6x30mm)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c46x30mm
+	max_ammo = 30
+	
+/obj/item/ammo_box/c46x30mm/hp
+	name = "ammo box (4.6x30mm JHP)"
+	ammo_type = /obj/item/ammo_casing/c46x30mmhp
+
+/obj/item/ammo_box/c46x30mm/ap
+	name = "ammo box (4.6x30mm HV AP)"
+	ammo_type = /obj/item/ammo_casing/c46x30mmap
+	
+/obj/item/ammo_box/c57x28mm
+	name = "ammo box (5.7x28mm)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c57x28mm
+	max_ammo = 30
+		
+/obj/item/ammo_box/c57x28mm/hp
+	name = "ammo box (5.7x28mm JHP)"
+	ammo_type = /obj/item/ammo_casing/c57x28mmhp
+	
+/obj/item/ammo_box/c57x28mm/ap
+	name = "ammo box (5.7x28mm HV AP)"
+	ammo_type = /obj/item/ammo_casing/c57x28mmap
+
+/obj/item/ammo_box/c9x18mm
+	name = "ammo box (9x18mm Makarov)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c9x18mm
+	max_ammo = 30
+
+/obj/item/ammo_box/c9x18mm/hp
+	name = "ammo box (9x18mm Makarov JHP)"
+	ammo_type = /obj/item/ammo_casing/c9x18mmhp
+
+/obj/item/ammo_box/c9x18mm/ap
+	name = "ammo box (9x18mm Makarov HV AP)"
+	ammo_type = /obj/item/ammo_casing/c9x18mmap
+	
 /obj/item/ammo_box/c9mm
-	name = "ammo box (9mm)"
+	name = "ammo box (9x19mm Luger)"
 	icon_state = "9mmbox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	max_ammo = 30
+	
+/obj/item/ammo_box/c9mm/hp
+	name = "ammo box (9x19mm Luger JHP)"
+	ammo_type = /obj/item/ammo_casing/c9mmhp
+
+/obj/item/ammo_box/c9mm/ap
+	name = "ammo box (9x19mm Luger HV AP)"
+	ammo_type = /obj/item/ammo_casing/c9mmap
 
 /obj/item/ammo_box/c10mm
-	name = "ammo box (10mm)"
+	name = "ammo box (10mm Auto)"
 	icon_state = "10mmbox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c10mm
 	max_ammo = 20
 
-/obj/item/ammo_box/c45
-	name = "ammo box (.45)"
-	icon_state = "45box"
-	origin_tech = "combat=2"
-	ammo_type = /obj/item/ammo_casing/c45
-	max_ammo = 20
+/obj/item/ammo_box/c10mm/hp
+	name = "ammo box (10mm Auto JHP)"
+	ammo_type = /obj/item/ammo_casing/c10mmhp
+	
+/obj/item/ammo_box/c10mm/ap
+	name = "ammo box (10mm Auto HV AP)"
+	ammo_type = /obj/item/ammo_casing/c10mmap
+	
+//imperial rifle ammo
 
-/obj/item/ammo_box/a40mm
-	name = "ammo box (40mm grenades)"
-	icon_state = "40mm"
-	ammo_type = /obj/item/ammo_casing/a40mm
-	max_ammo = 4
-	multiple_sprites = 1
+/obj/item/ammo_box/c223
+	name = "ammo box (.223 Remington)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c223
+	max_ammo = 30
+
+/obj/item/ammo_box/c223/hp
+	name = "ammo box (.223 Remington SpHP)"
+	ammo_type = /obj/item/ammo_casing/c223hp
+
+/obj/item/ammo_box/c223/ap
+	name = "ammo box (.223 Remington AP-T)"
+	ammo_type = /obj/item/ammo_casing/c223hp
+	
+/obj/item/ammo_box/c3006
+	name = "ammo box (.30-06 Springfield)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c3006
+	max_ammo = 30
+	
+/obj/item/ammo_box/c3006/hp
+	name = "ammo box (.30-06 Springfield SpHP)"
+	ammo_type = /obj/item/ammo_casing/c3006hp
+	
+/obj/item/ammo_box/c3006/ap
+	name = "ammo box (.30-06 Springfield AP-T)"
+	ammo_type = /obj/item/ammo_casing/c3006ap
+	
+/obj/item/ammo_box/c308
+	name = "ammo box (.308 Winchester)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c308
+	max_ammo = 30
+	
+/obj/item/ammo_box/c308/hp
+	name = "ammo box (.308 Winchester SpHP)"
+	ammo_type = /obj/item/ammo_casing/c308hp
+	
+/obj/item/ammo_box/c308/ap
+	name = "ammo box (.308 Winchester AP-T)"
+	ammo_type = /obj/item/ammo_casing/c308hp
+	
+/obj/item/ammo_box/c338
+	name = "ammo box (.338 Lapua Magnum)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c338
+	max_ammo = 20
+	
+/obj/item/ammo_box/c4570
+	name = "ammo box (.45-70 Government)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/c4570
+	max_ammo = 15
+	
+/obj/item/ammo_box/c50bmg
+	name = "ammo box (.50 BMG SLAP)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/point50
+	max_ammo = 10
+
+/obj/item/ammo_box/c50bmg/tranq
+	name = "ammo box (.50 BMG Tranquilizer)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/soporific
+	max_ammo = 10
+
+//metric rifle ammo
+
+/obj/item/ammo_box/c556x45
+	name = "ammo box (5.56x45mm NATO)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/mm556x45
+	max_ammo = 30
+	
+/obj/item/ammo_box/c556x45/hp
+	name = "ammo box (5.56x45mm NATO SpHP)"
+	ammo_type = /obj/item/ammo_casing/mm556x45/hollow
+	
+/obj/item/ammo_box/c556x45/ap
+	name = "ammo box (5.56x45mm NATO AP-T)"
+	ammo_type = /obj/item/ammo_casing/mm556x45/ap	
+
+/obj/item/ammo_box/c762x39
+	name = "ammo box (7.62x39mm)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/a762x39
+	max_ammo = 25
+	
+/obj/item/ammo_box/c762x39/hp
+	name = "ammo box (7.62x39mm SpHP)"
+	ammo_type = /obj/item/ammo_casing/a762x39hp
+	
+/obj/item/ammo_box/c762x39/ap
+	name = "ammo box (7.62x39mm AP-T)"
+	ammo_type = /obj/item/ammo_casing/a762x39ap
+	
+/obj/item/ammo_box/c762x51
+	name = "ammo box (7.62x51mm)"
+	icon_state = "9mmbox"
+	origin_tech = "combat=2"
+	ammo_type = /obj/item/ammo_casing/a762
+	max_ammo = 20
+	
+/obj/item/ammo_box/c762x51/ap
+	name = "ammo box (7.62x51mm AP-T)"
+	ammo_type = /obj/item/ammo_casing/a762/ap
 
 /obj/item/ammo_box/a762
 	name = "stripper clip (7.62mm)"
@@ -50,12 +322,20 @@
 	max_ammo = 5
 	multiple_sprites = 1
 
+
 /obj/item/ammo_box/n762
 	name = "ammo box (7.62x38mmR)"
 	icon_state = "10mmbox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/n762
 	max_ammo = 14
+
+/obj/item/ammo_box/a40mm
+	name = "ammo box (40mm grenades)"
+	icon_state = "40mm"
+	ammo_type = /obj/item/ammo_casing/a40mm
+	max_ammo = 4
+	multiple_sprites = 1
 
 /obj/item/ammo_box/foambox
 	name = "ammo box (Foam Darts)"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -387,7 +387,7 @@
 	name = "SMG magazine (.45)"
 	icon_state = "c20r45-24"
 	origin_tech = "combat=2"
-	ammo_type = /obj/item/ammo_casing/c45nostamina
+	ammo_type = /obj/item/ammo_casing/c45
 	caliber = ".45"
 	max_ammo = 24
 

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -204,8 +204,8 @@
 	name = "en-bloc clip"
 	icon_state = "enbloc"
 	origin_tech = "combat=3"
-	ammo_type = /obj/item/ammo_casing/a762
-	caliber = "a762"
+	ammo_type = /obj/item/ammo_casing/c3006
+	caliber = ".30-06"
 	max_ammo = 8
 
 /obj/item/ammo_box/magazine/enbloc/update_icon()

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -40,7 +40,7 @@
 	projectile_type = null
 
 /obj/item/ammo_casing/energy/c3dbullet
-	projectile_type = /obj/item/projectile/bullet/midbullet3
+	projectile_type = /obj/item/projectile/bullet/calibre/cal9x18		//9x18mm Makarov, because fuck you that's why
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	e_cost = 20

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -36,6 +36,7 @@
 	var/canmagnum = BYPASS					//can the weapon handle magnum or +P/+P+ ammunition?
 	var/wear = 0						//you can only shoot so much magnum before the gun has a chance to blow up
 	var/chance_to_explode_violently = 0			//used in magnum check, doesn't do shit otherwise
+	var/spread_already_adjusted = 0
 
 	var/spread = 0						//Spread induced by the gun itself.
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
@@ -206,36 +207,43 @@
 obj/item/weapon/gun/proc/newshot()
 	return
 	
-obj/item/weapon/gun/proc/process_magnum(mob/living/user)
+obj/item/weapon/gun/proc/process_magnum(mob/user)
 	if(canmagnum == BYPASS)		//bypass the check entirely
 		return 1
 	else
 		if(chambered.ismagnum > canmagnum)
-			wear += initial(wear) + (rand(10) * (chambered.ismagnum - canmagnum))
-			return 1		//gun didn't explode
-		else				//the gun is rated for the class of ammunition
-			return 1
+			wear += initial(wear) + (rand(10,15) * (chambered.ismagnum - canmagnum))
+		else
+			wear += chambered.ismagnum			//it'll still wear the barrel out a bit, but less quickly
+
+		if(wear > 1000)			//even your luck has its limits
+			explode_gun(user)
+			return 0
 
 		if(wear > 100)			//you used too much magnum ammo and now the barrel is warped
-			var/spread_already_adjusted = 0
-			chance_to_explode_violently = 100 * (1 - (100 / wear))
+			chance_to_explode_violently = 100 - ((100 / wear) * 100)
 			
 			if(prob(chance_to_explode_violently))
-				explode_gun()
-				return 0		//kaboom.
+				explode_gun(user)
+				return 0
 			else
 				if(!spread_already_adjusted)
-					spread = initial(spread) * 2
+					spread = initial(spread) * 5
 					spread_already_adjusted = 1
 				user << "<span class='warning'>You notice the bullet go wide....</span>"
-				return 1		//no explosion.
+				
+				
+	return 1
 
-obj/item/weapon/gun/proc/explode_gun(mob/living/user)		//called above
-	playsound(user, fire_sound, 50, 1)	
+
+obj/item/weapon/gun/proc/explode_gun(mob/user, mob/living/A)		//called above
+	
+	playsound(user, fire_sound, 50, 1)
 	user.visible_message("[user]'s [src] explodes violently!", "<span class='userdanger'>The [src] blows up in your face!</span>")
-	explosion(get_turf(src), 0, 0, (chambered.ismagnum + 1), flame_range = 2)
+	explosion(get_turf(src), 0, 0, (chambered.ismagnum + 1), flame_range = 0)
 	message_admins("Explosion due to malfunction of a firearm held by [key_name_admin(user)]<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>).")
-	log_game("Explosion due to malfunction of a firearm held by [key_name_admin(user)]/[user].")
+	log_game("Explosion due to malfunction of a firearm held by [key_name_admin(user)].")
+	wear += 100
 	user.unEquip(src)
 	qdel(chambered)
 	return 0
@@ -262,7 +270,7 @@ obj/item/weapon/gun/proc/explode_gun(mob/living/user)		//called above
 				if( i>1 && !(src in get_both_hands(user))) //for burst firing
 					break
 			if(chambered)
-				if(!process_magnum())		//if gun went boom
+				if(!process_magnum(user))		//if gun went boom
 					return
 				var/sprd = 0
 				if(randomspread)
@@ -286,7 +294,7 @@ obj/item/weapon/gun/proc/explode_gun(mob/living/user)		//called above
 		firing_burst = 0
 	else
 		if(chambered)
-			if(!process_magnum())		//if the gun went boom
+			if(!process_magnum(user))		//if the gun went boom
 				return
 			if(!chambered.fire(target, user, params, , suppressed, zone_override, spread))
 				shoot_with_empty_chamber(user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -260,7 +260,7 @@ obj/item/weapon/gun/proc/explode_gun(mob/living/user)		//called above
 					break
 			if(chambered)
 				if(!process_magnum())		//if gun went boom
-					break
+					return
 				var/sprd = 0
 				if(randomspread)
 					sprd = round((rand() - 0.5) * spread)
@@ -284,7 +284,7 @@ obj/item/weapon/gun/proc/explode_gun(mob/living/user)		//called above
 	else
 		if(chambered)
 			if(!process_magnum())		//if the gun went boom
-				break
+				return
 			if(!chambered.fire(target, user, params, , suppressed, zone_override, spread))
 				shoot_with_empty_chamber(user)
 				return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -217,13 +217,16 @@ obj/item/weapon/gun/proc/process_magnum(mob/living/user)
 			return 1
 
 		if(wear > 100)			//you used too much magnum ammo and now the barrel is warped
+			var/spread_already_adjusted = 0
 			chance_to_explode_violently = 100 * (1 - (100 / wear))
 			
 			if(prob(chance_to_explode_violently))
 				explode_gun()
 				return 0		//kaboom.
 			else
-				spread = initial(spread) * 2
+				if(!spread_already_adjusted)
+					spread = initial(spread) * 2
+					spread_already_adjusted = 1
 				user << "<span class='warning'>You notice the bullet go wide....</span>"
 				return 1		//no explosion.
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -206,7 +206,7 @@
 obj/item/weapon/gun/proc/newshot()
 	return
 	
-obj/item/weapon/gun/proc/process_magnum()
+obj/item/weapon/gun/proc/process_magnum(mob/living/user)
 	if(canmagnum == BYPASS)		//bypass the check entirely
 		return 1
 	else
@@ -227,7 +227,7 @@ obj/item/weapon/gun/proc/process_magnum()
 				user << "<span class='warning'>You notice the bullet go wide....</span>"
 				return 1		//no explosion.
 
-obj/item/weapon/gun/proc/explode_gun()		//called above
+obj/item/weapon/gun/proc/explode_gun(mob/living/user)		//called above
 	playsound(user, fire_sound, 50, 1)	
 	user.visible_message("[user]'s [src] explodes violently!", "<span class='userdanger'>The [src] blows up in your face!</span>")
 	explosion(get_turf(src), 0, 0, (chambered.ismagnum + 1), flame_range = 2)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1,3 +1,5 @@
+#define BYPASS -1
+
 /obj/item/weapon/gun
 	name = "gun"
 	desc = "It's a gun. It's pretty terrible, though."
@@ -31,6 +33,9 @@
 	var/firing_burst = 0				//Prevent the weapon from firing again while already firing
 	var/semicd = 0						//cooldown handler
 	var/weapon_weight = WEAPON_LIGHT
+	var/canmagnum = BYPASS					//can the weapon handle magnum or +P/+P+ ammunition?
+	var/wear = 0						//you can only shoot so much magnum before the gun has a chance to blow up
+	var/chance_to_explode_violently = 0			//used in magnum check, doesn't do shit otherwise
 
 	var/spread = 0						//Spread induced by the gun itself.
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
@@ -200,7 +205,38 @@
 
 obj/item/weapon/gun/proc/newshot()
 	return
+	
+obj/item/weapon/gun/proc/process_magnum()
+	if(canmagnum == BYPASS)		//bypass the check entirely
+		return 1
+	else
+		if(chambered.ismagnum > canmagnum)
+			wear = initial(wear) + (rand(10) * (chambered.ismagnum - canmagnum))
+			return 1		//gun didn't explode
+		else				//the gun is rated for the class of ammunition
+			return 1
 
+		if(wear > 100)			//you used too much magnum ammo and now the barrel is warped
+			chance_to_explode_violently = 100 * (1 - (100 / wear))
+			
+			if(prob(chance_to_explode_violently))
+				explode_gun()
+				return 0		//kaboom.
+			else
+				spread = initial(spread) * 2
+				user << "<span class='warning'>You notice the bullet go wide....</span>"
+				return 1		//no explosion.
+
+obj/item/weapon/gun/proc/explode_gun()		//called above
+	playsound(user, fire_sound, 50, 1)	
+	user.visible_message("[user]'s [src] explodes violently!", "<span class='userdanger'>The [src] blows up in your face!</span>")
+	explosion(get_turf(src), 0, 0, (chambered.ismagnum + 1), flame_range = 2)
+	message_admins("Explosion due to malfunction of a firearm held by [key_name_admin(user)]<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>).")
+	log_game("Explosion due to malfunction of a firearm held by [key_name_admin(user)]/[user].")
+	user.unEquip(src)
+	qdel(chambered)
+	return 0
+	
 /obj/item/weapon/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override)
 	add_fingerprint(user)
 
@@ -212,6 +248,7 @@ obj/item/weapon/gun/proc/newshot()
 			recoil = 4 //one-handed kick
 		else
 			recoil = initial(recoil)
+			
 
 	if(burst_size > 1)
 		firing_burst = 1
@@ -222,6 +259,8 @@ obj/item/weapon/gun/proc/newshot()
 				if( i>1 && !(src in get_both_hands(user))) //for burst firing
 					break
 			if(chambered)
+				if(!process_magnum)		//if gun went boom
+					break
 				var/sprd = 0
 				if(randomspread)
 					sprd = round((rand() - 0.5) * spread)
@@ -244,6 +283,8 @@ obj/item/weapon/gun/proc/newshot()
 		firing_burst = 0
 	else
 		if(chambered)
+			if(!process_magnum)		//if the gun went boom
+				break
 			if(!chambered.fire(target, user, params, , suppressed, zone_override, spread))
 				shoot_with_empty_chamber(user)
 				return
@@ -252,6 +293,7 @@ obj/item/weapon/gun/proc/newshot()
 					shoot_live_shot(user, 1, target, message)
 				else
 					shoot_live_shot(user, 0, target, message)
+				
 		else
 			shoot_with_empty_chamber(user)
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -259,7 +259,7 @@ obj/item/weapon/gun/proc/explode_gun()		//called above
 				if( i>1 && !(src in get_both_hands(user))) //for burst firing
 					break
 			if(chambered)
-				if(!process_magnum)		//if gun went boom
+				if(!process_magnum())		//if gun went boom
 					break
 				var/sprd = 0
 				if(randomspread)
@@ -283,7 +283,7 @@ obj/item/weapon/gun/proc/explode_gun()		//called above
 		firing_burst = 0
 	else
 		if(chambered)
-			if(!process_magnum)		//if the gun went boom
+			if(!process_magnum())		//if the gun went boom
 				break
 			if(!chambered.fire(target, user, params, , suppressed, zone_override, spread))
 				shoot_with_empty_chamber(user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -211,7 +211,7 @@ obj/item/weapon/gun/proc/process_magnum(mob/living/user)
 		return 1
 	else
 		if(chambered.ismagnum > canmagnum)
-			wear = initial(wear) + (rand(10) * (chambered.ismagnum - canmagnum))
+			wear += initial(wear) + (rand(10) * (chambered.ismagnum - canmagnum))
 			return 1		//gun didn't explode
 		else				//the gun is rated for the class of ammunition
 			return 1

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -4,6 +4,7 @@
 	icon_state = "pistol"
 	origin_tech = "combat=2;materials=2"
 	w_class = 3
+	spread = 6			//six degree cone of fire
 
 	var/mag_type = /obj/item/ammo_box/magazine/m10mm //Removes the need for max_ammo and caliber info
 	var/obj/item/ammo_box/magazine/magazine

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -3,6 +3,7 @@
 	name = "projectile gun"
 	icon_state = "pistol"
 	origin_tech = "combat=2;materials=2"
+	canmagnum = 0			//We no longer want to bypass the check
 	w_class = 3
 	spread = 6			//six degree cone of fire
 

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -548,7 +548,7 @@
 	
 /obj/item/weapon/gun/projectile/automatic/garand/update_icon()
 	..()
-	icon_state = "[initial(icon_state)][chambered ? "" : "-locked"]"
+	icon_state = "[initial(icon_state)][magazine ? "" : "-locked"]"
 
 
 /obj/item/weapon/gun/projectile/automatic/garand/afterattack()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -533,7 +533,7 @@
 	w_class = 4
 	fire_delay = 2
 	name = "\improper M1 Garand"
-	desc = "This 7.62x51mm rifle is well-known for its eight-round en-bloc clip that ejects with a distinctive <i>ping!</i>, and its use during a war in the early 1940s."
+	desc = "This .30-06 rifle is well-known for its eight-round en-bloc clip that ejects with a distinctive <i>ping!</i>, and its use during a war in the early 1940s."
 	icon_state = "garand"
 	item_state = "moistnugget"
 	mag_type = /obj/item/ammo_box/magazine/enbloc

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -7,6 +7,7 @@
 	can_suppress = 1
 	burst_size = 3
 	fire_delay = 2
+	spread = 5
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	var/eject_sound = null		//only used with the M1 Garand, so expect disappointment if you try it elsewhere
 
@@ -52,7 +53,7 @@
 				update_icon()
 				return 1
 	else if(can_tactical_reload == 2)		//used with the M1 Garand
-		if(magazine || !chambered)		//cheap hack, removing the magazine dechambers it
+		if(magazine || chambered)		//cheap hack, removing the magazine dechambers it
 			user << "<span class='warning'>You cannot perform a tactical reload with an en-bloc clip, eject it first!</span>"
 			return
 		else
@@ -133,6 +134,7 @@
 	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds and is designated the WT-550 Automatic Rifle."
 	icon_state = "wt550"
 	item_state = "arg"
+	spread = 6			//cheap malaysian piece of shit
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	can_suppress = 0
@@ -148,10 +150,13 @@
 	desc = "A battle rifle chambered in 4.6x30mm, first manufactured in 2524. Bears the logo of Misriah Armory laser-engraved into the cheek plate. The firing selector has a 3-round-burst and a semi-automatic mode."
 	icon_state = "br55"
 	item_state = "c20r"
+	spread = 4
 	mag_type = /obj/item/ammo_box/magazine/br55
 	fire_delay = 1
 	can_suppress = 0
 	burst_size = 3
+	zoomable = TRUE			//EXPERIMENTAL
+	zoom_amt = 4		
 	fire_sound = 'sound/weapons/gunshot_br55.ogg'
 
 /obj/item/weapon/gun/projectile/automatic/br55/update_icon()
@@ -164,15 +169,18 @@
 	desc = "The civilian variant of a battle rifle chambered in 4.6x30mm, first manufactured in 2524. Bears the logo of Misriah Armory laser-engraved into the cheek plate. The firing selector only has a semi-automatic mode."
 	icon_state = "br55civ"
 	mag_type = /obj/item/ammo_box/magazine/br55/civilian
+	spread = 2		//you lose the burst, but get better accuracy because less kick
 	fire_delay = 2
 	can_suppress = 0
 	burst_size = 0
+	zoom_amt = 2		//honk.
 	actions_types = list()
 
 /obj/item/weapon/gun/projectile/automatic/mini_uzi
 	name = "\improper 'Type U3' Uzi"
 	desc = "A lightweight, burst-fire submachine gun, for when you really want someone dead. Uses 9mm rounds."
 	icon_state = "mini-uzi"
+	spread = 8		//short barrel, automatic
 	origin_tech = "combat=4;materials=2;syndicate=4"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
 	burst_size = 2
@@ -256,6 +264,7 @@
 	desc = "Based on the classic 'Chicago Typewriter'."
 	icon_state = "tommygun"
 	item_state = "shotgun"
+	spread = 3
 	w_class = 5
 	slot_flags = 0
 	origin_tech = "combat=5;materials=1;syndicate=3"
@@ -291,6 +300,7 @@
 	origin_tech = "combat=6;materials=4;syndicate=6"
 	mag_type = /obj/item/ammo_box/magazine/m12g
 	fire_sound = 'sound/weapons/Gunshot.ogg'
+	spread = 0		//handled in buckshot code. We don't want spread here as well.
 	can_suppress = 0
 	burst_size = 1
 	fire_delay = 0
@@ -406,6 +416,7 @@
 	burst_size = 1
 	origin_tech = "combat=7"
 	can_unsuppress = 1
+	spread = 0			//no spread
 	can_suppress = 1
 	w_class = 3
 	zoomable = TRUE
@@ -464,6 +475,7 @@
 	w_class = 3
 	burst_size = 3
 	fire_delay = 1
+	spread = 3
 	force = 10 //melee damage
 	origin_tech = "combat=6;materials=4;syndicate=8"
 	fire_sound = 'sound/weapons/gunshot_g36.ogg'
@@ -527,6 +539,7 @@
 	mag_type = /obj/item/ammo_box/magazine/enbloc
 	actions_types = list()
 	fire_delay = 2
+	spread = 1
 	can_tactical_reload = 2
 	can_suppress = 0
 	burst_size = 0

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -26,7 +26,8 @@
 /obj/item/weapon/gun/projectile/automatic/pistol/m1911/meusoc
 	name = "M45 MEU(SOC)"
 	spread = 5
-	desc = "This adaptation of the Colt M1911 still sees use where Nanotrasen needs to arm its officers cheaply and effectively."
+	canmagnum = 2		//rated for +P+
+	desc = "This adaptation of the Colt M1911 still sees use where Nanotrasen needs to arm its officers cheaply and effectively. Rated for +P+ ammunition."
 
 /obj/item/weapon/gun/projectile/automatic/pistol/deagle
 	name = "desert eagle"
@@ -94,6 +95,7 @@
 	name = "P053M Luger"
 	desc = "A modern take on an ancient weapon, this one is chambered in .357."
 	icon_state = "p08"
+	canmagnum = 1
 	mag_type = /obj/item/ammo_box/magazine/luger
 	can_suppress = 0
 	w_class = 3
@@ -106,10 +108,11 @@
 	
 /obj/item/weapon/gun/projectile/automatic/pistol/usp
 	name = "\improper P12 Compact"
-	desc = "Renowned on Earth for its legendary reliability, this .45 handgun is still in use in some militaries throughout the galaxy. Has a threaded barrel to mount a suppressor. Has an accessory rail to mount a flashlight."
+	desc = "Renowned on Earth for its legendary reliability, this .45 handgun is still in use in some militaries throughout the galaxy. Has a threaded barrel to mount a suppressor. Has an accessory rail to mount a flashlight. Rated for +P ammunition."
 	icon_state = "usp"
 	mag_type = /obj/item/ammo_box/magazine/usp
 	can_flashlight = 1
+	canmagnum = 1
 	flight_x_offset = 16
 	flight_y_offset = 12
 	spread = 5
@@ -131,5 +134,5 @@
 	
 
 /obj/item/weapon/gun/projectile/automatic/pistol/usp/andreas
-	desc = "Renowned on Earth for its legendary reliability, this .45 handgun is still in use in some militaries throughout the galaxy. Has a threaded barrel to mount a suppressor. Has an accessory rail to mount a flashlight. \n \nThis particular handgun bears an engraving on the left side of an encircled eagle, over the words \"DEUTSCHE BUNDESWEHR\" painted in white. Above the serial is '5842189 R S', engraved messily. The handgun seems carefully tuned with a match-grade trigger and an ambidexterous safety. It also seems well-maintained - seems its owner cared a lot about it."
+	desc = "Renowned on Earth for its legendary reliability, this .45 handgun is still in use in some militaries throughout the galaxy. Has a threaded barrel to mount a suppressor. Has an accessory rail to mount a flashlight. Rated for +P ammunition. \n \nThis particular handgun bears an engraving on the left side of an encircled eagle, over the words \"DEUTSCHE BUNDESWEHR\" painted in white. Above the serial is '5842189 R S', engraved messily. The handgun seems carefully tuned with a match-grade trigger and an ambidexterous safety. It also seems well-maintained - seems its owner cared a lot about it."
 	spread = 4.5

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -25,6 +25,7 @@
 	
 /obj/item/weapon/gun/projectile/automatic/pistol/m1911/meusoc
 	name = "M45 MEU(SOC)"
+	spread = 5
 	desc = "This adaptation of the Colt M1911 still sees use where Nanotrasen needs to arm its officers cheaply and effectively."
 
 /obj/item/weapon/gun/projectile/automatic/pistol/deagle
@@ -65,6 +66,7 @@
 	name = "Automag"
 	desc = "A semi-automatic .44 AMP caliber handgun. A rare firearm generally only seen among the highest-ranking NanoTrasen officers. The caliber gives this weapon immense firepower in a fairly small size."
 	icon_state = "automag"
+	spread = 4
 	force = 10
 	mag_type = /obj/item/ammo_box/magazine/m44
 	can_suppress = 0
@@ -110,6 +112,7 @@
 	can_flashlight = 1
 	flight_x_offset = 16
 	flight_y_offset = 12
+	spread = 5
 	w_class = 2
 	fire_sound = 'sound/weapons/pistol_glock17_1.ogg'
 
@@ -129,3 +132,4 @@
 
 /obj/item/weapon/gun/projectile/automatic/pistol/usp/andreas
 	desc = "Renowned on Earth for its legendary reliability, this .45 handgun is still in use in some militaries throughout the galaxy. Has a threaded barrel to mount a suppressor. Has an accessory rail to mount a flashlight. \n \nThis particular handgun bears an engraving on the left side of an encircled eagle, over the words \"DEUTSCHE BUNDESWEHR\" painted in white. Above the serial is '5842189 R S', engraved messily. The handgun seems carefully tuned with a match-grade trigger and an ambidexterous safety. It also seems well-maintained - seems its owner cared a lot about it."
+	spread = 4.5

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -98,32 +98,34 @@
 
 /obj/item/projectile/New()
 	permutated = list()
-	if(damage_spread_type == (DAMAGE_SPREAD_OFF || DAMAGE_SPREAD_MULT || DAMAGE_SPREAD_MULT_HALVED || DAMAGE_SPREAD_ADD || DAMAGE_SPREAD_ADD_HALVED))
-		if(damage_spread_type == DAMAGE_SPREAD_OFF)			//no damage spread
-			new_damage = damage
-			
-		else if(damage_spread_type == DAMAGE_SPREAD_MULT)		//multiplicative
-			new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff)))
-			
-		else if(damage_spread_type == DAMAGE_SPREAD_MULT_HALVED)	//halved-multiplicative
-			new_damage_spread_coeff = (damage_spread_coeff * 0.5)
-			damage_spread_coeff = new_damage_spread_coeff
-			new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff)))
-			
-		else if(damage_spread_type == DAMAGE_SPREAD_ADD)		//additive
-			new_damage = rand(round(damage - damage_spread_coeff), round(damage + damage_spread_coeff))
-			
-		else if(damage_spread_type == DAMAGE_SPREAD_ADD_HALVED)		//halved-additive
-			new_damage_spread_coeff = (damage_spread_coeff * 0.5)
-			damage_spread_coeff = new_damage_spread_coeff
-			new_damage = rand(round(damage - damage_spread_coeff), round(damage + damage_spread_coeff))
+	if(damage_spread_type == DAMAGE_SPREAD_OFF)			//no damage spread
+		new_damage = damage
 		
-		damage = new_damage
-
+	else if(damage_spread_type == DAMAGE_SPREAD_MULT)		//multiplicative
+		new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff)))
+		
+	else if(damage_spread_type == DAMAGE_SPREAD_MULT_HALVED)	//halved-multiplicative
+		new_damage_spread_coeff = (damage_spread_coeff * 0.5)
+		damage_spread_coeff = new_damage_spread_coeff
+		new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff)))
+		
+	else if(damage_spread_type == DAMAGE_SPREAD_ADD)		//additive
+		new_damage = rand(round(damage - damage_spread_coeff), round(damage + damage_spread_coeff))
+		
+	else if(damage_spread_type == DAMAGE_SPREAD_ADD_HALVED)		//halved-additive
+		new_damage_spread_coeff = (damage_spread_coeff * 0.5)
+		damage_spread_coeff = new_damage_spread_coeff
+		new_damage = rand(round(damage - damage_spread_coeff), round(damage + damage_spread_coeff))
+		
 	else			//our damage spread type is not listed. Crash the proc, something went wrong.
 		damage_spread_type = DAMAGE_SPREAD_OFF
 		CRASH("Invalid damage spread type!")
+	damage = new_damage
+
 	return ..()
+
+
+
 
 /obj/item/projectile/proc/Range()
 	range--

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -103,12 +103,12 @@
 			new_damage = damage
 			
 		else if(damage_spread_type == DAMAGE_SPREAD_MULT)		//multiplicative
-			new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff))
+			new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff)))
 			
 		else if(damage_spread_type == DAMAGE_SPREAD_MULT_HALVED)	//halved-multiplicative
 			new_damage_spread_coeff = (damage_spread_coeff * 0.5)
 			damage_spread_coeff = new_damage_spread_coeff
-			new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff))
+			new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff)))
 			
 		else if(damage_spread_type == DAMAGE_SPREAD_ADD)		//additive
 			new_damage = rand(round(damage - damage_spread_coeff), round(damage + damage_spread_coeff))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -76,8 +76,8 @@
 	var/damage = 10
 	var/damage_spread_type = DAMAGE_SPREAD_OFF
 	var/damage_spread_coeff = 0.2
-	var/new_damage = NULL			//damage calculation
-	var/new_damage_spread_coeff = NULL		//used in halved-spread
+	var/new_damage = null				//damage calculation
+	var/new_damage_spread_coeff = null		//used in halved-spread
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
 	var/nodamage = 0 //Determines if the projectile will skip any damage inflictions
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -98,7 +98,7 @@
 
 /obj/item/projectile/New()
 	permutated = list()
-	if(damage_spread_type == (0 || 1 || 2 || 3 || 4))
+	if(damage_spread_type == (DAMAGE_SPREAD_OFF || DAMAGE_SPREAD_MULT || DAMAGE_SPREAD_MULT_HALVED || DAMAGE_SPREAD_ADD || DAMAGE_SPREAD_ADD_HALVED))
 		if(damage_spread_type == DAMAGE_SPREAD_OFF)			//no damage spread
 			new_damage = damage
 			

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1,3 +1,45 @@
+/*	DAMAGE SPREAD TEXTWALL
+ *
+ *	Okay, before I begin, a quick note on damage spread. Damage spread gives the bullet a
+ *	degree of unpredictibility versus it just being a flat numbers game. For example, without
+ *	damage spread, a Stechkin bullet will do 30 damage, meaning you've got a 4 bullet crit
+ *	and a 7 bullet kill. If we add, say a plus-or-minus 20% range on that, that puts it
+ *	between 3 and 5 bullets to crit, and 6 to 9 bullets to kill, making it rely a little
+ *	less on getting the drop on someone and a little more on your luck.
+ *
+ *	There are 5 modes, defined immediately below, that the bullets will use to determine
+ *	damage spread. The first is no damage spread at all, meaning the base damage is the updated
+ *	damage. We want to use this in instances where we don't want luck to play a factor, for
+ *	instance mounted turrets like those in Centcomm stations.
+ *
+ *	The second damage spread mode is multiplicative (of multiplication), so if the damage
+ *	spread coefficient is 0.2, the bullet will do between 80% and 120% the base damage.
+ *
+ *	The third damage spread mode is halved-multiplicative. The coefficient becomes the total
+ *	range of the damage spread, so if the damage spread coefficient is 0.2, the bullet will
+ *	have a total spread of 20%, and will do between 90% and 110% base damage. This is here
+ *	for maintainer's ease.
+ *
+ *	The fourth damage spread option is additive. The coefficient becomes the total damage spread.
+ *	It's pretty straight-forward: If you have a damage of 10 and a spread coefficient of 2, then
+ *	the bullet will do between 8 and 12 damage.
+ *
+ *	The fifth damage spread mode is halved-additive. Similar to halved-multiplicative, this is
+ *	the total range of the spread, centered, so if I have a bullet damage of 10 and a spread 
+ *	coefficient of 2, the bullet will do between 9 and 11 damage.
+ *
+ *	An important thing to note is DAMAGE SPREAD IS AFFECTED BY ROUNDING. The rand() variable used
+ *	to determine bullet damage from spread will have the upper and lower bounds (determined by
+ *	the spread coefficient) rounded.
+ */
+
+// DAMAGE SPREAD DEFINES
+#define DAMAGE_SPREAD_OFF 0		//no damage spread
+#define DAMAGE_SPREAD_MULT 1		//multiplicative
+#define DAMAGE_SPREAD_MULT_HALVED 2	//halved-multiplicative
+#define DAMAGE_SPREAD_ADD 3		//additive
+#define DAMAGE_SPREAD_ADD_HALVED 4	//halved-additive
+
 /obj/item/projectile
 	name = "projectile"
 	icon = 'icons/obj/projectiles.dmi'
@@ -32,6 +74,10 @@
 	animate_movement = 0	//Use SLIDE_STEPS in conjunction with legacy
 
 	var/damage = 10
+	var/damage_spread_type = DAMAGE_SPREAD_OFF
+	var/damage_spread_coeff = 0.2
+	var/new_damage = NULL			//damage calculation
+	var/new_damage_spread_coeff = NULL		//used in halved-spread
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
 	var/nodamage = 0 //Determines if the projectile will skip any damage inflictions
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb
@@ -52,6 +98,31 @@
 
 /obj/item/projectile/New()
 	permutated = list()
+	if(damage_spread_type == (0 || 1 || 2 || 3 || 4))
+		if(damage_spread_type == DAMAGE_SPREAD_OFF)			//no damage spread
+			new_damage = damage
+			
+		else if(damage_spread_type == DAMAGE_SPREAD_MULT)		//multiplicative
+			new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff))
+			
+		else if(damage_spread_type == DAMAGE_SPREAD_MULT_HALVED)	//halved-multiplicative
+			new_damage_spread_coeff = (damage_spread_coeff * 0.5)
+			damage_spread_coeff = new_damage_spread_coeff
+			new_damage = rand(round(damage * (1 - damage_spread_coeff)), round(damage * (1 + damage_spread_coeff))
+			
+		else if(damage_spread_type == DAMAGE_SPREAD_ADD)		//additive
+			new_damage = rand(round(damage - damage_spread_coeff), round(damage + damage_spread_coeff))
+			
+		else if(damage_spread_type == DAMAGE_SPREAD_ADD_HALVED)		//halved-additive
+			new_damage_spread_coeff = (damage_spread_coeff * 0.5)
+			damage_spread_coeff = new_damage_spread_coeff
+			new_damage = rand(round(damage - damage_spread_coeff), round(damage + damage_spread_coeff))
+		
+		damage = new_damage
+
+	else			//our damage spread type is not listed. Crash the proc, something went wrong.
+		damage_spread_type = DAMAGE_SPREAD_OFF
+		CRASH("Invalid damage spread type!")
 	return ..()
 
 /obj/item/projectile/proc/Range()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,7 +1,10 @@
 //quick numbers for personal manual of style
 // max base damage of 75
-//armour piercing divides damage and armour by 1.5
-//hollowpoint multiplies damage and armour by 1.5
+//armour piercing reduces base damage and armour
+//hollowpoint increases base damage and armour
+//the basic idea is the armour multiplier is more than the base, so using hollowpoint against armour will do
+//less damage to armoured foes than regular ammo against unarmoured
+//similarly using armour piercing is better against armoured foes than unarmoured
 
 /obj/item/projectile/bullet
 	name = "bullet"
@@ -119,6 +122,13 @@
 /obj/item/projectile/bullet/calibre/cal556x45/cal223	//.223 Remington Magnum
 	damage = 30
 	ismagnum = 0
+	
+/obj/item/projectile/bullet/calibre/cal762x39		//7.62x39mm Kalashnikov
+	damage = 38
+	
+/obj/item/projectile/bullet/calibre/cal762x51		//7.62x51mm Mosin
+	damage = 40
+
 	
 /////BOOKMARK
 	

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -173,7 +173,7 @@
 	damage = 24
 	armour_penetration = 25
 	
-/obj/item/projectile/bullet/calibre/cal9x18/ap
+/obj/item/projectile/bullet/calibre/cal9x18/hp
 	damage = 36
 	armour_penetration = -25
 	

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -5,6 +5,7 @@
 //the basic idea is the armour multiplier is more than the base, so using hollowpoint against armour will do
 //less damage to armoured foes than regular ammo against unarmoured
 //similarly using armour piercing is better against armoured foes than unarmoured
+//using AP against an unarmoured target or HP against an armoured target will do less damage than a regular bullet
 
 /obj/item/projectile/bullet
 	name = "bullet"
@@ -13,7 +14,7 @@
 	damage_type = BRUTE
 	damage_spread_coeff = 0
 	damage_spread_type = DAMAGE_SPREAD_OFF
-	var/ismagnum = 0		//for magnum rounds, such as +p/+p+
+	var/ismagnum = 0		//for magnum rounds, such as +p/+p+ - currently unused, but may later cause it to blow up the gun
 	nodamage = 0
 	flag = "bullet"
 	hitsound_wall = "ricochet"
@@ -187,15 +188,30 @@
 	damage = 24
 	armour_penetration = -25
 
+/obj/item/projectile/bullet/calibre/cal9x19/tox
+	damage = 15
+	damage_type = TOX
+	
+/obj/item/projectile/bullet/calibre/cal9x19/incendiary
+	damage = 10
+	
+/obj/item/projectile/bullet/calibre/cal9x19/incendiary/on_hit(atom/target, blocked = 0)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(4)
+		M.IgniteMob()
+
+
 /obj/item/projectile/bullet/calibre/cal68x43			//6.8x43mm Caseless
-	damage = 35
+	damage = 30
 	
 /obj/item/projectile/bullet/calibre/cal68x43/ap
-	damage = 28
+	damage = 24
 	armour_penetration = 25
 	
 /obj/item/projectile/bullet/calibre/cal68x43/ap
-	damage = 42
+	damage = 36
 	armour_penetration = -25
 	
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -283,35 +283,35 @@ obj/item/projectile/bullet/calibre/cal3006/hp
 		target.ex_act(rand(1,2))
 	return ..()
 	
-/obj/item/projectile/calibre/cal50bmg/narq
+/obj/item/projectile/bullet/calibre/cal50bmg/narq
 	armour_penetration = 0
 	nodamage = 1
 	stun = 0
 	weaken = 0
 	breakthings = FALSE
 
-/obj/item/projectile/calibre/cal50bmg/narq/on_hit(atom/target, blocked = 0, hit_zone)
+/obj/item/projectile/bullet/calibre/cal50bmg/narq/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && istype(target, /mob/living))
 		var/mob/living/L = target
 		L.Sleeping(20)
 	return ..()
 
 
-/obj/item/projectile/calibre/cal50bmg/haemorrhage
+/obj/item/projectile/bullet/calibre/cal50bmg/cal50bmg/haemorrhage
 	armour_penetration = 15
 	damage = 15
 	stun = 0
 	weaken = 0
 	breakthings = FALSE
 
-/obj/item/projectile/calibre/cal50bmghaemorrhage/on_hit(atom/target, blocked = 0, hit_zone)
+/obj/item/projectile/bullet/calibre/cal50bmg/haemorrhage/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/C = target
 		C.bleed(100)
 	return ..()
 
 
-/obj/item/projectile/calibre/cal50bmg/penetrator
+/obj/item/projectile/bullet/calibre/cal50bmg/penetrator
 	icon_state = "gauss"
 	name = "penetrator round"
 	damage = 60

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -37,7 +37,7 @@
 	damage = 50
 	ismagnum = 1
 	
-/obj/item/projectile/bullet/calibre/cal357/38spl		//.38 Special
+/obj/item/projectile/bullet/calibre/cal357/spl		//.38 Special
 	damage = 15
 	stamina = 50
 	ismagnum = 0
@@ -46,7 +46,7 @@
 	damage = 60
 	ismagnum = 1
 
-/obj/item/projectile/bullet/calibre/cal44mag/44spl		//.44 Special
+/obj/item/projectile/bullet/calibre/cal44mag/spl		//.44 Special
 	damage = 50
 	ismagnum = 0
 	

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -124,10 +124,10 @@
 	ismagnum = 0
 	
 /obj/item/projectile/bullet/calibre/cal762x39		//7.62x39mm Kalashnikov
-	damage = 38
+	damage = 50
 	
 /obj/item/projectile/bullet/calibre/cal762x51		//7.62x51mm Mosin
-	damage = 40
+	damage = 65
 
 	
 /////BOOKMARK

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,11 +1,84 @@
+//quick numbers for personal manual of style
+// max base damage of 75
+//armour piercing divides damage and armour by 1.5
+//hollowpoint multiplies damage and armour by 1.5
+
 /obj/item/projectile/bullet
 	name = "bullet"
 	icon_state = "bullet"
 	damage = 60
 	damage_type = BRUTE
+	damage_spread_coeff = 0
+	damage_spread_type = DAMAGE_SPREAD_OFF
+	var/ismagnum = 0		//for magnum rounds, such as +p/+p+
 	nodamage = 0
 	flag = "bullet"
 	hitsound_wall = "ricochet"
+	
+/obj/item/projectile/bullet/calibre
+	damage_spread_coeff = 0.2
+	damage_spread_type = DAMAGE_SPREAD_MULT
+	
+///////////////////////////////////
+// HANDGUN AND SMALL ARMS ROUNDS //
+///////////////////////////////////
+
+//IMPERIAL CALIBRES
+/obj/item/projectile/bullet/calibre/17		//.17 HMR
+	damage = 10
+
+/obj/item/projectile/bullet/calibre/177		//.177 airgun
+	damage = 5				//you'll shoot your eye out, kid
+
+/obj/item/projectile/bullet/calibre/22lr	//.22 Long Rifle
+	damage = 20
+	
+/obj/item/projectile/bullet/calibre/357		//.357 magnum
+	damage = 50
+	ismagnum = 1
+	
+/obj/item/projectile/bullet/calibre/38		//.38 Special
+	damage = 15
+	stamina = 50
+
+/obj/item/projectile/bullet/calibre/44mag	//.44 Magnum
+	damage = 60
+	ismagnum = 1
+
+/obj/item/projectile/bullet/calibre/44spl	//.44 Special
+	damage = 50
+	
+/obj/item/projectile/bullet/calibre/45acp	//.45 Automatic
+	damage = 35
+	
+/obj/item/projectile/bullet/calibre/454		//.454 Casull
+	damage = 55
+	damage_spread_coeff = 0.3	//.454 is a wildcat, so loading will vary between handloaders
+	
+/obj/item/projectile/bullet/calibre/50ae	//.50 Action Express
+	damage = 60
+	stamina = 10
+
+/obj/item/projectile/bullet/calibre/500sw	//.500 Smith & Wesson
+	damage = 65
+	stamina = 25
+	
+//METRIC
+/obj/item/projectile/bullet/calibre/46x30	//4.6x30mm
+	damage = 20
+
+/obj/item/projectile/bullet/calibre/57x28	//5.7x28mm
+	damage = 22
+
+/obj/item/projectile/bullet/calibre/9x18	//9x18mm Makarov
+	damage = 30
+	damage_spread_coeff = 0.25
+	
+/obj/item/projectile/bullet/calibre/9x19	//9x19 Parabellum
+	damage = 30
+
+/obj/item/projectile/bullet/calibre/68x43	//6.8x43mm Caseless
+
 
 /obj/item/projectile/bullet/nerfed
 	damage = 15

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -24,42 +24,44 @@
 ///////////////////////////////////
 
 //IMPERIAL CALIBRES
-/obj/item/projectile/bullet/calibre/17		//.17 HMR
+/obj/item/projectile/bullet/calibre/cal17		//.17 HMR
 	damage = 10
 
-/obj/item/projectile/bullet/calibre/177		//.177 airgun
-	damage = 5				//you'll shoot your eye out, kid
+/obj/item/projectile/bullet/calibre/cal177		//.177 airgun
+	damage = 5					//you'll shoot your eye out, kid
 
-/obj/item/projectile/bullet/calibre/22lr	//.22 Long Rifle
+/obj/item/projectile/bullet/calibre/cal22lr		//.22 Long Rifle
 	damage = 20
 	
-/obj/item/projectile/bullet/calibre/357		//.357 magnum
+/obj/item/projectile/bullet/calibre/cal357		//.357 magnum
 	damage = 50
 	ismagnum = 1
 	
-/obj/item/projectile/bullet/calibre/38		//.38 Special
+/obj/item/projectile/bullet/calibre/cal357/38spl		//.38 Special
 	damage = 15
 	stamina = 50
+	ismagnum = 0
 
-/obj/item/projectile/bullet/calibre/44mag	//.44 Magnum
+/obj/item/projectile/bullet/calibre/cal44mag			//.44 Magnum
 	damage = 60
 	ismagnum = 1
 
-/obj/item/projectile/bullet/calibre/44spl	//.44 Special
+/obj/item/projectile/bullet/calibre/cal44mag/44spl		//.44 Special
 	damage = 50
+	ismagnum = 0
 	
-/obj/item/projectile/bullet/calibre/45acp	//.45 Automatic
+/obj/item/projectile/bullet/calibre/cal45acp		//.45 Automatic
 	damage = 35
 	
-/obj/item/projectile/bullet/calibre/454		//.454 Casull
+/obj/item/projectile/bullet/calibre/cal454		//.454 Casull
 	damage = 55
-	damage_spread_coeff = 0.3	//.454 is a wildcat, so loading will vary between handloaders
+	damage_spread_coeff = 0.3			//.454 is a wildcat, so loading will vary between handloaders
 	
-/obj/item/projectile/bullet/calibre/50ae	//.50 Action Express
+/obj/item/projectile/bullet/calibre/cal50ae		//.50 Action Express
 	damage = 60
 	stamina = 10
 
-/obj/item/projectile/bullet/calibre/500sw	//.500 Smith & Wesson
+/obj/item/projectile/bullet/calibre/cal500sw	//.500 Smith & Wesson
 	damage = 65
 	stamina = 25
 	
@@ -67,7 +69,7 @@
 /obj/item/projectile/bullet/calibre/46x30	//4.6x30mm
 	damage = 20
 
-/obj/item/projectile/bullet/calibre/57x28	//5.7x28mm
+/obj/item/projectile/bullet/calibre/57x28	//5.7x28mm FNH
 	damage = 22
 
 /obj/item/projectile/bullet/calibre/9x18	//9x18mm Makarov
@@ -78,7 +80,48 @@
 	damage = 30
 
 /obj/item/projectile/bullet/calibre/68x43	//6.8x43mm Caseless
+	damage = 35
+	
 
+///////////////////////////////
+// RIFLE AND LONG ARM ROUNDS //
+///////////////////////////////
+
+//IMPERIAL CALIBRES
+
+//.223 Remington is under 556x45 below - identical to 5.56x45 NATO but lower pressure
+
+/obj/item/projectile/bullet/calibre/cal3006	//.30-06 Winchester
+	damage = 40
+	
+/obj/item/projectile/bullet/calibre/cal308	//.308 Winchester
+	damage = 40
+	
+/obj/item/projectile/bullet/calibre/cal338	//.338 Lapua
+	damage = 45
+	
+/obj/item/projectile/bullet/calibre/cal338/338mag	//.338 Lapua Magnum
+	damage = 50
+	ismagnum = 1
+
+/obj/item/projectile/bullet/calibre/cal4570	//.45-70 Government
+	damage = 55
+	
+/obj/item/projectile/bullet/calibre/cal50bmg	//.50 Browning Machine Gun
+	damage = 75				//the bullet is fucking huge, 12.7x99mm - and that's just the CASE!
+	
+//METRIC
+
+/obj/item/projectile/bullet/calibre/556x45	//5.56x45mm NATO
+	damage = 35
+	ismagnum = 1
+	
+/obj/item/projectile/bullet/calibre/556x45/cal223	//.223 Remington Magnum
+	damage = 30
+	ismagnum = 0
+	
+/////BOOKMARK
+	
 
 /obj/item/projectile/bullet/nerfed
 	damage = 15

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -85,7 +85,7 @@
 	
 /obj/item/projectile/bullet/calibre/cal45acp/ap
 	damage = 28
-	armour_piercing = 25
+	armour_penetration = 25
 	
 /obj/item/projectile/bullet/calibre/cal454			//.454 Casull
 	damage = 65
@@ -106,7 +106,7 @@
 	
 /obj/item/projectile/bullet/calibre/cal500sw/ap
 	damage = 52
-	armour_piercing = 25
+	armour_penetration = 25
 	
 	
 //METRIC
@@ -115,14 +115,14 @@
 
 /obj/item/projectile/bullet/calibre/cal46x30/ap
 	damage = 16
-	armour_piercing = 25
+	armour_penetration = 25
 
 /obj/item/projectile/bullet/calibre/cal57x28			//5.7x28mm FNH
 	damage = 22
 	
 /obj/item/projectile/bullet/calibre/cal57x28/ap
 	damage = 18
-	armour_piercing = 25
+	armour_penetration = 25
 
 /obj/item/projectile/bullet/calibre/cal9x18			//9x18mm Makarov
 	damage = 30
@@ -130,21 +130,21 @@
 	
 /obj/item/projectile/bullet/calibre/cal9x18/ap
 	damage = 24
-	armour_piercing = 25
+	armour_penetration = 25
 	
 /obj/item/projectile/bullet/calibre/cal9x19			//9x19 Parabellum
 	damage = 30
 	
 /obj/item/projectile/bullet/calibre/cal9x19/ap
 	damage = 24
-	armour_piercing = 25
+	armour_penetration = 25
 
 /obj/item/projectile/bullet/calibre/cal68x43			//6.8x43mm Caseless
 	damage = 35
 	
 /obj/item/projectile/bullet/calibre/cal68x43/ap
 	damage = 28
-	armour_piercing = 25
+	armour_penetration = 25
 	
 
 ///////////////////////////////

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -403,7 +403,7 @@ obj/item/projectile/bullet/calibre/cal3006/hp
  	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
  	sparks.set_up(1, 1, src)
  	sparks.start()
-	..()
+ 	..()
 
 /obj/item/projectile/bullet/shotshell/metal_shavings/overload/New()
 	damage = 3
@@ -418,7 +418,7 @@ obj/item/projectile/bullet/calibre/cal3006/hp
  	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
  	sparks.set_up(3, 3, src)
  	sparks.start()
-	..()	
+ 	..()	
 
 /obj/item/projectile/bullet/shotshell/incendiary	//incendiary shot
 	name = "incendiary slug"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -395,7 +395,7 @@ obj/item/projectile/bullet/calibre/cal3006/hp
 /obj/item/projectile/bullet/shotshell/quadrupleaught	//0000 buck
 	damage = 20
 	
-/obj/item/projectile/bullet/shotshell/metal_shavings	//improv shell
+/obj/item/projectile/bullet/shotshell/metal_shavings/New()	//improv shell
 	damage = 6
 	range = rand(8)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -368,7 +368,7 @@ obj/item/projectile/bullet/calibre/cal3006/hp
 	damage = 21
 	armour_penetration = 40
 	
-/obj/item/projectile/bullet/calibre/cal556x45/cal223/ap
+/obj/item/projectile/bullet/calibre/cal556x45/cal223/hp
 	damage = 39
 	armour_penetration = -40
 	

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -35,6 +35,10 @@
 	armour_penetration = 25				//against armoued foes than regular bullets
 	damage_spread_type = DAMAGE_SPREAD_ADD
 	damage_spread_coeff = 2				//the bullet's weak as hell, we don't want to nerf it much harder
+	
+/obj/item/projectile/bullet/calibre/cal17/hp
+	damage = 18					//20% stronger, but does 25% less penetration, which does better damage
+	armour_penetration = -25			//against unarmoued foes than regular bullets
 
 /obj/item/projectile/bullet/calibre/cal177			//.177 airgun
 	damage = 5					//you'll shoot your eye out, kid
@@ -50,6 +54,10 @@
 /obj/item/projectile/bullet/calibre/cal357/ap
 	damage = 40
 	armour_penetration = 25
+	
+/obj/item/projectile/bullet/calibre/cal357/hp
+	damage = 60
+	armour_penetration = -25
 
 /obj/item/projectile/bullet/calibre/cal357/spl			//.38 Special
 	damage = 15
@@ -68,12 +76,17 @@
 	damage = 44
 	armour_penetration = 25
 
+/obj/item/projectile/bullet/calibre/cal44mag/hp
+	damage = 66
+	armour_penetration = -25
+
 /obj/item/projectile/bullet/calibre/cal44mag/spl		//.44 Special
 	damage = 50
 	ismagnum = 0
 	
 /obj/item/projectile/bullet/calibre/cal45acp			//.45 Automatic
 	damage = 35
+	stamina = 20
 	
 /obj/item/projectile/bullet/calibre/cal45acp/plus			//+P
 	damage = 45
@@ -82,10 +95,14 @@
 /obj/item/projectile/bullet/calibre/cal5acp/plusplus			//+P+
 	damage = 50
 	ismagnum = 2			//very high pressure
-	
+
 /obj/item/projectile/bullet/calibre/cal45acp/ap
 	damage = 28
 	armour_penetration = 25
+	
+/obj/item/projectile/bullet/calibre/cal45acp/hp
+	damage = 42
+	armour_penetration = -25
 	
 /obj/item/projectile/bullet/calibre/cal454			//.454 Casull
 	damage = 65
@@ -99,14 +116,15 @@
 /obj/item/projectile/bullet/calibre/cal50ae/ap
 	damage = 48
 	armour_penetration = 25
+	
+/obj/item/projectile/bullet/calibre/cal50ae/hp
+	damage = 72
+	armour_penetration = -25
 
 /obj/item/projectile/bullet/calibre/cal500sw			//.500 Smith & Wesson
 	damage = 65
 	stamina = 25
-	
-/obj/item/projectile/bullet/calibre/cal500sw/ap
-	damage = 52
-	armour_penetration = 25
+//if your gun's this powerful, you don't need AP or HP rounds
 	
 	
 //METRIC
@@ -116,6 +134,24 @@
 /obj/item/projectile/bullet/calibre/cal46x30/ap
 	damage = 16
 	armour_penetration = 25
+	
+/obj/item/projectile/bullet/calibre/cal46x30/hp
+	damage = 24
+	armour_penetration = -25
+	
+/obj/item/projectile/bullet/calibre/cal46x30/tox
+	damage = 15
+	damage_type = TOX
+	
+/obj/item/projectile/bullet/calibre/cal46x30/incendiary
+	damage = 10
+	
+/obj/item/projectile/bullet/calibre/cal46x30/incendiary/on_hit(atom/target, blocked = 0)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(4)
+		M.IgniteMob()
 
 /obj/item/projectile/bullet/calibre/cal57x28			//5.7x28mm FNH
 	damage = 22
@@ -123,6 +159,10 @@
 /obj/item/projectile/bullet/calibre/cal57x28/ap
 	damage = 18
 	armour_penetration = 25
+	
+/obj/item/projectile/bullet/calibre/cal57x28/ap
+	damage = 26
+	armour_penetration = -25
 
 /obj/item/projectile/bullet/calibre/cal9x18			//9x18mm Makarov
 	damage = 30
@@ -132,12 +172,20 @@
 	damage = 24
 	armour_penetration = 25
 	
+/obj/item/projectile/bullet/calibre/cal9x18/ap
+	damage = 36
+	armour_penetration = -25
+	
 /obj/item/projectile/bullet/calibre/cal9x19			//9x19 Parabellum
 	damage = 30
 	
 /obj/item/projectile/bullet/calibre/cal9x19/ap
 	damage = 24
 	armour_penetration = 25
+	
+/obj/item/projectile/bullet/calibre/cal9x19/hp
+	damage = 24
+	armour_penetration = -25
 
 /obj/item/projectile/bullet/calibre/cal68x43			//6.8x43mm Caseless
 	damage = 35
@@ -145,6 +193,10 @@
 /obj/item/projectile/bullet/calibre/cal68x43/ap
 	damage = 28
 	armour_penetration = 25
+	
+/obj/item/projectile/bullet/calibre/cal68x43/ap
+	damage = 42
+	armour_penetration = -25
 	
 
 ///////////////////////////////
@@ -163,12 +215,21 @@
 	damage = 28			//more of a hit for rifle bullets (30%), but...
 	armour_penetration = 40		//...more of a return against armoured targets (40%)
 	
+	
+obj/item/projectile/bullet/calibre/cal3006/hp
+	damage = 52			//and vice versa
+	armour_penetration = -40		
+
 /obj/item/projectile/bullet/calibre/cal308	//.308 Winchester
 	damage = 40
 	
 /obj/item/projectile/bullet/calibre/cal308/ap
 	damage = 28
 	armour_penetration = 40
+	
+/obj/item/projectile/bullet/calibre/cal308/hp
+	damage = 52
+	armour_penetration = -40
 	
 /obj/item/projectile/bullet/calibre/cal338	//.338 Lapua
 	damage = 45
@@ -186,6 +247,49 @@
 	damage = 75				//the bullet is fucking huge, 12.7x99mm - and that's just the CASE!
 	armour_penetration = 5
 	
+/obj/item/projectile/bullet/calibre/cal50bmg/on_hit(atom/target, blocked = 0, hit_zone)
+	if((blocked != 100) && (!ismob(target) && breakthings))
+		target.ex_act(rand(1,2))
+	return ..()
+	
+/obj/item/projectile/calibre/cal50bmg/narq
+	armour_penetration = 0
+	nodamage = 1
+	stun = 0
+	weaken = 0
+	breakthings = FALSE
+
+/obj/item/projectile/calibre/cal50bmg/narq/on_hit(atom/target, blocked = 0, hit_zone)
+	if((blocked != 100) && istype(target, /mob/living))
+		var/mob/living/L = target
+		L.Sleeping(20)
+	return ..()
+
+
+/obj/item/projectile/calibre/cal50bmg/haemorrhage
+	armour_penetration = 15
+	damage = 15
+	stun = 0
+	weaken = 0
+	breakthings = FALSE
+
+/obj/item/projectile/calibre/cal50bmghaemorrhage/on_hit(atom/target, blocked = 0, hit_zone)
+	if((blocked != 100) && iscarbon(target))
+		var/mob/living/carbon/C = target
+		C.bleed(100)
+	return ..()
+
+
+/obj/item/projectile/calibre/cal50bmg/penetrator
+	icon_state = "gauss"
+	name = "penetrator round"
+	damage = 60
+	forcedodge = 1
+	stun = 0
+	weaken = 0
+	breakthings = FALSE
+	
+
 //METRIC
 
 /obj/item/projectile/bullet/calibre/cal556x45	//5.56x45mm NATO
@@ -196,6 +300,39 @@
 	damage = 25
 	armour_penetration = 40
 	
+/obj/item/projectile/bullet/calibre/cal556x45/bleeding
+	damage = 20
+	armour_penetration = 0
+
+/obj/item/projectile/bullet/calibre/cal556x45/bleeding/on_hit(atom/target, blocked = 0, hit_zone)
+	. = ..()
+	if((blocked != 100) && iscarbon(target))
+		var/mob/living/carbon/C = target
+		C.bleed(35)
+
+/obj/item/projectile/bullet/calibre/cal556x45/hp
+	damage = 45
+	armour_penetration = -40
+
+
+/obj/item/projectile/bullet/calibre/cal556x45/incen
+	damage = 7
+	armour_penetration = 0
+	
+/obj/item/projectile/bullet/calibre/cal556x45/incen/Move()
+	..()
+	var/turf/location = get_turf(src)
+	if(location)
+		PoolOrNew(/obj/effect/hotspot, location)
+		location.hotspot_expose(700, 50, 1)
+
+/obj/item/projectile/bullet/calibre/cal556x45/incen/on_hit(atom/target, blocked = 0)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(3)
+		M.IgniteMob()
+	
 /obj/item/projectile/bullet/calibre/cal556x45/cal223	//.223 Remington Magnum
 	damage = 30
 	ismagnum = 0
@@ -204,6 +341,10 @@
 	damage = 21
 	armour_penetration = 40
 	
+/obj/item/projectile/bullet/calibre/cal556x45/cal223/ap
+	damage = 39
+	armour_penetration = -40
+	
 /obj/item/projectile/bullet/calibre/cal762x39		//7.62x39mm Kalashnikov
 	damage = 50
 	
@@ -211,12 +352,18 @@
 	damage = 35
 	armour_penetration = 40
 	
+/obj/item/projectile/bullet/calibre/cal762x39/hp
+	damage = 65
+	armour_penetration = -40
+	
 /obj/item/projectile/bullet/calibre/cal762x51		//7.62x51mm NATO
 	damage = 65
 	
 /obj/item/projectile/bullet/calibre/cal762x51/ap
 	damage = 46
 	armour_penetration = 40
+	
+//no hollowpoint, it goes past base damage on my personal MoS
 
 ///////////////////////////////
 // SHOTGUN AMMUNITION (12ga) //
@@ -247,6 +394,46 @@
 	
 /obj/item/projectile/bullet/shotshell/quadrupleaught	//0000 buck
 	damage = 20
+	
+/obj/item/projectile/bullet/shotshell/metal_shavings	//improv shell
+	damage = 6
+	range = rand(8)
+
+/obj/item/projectile/bullet/shotshell/metal_shavings/on_range()
+ 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
+ 	sparks.set_up(1, 1, src)
+ 	sparks.start()
+	..()
+
+/obj/item/projectile/bullet/shotshell/metal_shavings/overload/New()
+	damage = 3
+	range = rand(10)
+
+/obj/item/projectile/bullet/shotshell/metal_shavings/overload/on_hit(atom/target, blocked = 0)
+ 	..()
+ 	explosion(target, 0, 0, 2)
+
+/obj/item/projectile/bullet/shotshell/metal_shavings/overload/on_range()
+ 	explosion(src, 0, 0, 2)
+ 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
+ 	sparks.set_up(3, 3, src)
+ 	sparks.start()
+	..()	
+
+/obj/item/projectile/bullet/shotshell/incendiary	//incendiary shot
+	name = "incendiary slug"
+	damage = 20
+
+/obj/item/projectile/bullet/shotshell/incendiary/Move()
+	..()
+	var/turf/location = get_turf(src)
+	if(location)
+		PoolOrNew(/obj/effect/hotspot, location)
+	location.hotspot_expose(700, 50, 1)
+	
+/obj/item/projectile/bullet/shotshell/incendiary/dragon		//dragonsbreath shot
+	name = "dragonsbreath shot"
+	damage = 5
 
 //LESS THAN LETHAL
 
@@ -267,7 +454,7 @@
 	damage = 5
 	stamina = 35
 	
-/obj/item/projectile/bullet/shotshell/ltl/xrep		//eXtended Range Electromuscular Projectile
+/obj/item/projectile/bullet/shotshell/ltl/xrep			//eXtended Range Electromuscular Projectile
 	name = "XREP"
 	damage = 5
 	stun = 5
@@ -278,50 +465,38 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 	
+/obj/item/projectile/bullet/shotshell/ltl/meteor		//meteor shot
+	name = "meteor"
+	icon = 'icons/obj/meteor.dmi'
+	icon_state = "dust"
+	damage = 30
+	damage_spread_type = DAMAGE_SPREAD_MULT
+	weaken = 8
+	stun = 8
+	hitsound = 'sound/effects/meteorimpact.ogg'
 	
+/obj/item/projectile/bullet/shotshell/ltl/meteor/on_hit(atom/target, blocked = 0)
+	. = ..()
+	if(istype(target, /atom/movable))
+		var/atom/movable/M = target
+		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
+		M.throw_at(throw_target, 3, 2)
+
+/obj/item/projectile/bullet/shotshell/ltl/meteor/New()
+	..()
+	SpinAnimation()
+
+
+/obj/item/projectile/bullet/shotshell/ltl/meteor/breach		//Avon Calling
+	damage = 10
+	weaken = 4
+	stun = 4
+	
+
+
 /////BOOKMARK
 	
 
-/obj/item/projectile/bullet/nerfed
-	damage = 15
-
-/obj/item/projectile/bullet/weakbullet //beanbag, heavy stamina damage
-	damage = 5
-	stamina = 80
-
-/obj/item/projectile/bullet/weakbullet2 //detective revolver instastuns, but multiple shots are better for keeping punks down
-	damage = 15
-	weaken = 3
-	stamina = 50
-
-/obj/item/projectile/bullet/weakbullet3
-	damage = 20
-
-/obj/item/projectile/bullet/toxinbullet
-	damage = 15
-	damage_type = TOX
-
-/obj/item/projectile/bullet/incendiary/firebullet
-	damage = 10
-
-/obj/item/projectile/bullet/armourpiercing
-	damage = 17
-	armour_penetration = 10
-
-/obj/item/projectile/bullet/pellet
-	name = "pellet"
-	damage = 15
-
-/obj/item/projectile/bullet/pellet/weak/New()
-	damage = 6
-	range = rand(8)
-
-/obj/item/projectile/bullet/pellet/weak/on_range()
- 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
- 	sparks.set_up(1, 1, src)
- 	sparks.start()
- 	..()
-	
 /obj/item/projectile/bullet/SDSbullet
 	name = "bullet"
 	icon_state = "bullet"
@@ -330,96 +505,6 @@
 	nodamage = 0
 	flag = "bullet"
 	hitsound_wall = "ricochet"
-
-/obj/item/projectile/bullet/pellet/overload/New()
-	damage = 3
-	range = rand(10)
-
-/obj/item/projectile/bullet/pellet/overload/on_hit(atom/target, blocked = 0)
- 	..()
- 	explosion(target, 0, 0, 2)
-
-/obj/item/projectile/bullet/pellet/overload/on_range()
- 	explosion(src, 0, 0, 2)
- 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
- 	sparks.set_up(3, 3, src)
- 	sparks.start()
- 	..()
-
-/obj/item/projectile/bullet/midbullet
-	damage = 20
-	stamina = 65 //two round bursts from the c20r knocks people down
-
-
-/obj/item/projectile/bullet/midbullet2
-	damage = 25
-
-/obj/item/projectile/bullet/midbullet3
-	damage = 30
-
-/obj/item/projectile/bullet/heavybullet
-	damage = 35
-
-/obj/item/projectile/bullet/heavybullet2	//This is used in the .44 caliber Automag handgun. Do note that the gun is supposed to be rare as hell or exclusive to a very specific role, such as nukie leader.
-	damage = 85
-	armour_penetration = 10
-
-/obj/item/projectile/bullet/heavybullet3
-	damage = 40
-	armour_penetration = 15
-
-/obj/item/projectile/bullet/rpellet
-	damage = 3
-	stamina = 25
-
-/obj/item/projectile/bullet/stunshot //taser slugs for shotguns, nothing special
-	name = "stunshot"
-	damage = 5
-	stun = 5
-	weaken = 5
-	stutter = 5
-	jitter = 20
-	range = 7
-	icon_state = "spark"
-	color = "#FFFF00"
-
-/obj/item/projectile/bullet/incendiary/on_hit(atom/target, blocked = 0)
-	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/M = target
-		M.adjust_fire_stacks(4)
-		M.IgniteMob()
-
-
-/obj/item/projectile/bullet/incendiary/shell
-	name = "incendiary slug"
-	damage = 20
-
-/obj/item/projectile/bullet/incendiary/shell/Move()
-	..()
-	var/turf/location = get_turf(src)
-	if(location)
-		PoolOrNew(/obj/effect/hotspot, location)
-		location.hotspot_expose(700, 50, 1)
-
-/obj/item/projectile/bullet/incendiary/shell/dragonsbreath
-	name = "dragonsbreath round"
-	damage = 5
-
-
-/obj/item/projectile/bullet/meteorshot
-	name = "meteor"
-	icon = 'icons/obj/meteor.dmi'
-	icon_state = "dust"
-	damage = 30
-	weaken = 8
-	stun = 8
-	hitsound = 'sound/effects/meteorimpact.ogg'
-
-/obj/item/projectile/bullet/meteorshot/weak
-	damage = 10
-	weaken = 4
-	stun = 4
 
 /obj/item/projectile/bullet/honker
 	damage = 0
@@ -435,18 +520,6 @@
 /obj/item/projectile/bullet/honker/New()
 	..()
 	SpinAnimation()
-
-/obj/item/projectile/bullet/meteorshot/on_hit(atom/target, blocked = 0)
-	. = ..()
-	if(istype(target, /atom/movable))
-		var/atom/movable/M = target
-		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
-		M.throw_at(throw_target, 3, 2)
-
-/obj/item/projectile/bullet/meteorshot/New()
-	..()
-	SpinAnimation()
-
 
 /obj/item/projectile/bullet/mime
 	damage = 20
@@ -516,102 +589,3 @@
 		weaken = 0
 		nodamage = 1
 	. = ..() // Execute the rest of the code.
-
-
-
-//// SNIPER BULLETS
-
-/obj/item/projectile/bullet/sniper
-	damage = 70
-	stun = 5
-	weaken = 5
-	armour_penetration = 50
-	var/breakthings = TRUE
-
-/obj/item/projectile/bullet/sniper/on_hit(atom/target, blocked = 0, hit_zone)
-	if((blocked != 100) && (!ismob(target) && breakthings))
-		target.ex_act(rand(1,2))
-	return ..()
-
-
-/obj/item/projectile/bullet/sniper/soporific
-	armour_penetration = 0
-	nodamage = 1
-	stun = 0
-	weaken = 0
-	breakthings = FALSE
-
-/obj/item/projectile/bullet/sniper/soporific/on_hit(atom/target, blocked = 0, hit_zone)
-	if((blocked != 100) && istype(target, /mob/living))
-		var/mob/living/L = target
-		L.Sleeping(20)
-	return ..()
-
-
-/obj/item/projectile/bullet/sniper/haemorrhage
-	armour_penetration = 15
-	damage = 15
-	stun = 0
-	weaken = 0
-	breakthings = FALSE
-
-/obj/item/projectile/bullet/sniper/haemorrhage/on_hit(atom/target, blocked = 0, hit_zone)
-	if((blocked != 100) && iscarbon(target))
-		var/mob/living/carbon/C = target
-		C.bleed(100)
-	return ..()
-
-
-/obj/item/projectile/bullet/sniper/penetrator
-	icon_state = "gauss"
-	name = "penetrator round"
-	damage = 60
-	forcedodge = 1
-	stun = 0
-	weaken = 0
-	breakthings = FALSE
-
-
-
-//// SAW BULLETS
-
-
-/obj/item/projectile/bullet/saw
-	damage = 45
-	armour_penetration = 5
-
-/obj/item/projectile/bullet/saw/bleeding
-	damage = 20
-	armour_penetration = 0
-
-/obj/item/projectile/bullet/saw/bleeding/on_hit(atom/target, blocked = 0, hit_zone)
-	. = ..()
-	if((blocked != 100) && iscarbon(target))
-		var/mob/living/carbon/C = target
-		C.bleed(35)
-
-/obj/item/projectile/bullet/saw/hollow
-	damage = 60
-	armour_penetration = -10
-
-/obj/item/projectile/bullet/saw/ap
-	damage = 40
-	armour_penetration = 75
-
-/obj/item/projectile/bullet/saw/incen
-	damage = 7
-	armour_penetration = 0
-
-obj/item/projectile/bullet/saw/incen/Move()
-	..()
-	var/turf/location = get_turf(src)
-	if(location)
-		PoolOrNew(/obj/effect/hotspot, location)
-		location.hotspot_expose(700, 50, 1)
-
-/obj/item/projectile/bullet/saw/incen/on_hit(atom/target, blocked = 0)
-	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/M = target
-		M.adjust_fire_stacks(3)
-		M.IgniteMob()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -27,63 +27,124 @@
 ///////////////////////////////////
 
 //IMPERIAL CALIBRES
-/obj/item/projectile/bullet/calibre/cal17		//.17 HMR
-	damage = 10
+/obj/item/projectile/bullet/calibre/cal17			//.17 HMR
+	damage = 15
 
-/obj/item/projectile/bullet/calibre/cal177		//.177 airgun
+/obj/item/projectile/bullet/calibre/cal17/ap
+	damage = 12					//20% weaker, but does 25% armour penetration, which does better damage
+	armour_penetration = 25				//against armoued foes than regular bullets
+	damage_spread_type = DAMAGE_SPREAD_ADD
+	damage_spread_coeff = 2				//the bullet's weak as hell, we don't want to nerf it much harder
+
+/obj/item/projectile/bullet/calibre/cal177			//.177 airgun
 	damage = 5					//you'll shoot your eye out, kid
+	stamina = 2					
 
-/obj/item/projectile/bullet/calibre/cal22lr		//.22 Long Rifle
+/obj/item/projectile/bullet/calibre/cal22lr			//.22 Long Rifle
 	damage = 20
 	
-/obj/item/projectile/bullet/calibre/cal357		//.357 magnum
+/obj/item/projectile/bullet/calibre/cal357			//.357 magnum
 	damage = 50
 	ismagnum = 1
 	
-/obj/item/projectile/bullet/calibre/cal357/spl		//.38 Special
+/obj/item/projectile/bullet/calibre/cal357/ap
+	damage = 40
+	armour_penetration = 25
+
+/obj/item/projectile/bullet/calibre/cal357/spl			//.38 Special
 	damage = 15
 	stamina = 50
 	ismagnum = 0
+	
+/obj/item/projectile/bullet/calibre/cal357/spl/lethal
+	damage = 40
+	stamina = 0
 
 /obj/item/projectile/bullet/calibre/cal44mag			//.44 Magnum
-	damage = 60
+	damage = 55
 	ismagnum = 1
+	
+/obj/item/projectile/bullet/calibre/cal44mag/ap
+	damage = 44
+	armour_penetration = 25
 
 /obj/item/projectile/bullet/calibre/cal44mag/spl		//.44 Special
 	damage = 50
 	ismagnum = 0
 	
-/obj/item/projectile/bullet/calibre/cal45acp		//.45 Automatic
+/obj/item/projectile/bullet/calibre/cal45acp			//.45 Automatic
 	damage = 35
 	
-/obj/item/projectile/bullet/calibre/cal454		//.454 Casull
-	damage = 55
-	damage_spread_coeff = 0.3			//.454 is a wildcat, so loading will vary between handloaders
+/obj/item/projectile/bullet/calibre/cal45acp/plus			//+P
+	damage = 45
+	ismagnum = 1
 	
-/obj/item/projectile/bullet/calibre/cal50ae		//.50 Action Express
+/obj/item/projectile/bullet/calibre/cal5acp/plusplus			//+P+
+	damage = 50
+	ismagnum = 2			//very high pressure
+	
+/obj/item/projectile/bullet/calibre/cal45acp/ap
+	damage = 28
+	armour_piercing = 25
+	
+/obj/item/projectile/bullet/calibre/cal454			//.454 Casull
+	damage = 65
+	damage_spread_coeff = 0.3			//.454 is a wildcat, so loading will vary between handloaders
+	ismagnum = 1
+	
+/obj/item/projectile/bullet/calibre/cal50ae			//.50 Action Express
 	damage = 60
 	stamina = 10
 
-/obj/item/projectile/bullet/calibre/cal500sw	//.500 Smith & Wesson
+/obj/item/projectile/bullet/calibre/cal50ae/ap
+	damage = 48
+	armour_penetration = 25
+
+/obj/item/projectile/bullet/calibre/cal500sw			//.500 Smith & Wesson
 	damage = 65
 	stamina = 25
 	
+/obj/item/projectile/bullet/calibre/cal500sw/ap
+	damage = 52
+	armour_piercing = 25
+	
+	
 //METRIC
-/obj/item/projectile/bullet/calibre/cal46x30	//4.6x30mm
+/obj/item/projectile/bullet/calibre/cal46x30			//4.6x30mm
 	damage = 20
 
-/obj/item/projectile/bullet/calibre/cal57x28	//5.7x28mm FNH
-	damage = 22
+/obj/item/projectile/bullet/calibre/cal46x30/ap
+	damage = 16
+	armour_piercing = 25
 
-/obj/item/projectile/bullet/calibre/cal9x18	//9x18mm Makarov
+/obj/item/projectile/bullet/calibre/cal57x28			//5.7x28mm FNH
+	damage = 22
+	
+/obj/item/projectile/bullet/calibre/cal57x28/ap
+	damage = 18
+	armour_piercing = 25
+
+/obj/item/projectile/bullet/calibre/cal9x18			//9x18mm Makarov
 	damage = 30
 	damage_spread_coeff = 0.25
 	
-/obj/item/projectile/bullet/calibre/cal9x19	//9x19 Parabellum
+/obj/item/projectile/bullet/calibre/cal9x18/ap
+	damage = 24
+	armour_piercing = 25
+	
+/obj/item/projectile/bullet/calibre/cal9x19			//9x19 Parabellum
 	damage = 30
+	
+/obj/item/projectile/bullet/calibre/cal9x19/ap
+	damage = 24
+	armour_piercing = 25
 
-/obj/item/projectile/bullet/calibre/cal68x43	//6.8x43mm Caseless
+/obj/item/projectile/bullet/calibre/cal68x43			//6.8x43mm Caseless
 	damage = 35
+	
+/obj/item/projectile/bullet/calibre/cal68x43/ap
+	damage = 28
+	armour_piercing = 25
 	
 
 ///////////////////////////////
@@ -97,11 +158,21 @@
 /obj/item/projectile/bullet/calibre/cal3006	//.30-06 Winchester
 	damage = 40
 	
+
+/obj/item/projectile/bullet/calibre/cal3006/ap
+	damage = 28			//more of a hit for rifle bullets (30%), but...
+	armour_penetration = 40		//...more of a return against armoured targets (40%)
+	
 /obj/item/projectile/bullet/calibre/cal308	//.308 Winchester
 	damage = 40
 	
+/obj/item/projectile/bullet/calibre/cal308/ap
+	damage = 28
+	armour_penetration = 40
+	
 /obj/item/projectile/bullet/calibre/cal338	//.338 Lapua
 	damage = 45
+	armour_penetration = 10		//sniper bullet
 	
 /obj/item/projectile/bullet/calibre/cal338/mag	//.338 Lapua Magnum
 	damage = 50
@@ -109,9 +180,11 @@
 
 /obj/item/projectile/bullet/calibre/cal4570	//.45-70 Government
 	damage = 55
-	
+	armour_penetration = 5
+
 /obj/item/projectile/bullet/calibre/cal50bmg	//.50 Browning Machine Gun
 	damage = 75				//the bullet is fucking huge, 12.7x99mm - and that's just the CASE!
+	armour_penetration = 5
 	
 //METRIC
 
@@ -119,16 +192,92 @@
 	damage = 35
 	ismagnum = 1
 	
+/obj/item/projectile/bullet/calibre/cal556x45/ap
+	damage = 25
+	armour_penetration = 40
+	
 /obj/item/projectile/bullet/calibre/cal556x45/cal223	//.223 Remington Magnum
 	damage = 30
 	ismagnum = 0
 	
+/obj/item/projectile/bullet/calibre/cal556x45/cal223/ap
+	damage = 21
+	armour_penetration = 40
+	
 /obj/item/projectile/bullet/calibre/cal762x39		//7.62x39mm Kalashnikov
 	damage = 50
 	
-/obj/item/projectile/bullet/calibre/cal762x51		//7.62x51mm Mosin
+/obj/item/projectile/bullet/calibre/cal762x39/ap
+	damage = 35
+	armour_penetration = 40
+	
+/obj/item/projectile/bullet/calibre/cal762x51		//7.62x51mm NATO
 	damage = 65
+	
+/obj/item/projectile/bullet/calibre/cal762x51/ap
+	damage = 46
+	armour_penetration = 40
 
+///////////////////////////////
+// SHOTGUN AMMUNITION (12ga) //
+///////////////////////////////
+
+/obj/item/projectile/bullet/shotshell	//TO REMAIN UNUSED
+	name = "shotgun pellet"
+	damage = 1				
+	damage_spread_coeff = 0.3
+
+//LETHALS
+
+/obj/item/projectile/bullet/shotshell/slug		//slug
+	name = "shotgun slug"
+	damage = 60
+	damage_spread_coeff = 0.2
+	
+/obj/item/projectile/bullet/shotshell/slug/ap		//fletchette
+	name = "shotgun fletchette"
+	damage = 40
+	armour_penetration = 40
+
+/obj/item/projectile/bullet/shotshell/doubleaught	//00 buck
+	damage = 10
+
+/obj/item/projectile/bullet/shotshell/tripleaught	//000 buck
+	damage = 15
+	
+/obj/item/projectile/bullet/shotshell/quadrupleaught	//0000 buck
+	damage = 20
+
+//LESS THAN LETHAL
+
+/obj/item/projectile/bullet/shotshell/ltl		//rubber slug
+	damage = 5
+	damage_spread_type = DAMAGE_SPREAD_OFF		//damage too low
+	stamina = 80
+
+/obj/item/projectile/bullet/shotshell/ltl/doubleaught	//00 rubber shot
+	damage = 3
+	stamina = 25
+	
+/obj/item/projectile/bullet/shotshell/ltl/tripleaught	//000 rubber shot
+	damage = 4
+	stamina = 30
+	
+/obj/item/projectile/bullet/shotshell/ltl/quadrupleaught	//0000 rubber shot
+	damage = 5
+	stamina = 35
+	
+/obj/item/projectile/bullet/shotshell/ltl/xrep		//eXtended Range Electromuscular Projectile
+	name = "XREP"
+	damage = 5
+	stun = 5
+	weaken = 5
+	stutter = 5
+	jitter = 20
+	range = 7
+	icon_state = "spark"
+	color = "#FFFF00"
+	
 	
 /////BOOKMARK
 	

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -235,7 +235,7 @@
 
 //.223 Remington is under 556x45 below - identical to 5.56x45 NATO but lower pressure
 
-/obj/item/projectile/bullet/calibre/cal3006	//.30-06 Winchester
+/obj/item/projectile/bullet/calibre/cal3006	//.30-06 Springfield
 	damage = 40
 	
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -161,7 +161,7 @@
 	damage = 18
 	armour_penetration = 25
 	
-/obj/item/projectile/bullet/calibre/cal57x28/ap
+/obj/item/projectile/bullet/calibre/cal57x28/hp
 	damage = 26
 	armour_penetration = -25
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -259,14 +259,10 @@ obj/item/projectile/bullet/calibre/cal3006/hp
 	damage = 52
 	armour_penetration = -40
 	
-/obj/item/projectile/bullet/calibre/cal338	//.338 Lapua
-	damage = 45
+/obj/item/projectile/bullet/calibre/cal338	//.338 Lapua Magnum
+	damage = 50
 	armour_penetration = 10		//sniper bullet
 	
-/obj/item/projectile/bullet/calibre/cal338/mag	//.338 Lapua Magnum
-	damage = 50
-	ismagnum = 1
-
 /obj/item/projectile/bullet/calibre/cal4570	//.45-70 Government
 	damage = 55
 	armour_penetration = 10

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -202,6 +202,18 @@
 		M.adjust_fire_stacks(4)
 		M.IgniteMob()
 
+/obj/item/projectile/bullet/calibre/cal10x25			//10x25 Automatic
+	damage = 32
+	damage_spread_coeff = 0.3		//not widely used IRL so loading will vary
+	
+/obj/item/projectile/bullet/calibre/cal10x25/ap
+	damage = 26
+	armour_penetration = 25
+	
+/obj/item/projectile/bullet/calibre/cal10x25/hp
+	damage = 38
+	armour_penetration = -25
+
 
 /obj/item/projectile/bullet/calibre/cal68x43			//6.8x43mm Caseless
 	damage = 30

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -241,11 +241,14 @@ obj/item/projectile/bullet/calibre/cal3006/hp
 
 /obj/item/projectile/bullet/calibre/cal4570	//.45-70 Government
 	damage = 55
-	armour_penetration = 5
+	armour_penetration = 10
 
 /obj/item/projectile/bullet/calibre/cal50bmg	//.50 Browning Machine Gun
 	damage = 75				//the bullet is fucking huge, 12.7x99mm - and that's just the CASE!
-	armour_penetration = 5
+	stun = 5
+	weaken = 5
+	armour_penetration = 15
+	var/breakthings = TRUE
 	
 /obj/item/projectile/bullet/calibre/cal50bmg/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && (!ismob(target) && breakthings))

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -66,20 +66,20 @@
 	stamina = 25
 	
 //METRIC
-/obj/item/projectile/bullet/calibre/46x30	//4.6x30mm
+/obj/item/projectile/bullet/calibre/cal46x30	//4.6x30mm
 	damage = 20
 
-/obj/item/projectile/bullet/calibre/57x28	//5.7x28mm FNH
+/obj/item/projectile/bullet/calibre/cal57x28	//5.7x28mm FNH
 	damage = 22
 
-/obj/item/projectile/bullet/calibre/9x18	//9x18mm Makarov
+/obj/item/projectile/bullet/calibre/cal9x18	//9x18mm Makarov
 	damage = 30
 	damage_spread_coeff = 0.25
 	
-/obj/item/projectile/bullet/calibre/9x19	//9x19 Parabellum
+/obj/item/projectile/bullet/calibre/cal9x19	//9x19 Parabellum
 	damage = 30
 
-/obj/item/projectile/bullet/calibre/68x43	//6.8x43mm Caseless
+/obj/item/projectile/bullet/calibre/cal68x43	//6.8x43mm Caseless
 	damage = 35
 	
 
@@ -100,7 +100,7 @@
 /obj/item/projectile/bullet/calibre/cal338	//.338 Lapua
 	damage = 45
 	
-/obj/item/projectile/bullet/calibre/cal338/338mag	//.338 Lapua Magnum
+/obj/item/projectile/bullet/calibre/cal338/mag	//.338 Lapua Magnum
 	damage = 50
 	ismagnum = 1
 
@@ -112,11 +112,11 @@
 	
 //METRIC
 
-/obj/item/projectile/bullet/calibre/556x45	//5.56x45mm NATO
+/obj/item/projectile/bullet/calibre/cal556x45	//5.56x45mm NATO
 	damage = 35
 	ismagnum = 1
 	
-/obj/item/projectile/bullet/calibre/556x45/cal223	//.223 Remington Magnum
+/obj/item/projectile/bullet/calibre/cal556x45/cal223	//.223 Remington Magnum
 	damage = 30
 	ismagnum = 0
 	

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -93,7 +93,7 @@
 	damage = 45
 	ismagnum = 1
 	
-/obj/item/projectile/bullet/calibre/cal5acp/plusplus			//+P+
+/obj/item/projectile/bullet/calibre/cal45acp/plusplus			//+P+
 	damage = 50
 	ismagnum = 2			//very high pressure
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -14,7 +14,6 @@
 	damage_type = BRUTE
 	damage_spread_coeff = 0
 	damage_spread_type = DAMAGE_SPREAD_OFF
-	var/ismagnum = 0		//for magnum rounds, such as +p/+p+ - currently unused, but may later cause it to blow up the gun
 	nodamage = 0
 	flag = "bullet"
 	hitsound_wall = "ricochet"
@@ -50,7 +49,6 @@
 	
 /obj/item/projectile/bullet/calibre/cal357			//.357 magnum
 	damage = 50
-	ismagnum = 1
 	
 /obj/item/projectile/bullet/calibre/cal357/ap
 	damage = 40
@@ -63,7 +61,6 @@
 /obj/item/projectile/bullet/calibre/cal357/spl			//.38 Special
 	damage = 15
 	stamina = 50
-	ismagnum = 0
 	
 /obj/item/projectile/bullet/calibre/cal357/spl/lethal
 	damage = 40
@@ -71,7 +68,6 @@
 
 /obj/item/projectile/bullet/calibre/cal44mag			//.44 Magnum
 	damage = 55
-	ismagnum = 1
 	
 /obj/item/projectile/bullet/calibre/cal44mag/ap
 	damage = 44
@@ -83,7 +79,6 @@
 
 /obj/item/projectile/bullet/calibre/cal44mag/spl		//.44 Special
 	damage = 50
-	ismagnum = 0
 	
 /obj/item/projectile/bullet/calibre/cal45acp			//.45 Automatic
 	damage = 35
@@ -91,11 +86,9 @@
 	
 /obj/item/projectile/bullet/calibre/cal45acp/plus			//+P
 	damage = 45
-	ismagnum = 1
 	
 /obj/item/projectile/bullet/calibre/cal45acp/plusplus			//+P+
 	damage = 50
-	ismagnum = 2			//very high pressure
 
 /obj/item/projectile/bullet/calibre/cal45acp/ap
 	damage = 28
@@ -108,7 +101,6 @@
 /obj/item/projectile/bullet/calibre/cal454			//.454 Casull
 	damage = 65
 	damage_spread_coeff = 0.3			//.454 is a wildcat, so loading will vary between handloaders
-	ismagnum = 1
 	
 /obj/item/projectile/bullet/calibre/cal50ae			//.50 Action Express
 	damage = 60
@@ -321,7 +313,6 @@ obj/item/projectile/bullet/calibre/cal3006/hp
 
 /obj/item/projectile/bullet/calibre/cal556x45	//5.56x45mm NATO
 	damage = 35
-	ismagnum = 1
 	
 /obj/item/projectile/bullet/calibre/cal556x45/ap
 	damage = 25
@@ -362,7 +353,6 @@ obj/item/projectile/bullet/calibre/cal3006/hp
 	
 /obj/item/projectile/bullet/calibre/cal556x45/cal223	//.223 Remington Magnum
 	damage = 30
-	ismagnum = 0
 	
 /obj/item/projectile/bullet/calibre/cal556x45/cal223/ap
 	damage = 21

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -972,7 +972,7 @@
 /datum/design/c556x45mm/hp
 	name = "Ammo box (5.56x45mm NATO HP)"
 	id = "c556_hp"
-	build_path = /obj/item/ammo_box/c556x4/hp
+	build_path = /obj/item/ammo_box/c556x45/hp
 
 /datum/design/c556x45mm/ap
 	name = "Ammo box (5.56x45mm NATO AP)"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -392,28 +392,38 @@
 	category = list("initial", "Medical")
 
 /datum/design/beanbag_slug
-	name = "Beanbag slug"
+	name = "Rubber slug"
 	id = "beanbag_slug"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 250)
 	build_path = /obj/item/ammo_casing/shotgun/beanbag
-	category = list("initial", "Security")
+	category = list("initial", "Ammunition")
 
 /datum/design/rubbershot
-	name = "Rubber shot"
+	name = "00 rubber shot"
 	id = "rubber_shot"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
-	category = list("initial", "Security")
+	category = list("initial", "Ammunition")
+	
+/datum/design/rubbershot/tripleaught
+	name = "000 rubber shot"
+	id = "rubber_shot_000"
+	build_path = /obj/item/ammo_casing/shotgun/rubbershot/tripleaught
+	
+/datum/design/rubbershot/quadrupleaught
+	name = "0000 rubber shot"
+	id = "rubber_shot_0000"
+	build_path = /obj/item/ammo_casing/shotgun/rubbershot/quadrupleaught
 
 /datum/design/c38
-	name = "Speed loader (.38)"
+	name = "Speedloader (.38 stunshot)"
 	id = "c38"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30000)
 	build_path = /obj/item/ammo_box/c38
-	category = list("initial", "Security")
+	category = list("initial", "Ammunition")
 
 /datum/design/recorder
 	name = "Universal recorder"
@@ -606,15 +616,25 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
+	category = list("hacked", "Ammunition")
 
 /datum/design/buckshot_shell
-	name = "Buckshot shell"
+	name = "00 Buckshot shell"
 	id = "buckshot_shell"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
+	category = list("hacked", "Ammunition")
+	
+/datum/design/buckshot_shell/tripleaught
+	name = "000 Buckshot shell"
+	id = "buckshot_shell_000"
+	build_path = /obj/item/ammo_casing/shotgun/buckshot/tripleaught
+	
+/datum/design/buckshot_shell/quadrupleaught
+	name = "0000 Buckshot shell"
+	id = "buckshot_shell_0000"
+	build_path = /obj/item/ammo_casing/shotgun/buckshot/quadrupleaught
 
 /datum/design/shotgun_dart
 	name = "Shotgun dart"
@@ -622,7 +642,7 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/dart
-	category = list("hacked", "Security")
+	category = list("hacked", "Ammunition")
 
 /datum/design/incendiary_slug
 	name = "Incendiary slug"
@@ -630,39 +650,365 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/incendiary
-	category = list("hacked", "Security")
+	category = list("hacked", "Ammunition")
+	
+/datum/design/a17
+	name = "Ammo box (.17 HMR)"
+	id = "c17hmr"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c17hmr
+	category = list("hacked", "Ammunition")
+	
+/datum/design/a17/hp
+	name = "Ammo box (.17 HMR HP)"
+	id = "c17hmr_hp"
+	build_path = /obj/item/ammo_box/c17hmr/hp
+	
+/datum/design/a17/ap
+	name = "Ammo box (.17 HMR AP)"
+	id = "c17hmr_hp"
+	build_path = /obj/item/ammo_box/c17hmr/ap
+	
+/datum/design/a22lr
+	name = "Ammo box (.22 LR)"
+	id = "c22lr"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c22lr
+	category = list("hacked", "Ammunition")
 
 /datum/design/a357
-	name = "Ammo box (.357)"
+	name = "Speedloader (.357)"
 	id = "a357"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30000)
 	build_path = /obj/item/ammo_box/a357
-	category = list("hacked", "Security")
+	category = list("hacked", "Ammunition")
 
-/datum/design/c10mm
-	name = "Ammo box (10mm)"
-	id = "c10mm"
+/datum/design/a357/hp
+	name = "Speedloader (.357 HP)"
+	id = "a357_hp"
+	build_path = /obj/item/ammo_box/a357/hp
+	
+/datum/design/a357/hp
+	name = "Speedloader (.357 AP)"
+	id = "a357_hp"
+	build_path = /obj/item/ammo_box/a357/hp
+
+/datum/design/c38lethal
+	name = "Speedloader (.38 Lethal)"
+	id = "a38_fmj"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c10mm
-	category = list("hacked", "Security")
+	build_path = /obj/item/ammo_box/c38lethal
+	category = list("hacked", "Ammunition")
 
+/datum/design/c44mag
+	name = "Ammo box (.44 Magnum)"
+	id = "a44mag"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c44mag
+	category = list("hacked", "Ammunition")
+
+/datum/design/c44mag/hp
+	name = "Ammo box (.44 Magnum HP)"
+	id = "a44mag_hp"
+	build_path = /obj/item/ammo_box/c44mag/hp
+
+/datum/design/c44mag/ap
+	name = "Ammo box (.44 Magnum AP)"
+	id = "a44mag_ap"
+	build_path = /obj/item/ammo_box/c44mag/ap
+	
 /datum/design/c45
-	name = "Ammo box (.45)"
+	name = "Ammo box (.45 ACP)"
 	id = "c45"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30000)
 	build_path = /obj/item/ammo_box/c45
-	category = list("hacked", "Security")
+	category = list("hacked", "Ammunition")
+
+/datum/design/c45/plus
+	name = "Ammo box (.45 ACP +P)"
+	id = "c45_plus"
+	build_path = /obj/item/ammo_box/c45/plus
+	
+/datum/design/c45/plus/plus
+	name = "Ammo box (.45 ACP +P+)"
+	id = "c45_plusplus"
+	build_path = /obj/item/ammo_box/c45/plus/plus
+
+/datum/design/c45/hp
+	name = "Ammo box (.45 ACP HP)"
+	id = "c45_hp"
+	build_path = /obj/item/ammo_box/c45/hp
+	
+/datum/design/c45/ap
+	name = "Ammo box (.45 ACP AP)"
+	id = "c45_ap
+	build_path = /obj/item/ammo_box/c45/ap
+	
+/datum/design/c454
+	name = "Ammo box (.454 wildcat)"
+	id = "c454"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c454casull
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c50ae
+	name = "Ammo box (.50 Action Express)"
+	id = "c50ae"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c50ae
+	category = list("hacked", "Ammunition")
+
+/datum/design/c50ae/hp
+	name = "Ammo box (.50 Action Express HP)"
+	id = "c50ae_hp"
+	build_path = /obj/item/ammo_box/c50ae/hp
+	
+/datum/design/c50ae/ap
+	name = "Ammo box (.50 Action Express AP)"
+	id = "c50ae_ap"
+	build_path = /obj/item/ammo_box/c50ae/ap
+	
+/datum/design/c50ae
+	name = "Ammo box (.500 S&W Magnum)"
+	id = "c500swm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c500sw
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c46x30mm
+	name = "Ammo box (HK 4.6x30mm)"
+	id = "c46x30mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c46x30mm
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c46x30mm/hp
+	name = "Ammo box (HK 4.6x30mm HP)"
+	id = "c46x30mm_hp"
+	build_path = /obj/item/ammo_box/c46x30mm/hp
+
+/datum/design/c46x30mm/ap
+	name = "Ammo box (HK 4.6x30mm AP)"
+	id = "c46x30mm_ap"
+	build_path = /obj/item/ammo_box/c46x30mm/ap
+
+/datum/design/c57x28mm
+	name = "Ammo box (FN 5.7x28mm)"
+	id = "c57x28mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c57x28mm
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c57x28mm/hp
+	name = "Ammo box (FN 5.7x28mm HP)"
+	id = "c57x28mm_hp"
+	build_path = /obj/item/ammo_box/c57x28mm/hp
+
+/datum/design/c57x28mm/ap
+	name = "Ammo box (FN 5.7x28mm AP)"
+	id = "c57x28mm_ap"
+	build_path = /obj/item/ammo_box/c57x28mm/ap
+	
+/datum/design/c9x18mm
+	name = "Ammo box (9x18mm Makarov)"
+	id = "c9x18mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c9x18mm
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c9x18mm/hp
+	name = "Ammo box (9x18mm Makarov HP)"
+	id = "c9x18mm_hp"
+	build_path = /obj/item/ammo_box/c9x18mm/hp
+	
+/datum/design/c9x18mm/ap
+	name = "Ammo box (9x18mm Makarov AP)"
+	id = "c9x18mm_hp"
+	build_path = /obj/item/ammo_box/c9x18mm/ap
 
 /datum/design/c9mm
-	name = "Ammo box (9mm)"
+	name = "Ammo box (9x19mm NATO)"
 	id = "c9mm"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30000)
 	build_path = /obj/item/ammo_box/c9mm
-	category = list("hacked", "Security")
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c9mm/hp
+	name = "Ammo box (9x19mm NATO HP)"
+	id = "c9mm_hp"
+	build_path = /obj/item/ammo_box/c9mm/hp
+	
+/datum/design/c9mm/ap
+	name = "Ammo box (9x19mm NATO AP)"
+	id = "c9mm_ap"
+	build_path = /obj/item/ammo_box/c9mm/ap
+	
+/datum/design/c10mm
+	name = "Ammo box (10mm Auto)"
+	id = "c10mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c10mm
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c10mm/hp
+	name = "Ammo box (10mm Auto HP)"
+	id = "c10mm_hp"
+	build_path = /obj/item/ammo_box/c10mm/hp
+	
+/datum/design/c10mm
+	name = "Ammo box (10mm Auto)"
+	id = "c10mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c10mm
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c223
+	name = "Ammo box (.223 Remington)"
+	id = "c223"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c223
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c223/hp
+	name = "Ammo box (.223 Remington HP)"
+	id = "c223_hp"
+	build_path = /obj/item/ammo_box/c223/hp
+	
+/datum/design/c223/ap
+	name = "Ammo box (.223 Remington AP)"
+	id = "c223_ap"
+	build_path = /obj/item/ammo_box/c223/ap
+
+/datum/design/c3006
+	name = "Ammo box (.30-06 Springfield)"
+	id = "c3006"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c3006
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c3006/hp
+	name = "Ammo box (.30-06 Springfield HP)"
+	id = "c3006_hp"
+	build_path = /obj/item/ammo_box/c3006/hp
+	
+/datum/design/c3006/ap
+	name = "Ammo box (.30-06 Springfield AP)"
+	id = "c3006_ap"
+	build_path = /obj/item/ammo_box/c3006/ap
+	
+/datum/design/c308
+	name = "Ammo box (.308 Winchester)"
+	id = "c308"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c308
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c308/hp
+	name = "Ammo box (.308 Winchester HP)"
+	id = "c308_hp"
+	build_path = /obj/item/ammo_box/c308/hp
+
+/datum/design/c308/ap
+	name = "Ammo box (.308 Winchester AP)"
+	id = "c308_ap"
+	build_path = /obj/item/ammo_box/c308/ap
+	
+/datum/design/c338
+	name = "Ammo box (.338 Lapua Magnum)"
+	id = "c338"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 40000)
+	build_path = /obj/item/ammo_box/c338
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c4570
+	name = "Ammo box (.45-70 Government)"
+	id = "c4570"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 45000)
+	build_path = /obj/item/ammo_box/4570
+	category = list("hacked", "Ammunition")	
+	
+/datum/design/c50bmg
+	name = "Ammo box (.50 BMG, Saboted LAP)"
+	id = "c50bmg"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 65000)
+	build_path = /obj/item/ammo_box/c50bmg
+	category = list("hacked", "Ammunition")	
+	
+/datum/design/c50bmg/narq	
+	name = "Ammo box (.50 BMG, Tranquilizer)"
+	id = "c50bmg_narq"
+	materials = list(MAT_METAL = 55000)
+	build_path = /obj/item/ammo_box/c50bmg/tranq
+
+/datum/design/c556x45mm
+	name = "Ammo box (5.56x45mm NATO)"
+	id = "c556"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c556x45
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c556x45mm/hp
+	name = "Ammo box (5.56x45mm NATO HP)"
+	id = "c556_hp"
+	build_path = /obj/item/ammo_box/c556x45_hp
+
+/datum/design/c556x45mm/ap
+	name = "Ammo box (5.56x45mm NATO AP)"
+	id = "c556_ap"
+	build_path = /obj/item/ammo_box/c556x45_ap
+
+/datum/design/c762x39mm
+	name = "Ammo box (7.62x39mm)"
+	id = "c762x39"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c762x39
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c762x39mm/hp
+	name = "Ammo box (7.62x39mm HP)"
+	id = "c762x39_hp"
+	build_path = /obj/item/ammo_box/c762x39/hp
+
+/datum/design/c762x39mm/ap
+	name = "Ammo box (7.62x39mm AP)"
+	id = "c762x39_ap"
+	build_path = /obj/item/ammo_box/c762x39/ap
+	
+/datum/design/c762x51mm
+	name = "Ammo box (7.62x51mm NATO)"
+	id = "c762x51"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 35000)
+	build_path = /obj/item/ammo_box/c762x51
+	category = list("hacked", "Ammunition")
+	
+/datum/design/c762x51mm/ap		//no HP rounds
+	name = "Ammo box (7.62x51mm NATO AP)"
+	id = "c762x51_ap"
+	build_path = /obj/item/ammo_box/c762x51/ap
 
 /datum/design/cleaver
 	name = "Butcher's cleaver"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -944,7 +944,7 @@
 	id = "c4570"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 45000)
-	build_path = /obj/item/ammo_box/4570
+	build_path = /obj/item/ammo_box/c4570
 	category = list("hacked", "Ammunition")	
 	
 /datum/design/c50bmg
@@ -972,12 +972,12 @@
 /datum/design/c556x45mm/hp
 	name = "Ammo box (5.56x45mm NATO HP)"
 	id = "c556_hp"
-	build_path = /obj/item/ammo_box/c556x45_hp
+	build_path = /obj/item/ammo_box/c556x4/hp
 
 /datum/design/c556x45mm/ap
 	name = "Ammo box (5.56x45mm NATO AP)"
 	id = "c556_ap"
-	build_path = /obj/item/ammo_box/c556x45_ap
+	build_path = /obj/item/ammo_box/c556x45/ap
 
 /datum/design/c762x39mm
 	name = "Ammo box (7.62x39mm)"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -747,7 +747,7 @@
 	
 /datum/design/c45/ap
 	name = "Ammo box (.45 ACP AP)"
-	id = "c45_ap
+	id = "c45_ap"
 	build_path = /obj/item/ammo_box/c45/ap
 	
 /datum/design/c454


### PR DESCRIPTION
Poll: http://www.strawpoll.me/12411902

:cl: EvilJackCarver
wip: Adds damage spread.
/:cl:

---

# READY FOR REVIEW / TESTMERGE

---

### Progress

* ~~Redo bullets~~ 5316804
* ~~Set ammo casing code to use updated bullets~~ e4dd88b
* ~~Add HP/AP ammo types, which are worse than regular ammo in the wrong situation but better in the right situation~~ 5316804
   * HP, which will be labelled JHP (**j**acketed **h**ollow**p**oint) for handguns and SpHP (**Sp**itzer **h**ollow**p**oint) for rifles in game, has a higher base damage, but increases the base armour of the target more than the base damage is increased.
   * AP, which will be labelled HVAP (**h**igh-**v**elocity **a**rmour-**p**iercing) for handguns and AP-T (**a**rmour-**p**iercing **t**racer) for rifles in-game, has a lower base damage, but decreases the base armour of the target more than the base damage is decreased.
   * Using a(n) HP round against an armoured target will theoretically do less damage than a regular FMJ bullet in the same scanario. Similarly, using an AP round against an unarmoured target will theoretically do less damage than a regular bullet. It's all situational.
   * Damage bonuses and reductions: AP round does 20% less base damage but reduces armour by 25% for small arms, and 30% less base damage but 40% armour reduction for rifles. Hollowpoint rounds do the same, but increase the base damage and target's armour rating.
* ~~Add all the new bullets to the ammo-casing code~~ fe351f0
* ~~Make the `ismagnum` var work.~~ 3b1cd80
   * The idea here is simple: `ismagnum` determines whether the bullet fires at a higher pressure than a regular bullet - like, firing a .357 magnum versus a .38 special, or a [+P round](https://en.wikipedia.org/wiki/Overpressure_ammunition) versus a regular FMJ. If the weapon was not rated for magnum or +P ammunition, or *was* rated for +P but not +P+, the weapon has a chance of exploding. ***~~This is not yet implemented.~~*** 3b1cd80
* ~~Add a separate category for ammunition in the autolathe~~  	7acde3f
* ~~Add ammunition boxes to the autolathe, containing all available ammunition.~~ 920715263930c375caa13319f344a4dc11b587b1
   * Hacked only, obviously. Maybe not so for some of the LTL rounds though.
* Add sprites for shotgun 000 and 0000 buckshot and rubber shot
   * more aughts, more damage, fewer pellets.
* ~~Make guns no longer shoot 100% accurate, 100% of the time~~ 681e921
   * A drift of a tile per ten tiles would be alright for handguns - this comes out to about a 5.7 degree spread
* ~~Fix Garand sprite to check for an inserted magazine, not an inserted round~~ 2e40114
* ~~Turn the BR55-CV into a sidegrade of the Autorifle, rather than a straight downgrade~~ 681e921
   * Fire rate, or maybe add a mild zoom feature from sighting in? Maybe a narrower cone of fire.
* ~~Change the ammo casings' descriptions to say "A bullet casing. The [headstamp](https://en.wikipedia.org/wiki/Headstamp) reads (such-and-such)."~~ fe351f0
   * i.e. "A bullet casing. The headstamp reads '.45ACP HV AP'." for an armour-piercing .45 Automatic bullet.

### Overview

Reworks projectiles to have damage spread. 

Damage spread is a range of damage values a bullet can have. For example, a Stechkin with 30 base damage and a damage spread of ±10% (multiplicative) or ±3 (additive) will do between 27 and 33 damage per bullet, making firearms combat slightly less a game of numbers.

The bounds of damage spread, if it's set to multiply the coefficient, is rounded - meaning assuming the scenario above but, say, ±16% will cause the Stechkin to do between 25 and 35 damage (unrounded, these bounds are 25.2 and 34.8). 

``` DM

/*	DAMAGE SPREAD TEXTWALL
 *
 *	Okay, before I begin, a quick note on damage spread. Damage spread gives the bullet a
 *	degree of unpredictibility versus it just being a flat numbers game. For example, without
 *	damage spread, a Stechkin bullet will do 30 damage, meaning you've got a 4 bullet crit
 *	and a 7 bullet kill. If we add, say a plus-or-minus 20% range on that, that puts it
 *	between 3 and 5 bullets to crit, and 6 to 9 bullets to kill, making it rely a little
 *	less on getting the drop on someone and a little more on your luck.
 *
 *	There are 5 modes, defined immediately below, that the bullets will use to determine
 *	damage spread. The first is no damage spread at all, meaning the base damage is the updated
 *	damage. We want to use this in instances where we don't want luck to play a factor, for
 *	instance mounted turrets like those in Centcomm stations.
 *
 *	The second damage spread mode is multiplicative (of multiplication), so if the damage
 *	spread coefficient is 0.2, the bullet will do between 80% and 120% the base damage.
 *
 *	The third damage spread mode is halved-multiplicative. The coefficient becomes the total
 *	range of the damage spread, so if the damage spread coefficient is 0.2, the bullet will
 *	have a total spread of 20%, and will do between 90% and 110% base damage. This is here
 *	for maintainer's ease.
 *
 *	The fourth damage spread option is additive. The coefficient becomes the total damage spread.
 *	It's pretty straight-forward: If you have a damage of 10 and a spread coefficient of 2, then
 *	the bullet will do between 8 and 12 damage.
 *
 *	The fifth damage spread mode is halved-additive. Similar to halved-multiplicative, this is
 *	the total range of the spread, centered, so if I have a bullet damage of 10 and a spread 
 *	coefficient of 2, the bullet will do between 9 and 11 damage.
 *
 *	An important thing to note is DAMAGE SPREAD IS AFFECTED BY ROUNDING. The rand() variable used
 *	to determine bullet damage from spread will have the upper and lower bounds (determined by
 *	the spread coefficient) rounded.
 */

```

### Quick notes

* FMJ = Full-metal jacket
* JHP = Jacketed Hollow-Point
* HVAP = High-Velocity Armour Piercing