### PR TITLE
Fixes charcoal pill mis-labeling.

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -108,7 +108,7 @@
 	list_reagents = list("salbutamol" = 30)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/charcoal
-	name = "antitoxin pill"
+	name = "charcoal pill"
 	desc = "Neutralizes many common toxins."
 	icon_state = "pill17"
 	list_reagents = list("charcoal" = 50)


### PR DESCRIPTION
:cl: hits
Fix: changed antitox pill name to charcoal.
/:cl:
It's fucking charcoal, not antitox. Don't make chemists think it's ok to dose people with more than 30u of antitox, or make people not use the pill in fear of overdosing.